### PR TITLE
Feature/fix 138

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -247,6 +247,7 @@ namespace EddiCompanionAppService
                 market = "{\"lastStarport\":" + market + "}";
                 shipyard = "{\"lastStarport\":" + shipyard + "}";
                 json.Merge(JObject.Parse(market), new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
+                JObject json2 = json;
                 json.Merge(JObject.Parse(shipyard), new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
                 data = JsonConvert.SerializeObject(json);
 
@@ -259,6 +260,8 @@ namespace EddiCompanionAppService
                     shipyard = "{\"lastStarport\":" + shipyard + "}";
                     JObject shipyardJson = JObject.Parse(shipyard);
                     cachedProfile.LastStation.shipyard = ShipyardFromProfile(shipyardJson);
+                    json2.Merge(shipyardJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
+                    cachedProfile.json = json2;
                 }
 
 
@@ -552,7 +555,6 @@ namespace EddiCompanionAppService
                     Profile.LastStation.systemname = Profile.CurrentStarSystem.name;
                     Profile.LastStation.outfitting = OutfittingFromProfile(json);
                     Profile.LastStation.commodities = CommoditiesFromProfile(json);
-                    Profile.LastStation.shipyard = ShipyardFromProfile(json);
                 }
             }
 
@@ -589,7 +591,7 @@ namespace EddiCompanionAppService
                 {
                     dynamic module = moduleJson.Value;
                     // Not interested in paintjobs, decals, ...
-                    if (module["category"] == "weapon" || module["category"] == "module")
+                    if (module["category"] == "weapon" || module["category"] == "module" || module["category"] == "utility")
                     {
                         Module Module = ModuleDefinitions.ModuleFromEliteID((long)module["id"]);
                         if (Module.name == null)
@@ -661,6 +663,17 @@ namespace EddiCompanionAppService
                     {
                         Ship.value = (long)ship["basevalue"];
                         Ships.Add(Ship);
+                    }
+                }
+
+                foreach (dynamic ship in json["lastStarport"]["ships"]["unavailable_list"])
+                {
+                    dynamic shipJson = ship.Value;
+                    Ship Ship2 = ShipDefinitions.FromEliteID((long)ship["id"]);
+                    if (Ship2.EDName != null)
+                    {
+                        Ship2.value = (long)ship["basevalue"];
+                        Ships.Add(Ship2);
                     }
                 }
             }

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Utilities;
 
 namespace EddiCompanionAppService
@@ -250,6 +251,17 @@ namespace EddiCompanionAppService
                 data = JsonConvert.SerializeObject(json);
 
                 cachedProfile = ProfileFromJson(data);
+
+                if ((bool)cachedProfile.LastStation.hasshipyard)
+                {
+                    Thread.Sleep(5000);
+                    shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
+                    shipyard = "{\"lastStarport\":" + shipyard + "}";
+                    JObject shipyardJson = JObject.Parse(shipyard);
+                    cachedProfile.LastStation.shipyard = ShipyardFromProfile(shipyardJson);
+                }
+
+
             }
             catch (JsonException ex)
             {

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -639,7 +639,19 @@ namespace EddiCompanionAppService
         {
             List<Ship> Ships = new List<Ship>();
 
-            // This information is not available at current from the companion app JSON so leave it empty
+            if (json["lastStarport"] != null && json["lastStarport"]["ships"] != null)
+            {
+                foreach (dynamic shipJson in json["lastStarport"]["ships"]["shipyard_list"])
+                {
+                    dynamic ship = shipJson.Value;
+                    Ship Ship = ShipDefinitions.FromEliteID((long)ship["id"]);
+                    if (Ship.EDName != null)
+                    {
+                        Ship.value = (long)ship["basevalue"];
+                        Ships.Add(Ship);
+                    }
+                }
+            }
 
             return Ships;
         }

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -263,8 +263,6 @@ namespace EddiCompanionAppService
                     json2.Merge(shipyardJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
                     cachedProfile.json = json2;
                 }
-
-
             }
             catch (JsonException ex)
             {

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -170,6 +170,7 @@ namespace EDDNResponder
             // When we dock we have access to commodity and outfitting information
             sendCommodityInformation();
             sendOutfittingInformation();
+            sendShipyardInformation();
         }
 
         private void handleMarketInformationUpdatedEvent(MarketInformationUpdatedEvent theEvent)
@@ -177,6 +178,7 @@ namespace EDDNResponder
             // When we dock we have access to commodity and outfitting information
             sendCommodityInformation();
             sendOutfittingInformation();
+            sendShipyardInformation();
         }
 
         private void sendCommodityInformation()
@@ -261,6 +263,36 @@ namespace EDDNResponder
                 }
             }
         }
+
+        private void sendShipyardInformation()
+        {
+            if (EDDI.Instance.CurrentStation != null && EDDI.Instance.CurrentStation.shipyard != null)
+            {
+                List<string> eddnShips = new List<string>();
+                foreach (Ship ship in EDDI.Instance.CurrentStation.shipyard)
+                {
+                        eddnShips.Add(ship.EDName);
+                }
+
+                // Only send the message if we have ships
+                if (eddnShips.Count > 0)
+                {
+                    IDictionary<string, object> data = new Dictionary<string, object>();
+                    data.Add("timestamp", DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                    data.Add("systemName", EDDI.Instance.CurrentStation.systemname);
+                    data.Add("stationName", EDDI.Instance.CurrentStation.name);
+                    data.Add("ships", eddnShips);
+
+                    EDDNBody body = new EDDNBody();
+                    body.header = generateHeader();
+                    body.schemaRef = "https://eddn.edcd.io/schemas/shipyard/2" + (EDDI.Instance.inBeta ? "/test" : "");
+                    body.message = data;
+
+                    sendMessage(body);
+                }
+            }
+        }
+
 
         private static string generateUploaderId()
         {


### PR DESCRIPTION
This PR addresses Issue #138.

Updated CompanionAppService to 2.4 cAPI changes. EDDI now properly queries the /profile, /market, and /shipyard endpoints. Additionally, due to a cAPI quirk, if the 'Last Starport' has shipyard services, /shipyard is queried again 5 sec later to accommodate the delayed shipyard data population in the /shipyard endpoint.

Updated EDDNRepsonder to now (for first time) send station ships available for purchase, using the shipyard/2 schema.

Tested using EDDN log that all data is successfully transmitted to, and accepted by, EDDN.