### PR TITLE
Add body reserves to body object

### DIFF
--- a/DataDefinitions/Body.cs
+++ b/DataDefinitions/Body.cs
@@ -117,6 +117,9 @@ namespace EddiDataDefinitions
         // materials
         public List<MaterialPresence> materials;
 
+        // The reserve level
+        public string reserves;
+
         /// <summary>
         /// Convert gravity in m/s to g
         /// </summary>

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1350,6 +1350,7 @@ namespace Eddi
                 {
                     body.materials.Add(new MaterialPresence(presence.definition, presence.percentage));
                 }
+                body.reserves = theEvent.reserves;
                 body.rings = theEvent.rings;
 
                 Logging.Debug("Saving data for scanned body " + theEvent.name);


### PR DESCRIPTION
Add reserve level to body object, to allow reporting to other 3rd party sources. Issue #97 noted that this is missing