### PR TITLE
Fix for EDSM rejecting long URIs

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,6 +5,7 @@
     * EDDI will now take commander ratings/rankings from the journal in addition to from the API.
     * EDDN market and outfitting updating restored, accomodating 2.4 cAPI changes. Bonus - now sending shipyard data to EDDN!
     * Updated Variables.md to include a description of commodities objects and their available properties.
+    * Fixed a bug where some commanders weren't receiving updates to their EDSM profiles (by suppressing sending Coriolis links that were too long to EDSM). 
   * Shipyard
     * Export to both Coriolis and EDShipyard is now supported.
     * Fixed a bug that was preventing EDDI from retaining full data from the API, thus mucking up exports to 3rd party services.

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -248,6 +248,15 @@ namespace EddiStarMapService
         {
             var client = new RestClient(baseUrl);
             var request = new RestRequest("api-commander-v1/update-ship");
+            string coriolis_uri = ship.CoriolisUri();
+
+            // EDSM may reject the data if the Coriolis URI is too long. 
+            // Testing seems to put the maximum length at around 8192 characters
+            if (coriolis_uri.Length > 8192)
+            {
+                coriolis_uri = null;
+            }
+
             request.AddParameter("apiKey", apiKey);
             request.AddParameter("commanderName", commanderName);
             request.AddParameter("shipId", ship.LocalId);
@@ -257,7 +266,7 @@ namespace EddiStarMapService
             request.AddParameter("paintJob", ship.paintjob);
             request.AddParameter("cargoQty", ship.cargocarried);
             request.AddParameter("cargoCapacity", ship.cargocapacity);
-            request.AddParameter("linkToCoriolis", ship.CoriolisUri());
+            request.AddParameter("linkToCoriolis", coriolis_uri);
 
             Thread thread = new Thread(() =>
             {
@@ -270,6 +279,7 @@ namespace EddiStarMapService
                     if (response == null)
                     {
                         Logging.Warn($"EDSM rejected ship data with {clientResponse.ErrorMessage}");
+                        Logging.Debug("Coriolis URI length: " + coriolis_uri.Length);
                         return;
                     }
                     if (response.msgnum != 100)


### PR DESCRIPTION
Fix for #161
The URI generated from the detailed raw given by the API may be very long. Testing seems to put the maximum length that EDSM can support at around 8192 characters, so if the URI exceeds this limit then the Coriolis URI is suppressed.