### PR TITLE
Feature/fix 27

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -210,10 +210,8 @@ namespace EddiCompanionAppService
             }
 
             string data = obtainProfile(BASE_URL + PROFILE_URL);
-            string market = obtainProfile(BASE_URL + MARKET_URL);
-            string shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
 
-            if (data == null || data == "Profile unavailable" || market == null || shipyard == null)
+            if (data == null || data == "Profile unavailable")
             {
                 // Happens if there is a problem with the API.  Logging in again might clear this...
                 relogin();
@@ -227,10 +225,8 @@ namespace EddiCompanionAppService
                 {
                     // Looks like login worked; try again
                     data = obtainProfile(BASE_URL + PROFILE_URL);
-                    market = obtainProfile(BASE_URL + MARKET_URL);
-                    shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
 
-                    if (data == null || data == "Profile unavailable" || market == null || shipyard == null)
+                    if (data == null || data == "Profile unavailable")
 
                     {
                         // No luck with a relogin; give up
@@ -244,25 +240,36 @@ namespace EddiCompanionAppService
             try
             {
                 JObject json = JObject.Parse(data);
-                market = "{\"lastStarport\":" + market + "}";
-                shipyard = "{\"lastStarport\":" + shipyard + "}";
-                json.Merge(JObject.Parse(market), new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
-                JObject json2 = json;
-                json.Merge(JObject.Parse(shipyard), new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
-                data = JsonConvert.SerializeObject(json);
-
                 cachedProfile = ProfileFromJson(data);
+
+                if (cachedProfile.LastStation.hasmarket ?? false)
+                {
+                    string market = obtainProfile(BASE_URL + MARKET_URL);
+                    market = "{\"lastStarport\":" + market + "}";
+                    JObject marketJson = JObject.Parse(market);
+                    cachedProfile.LastStation.commodities = CommoditiesFromProfile(marketJson);
+                    json.Merge(marketJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+                }
+
+                if (cachedProfile.LastStation.hasoutfitting ?? false)
+                {
+                    string outfitting = obtainProfile(BASE_URL + SHIPYARD_URL);
+                    outfitting = "{\"lastStarport\":" + outfitting + "}";
+                    JObject outfittingJson = JObject.Parse(outfitting);
+                    cachedProfile.LastStation.outfitting = OutfittingFromProfile(outfittingJson);
+                    json.Merge(outfittingJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+                }
 
                 if (cachedProfile.LastStation.hasshipyard ?? false)
                 {
                     Thread.Sleep(5000);
-                    shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
+                    string shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
                     shipyard = "{\"lastStarport\":" + shipyard + "}";
                     JObject shipyardJson = JObject.Parse(shipyard);
                     cachedProfile.LastStation.shipyard = ShipyardFromProfile(shipyardJson);
-                    json2.Merge(shipyardJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Concat });
-                    cachedProfile.json = json2;
+                    json.Merge(shipyardJson, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
                 }
+                cachedProfile.json = json;
             }
             catch (JsonException ex)
             {
@@ -551,8 +558,6 @@ namespace EddiCompanionAppService
                     }
 
                     Profile.LastStation.systemname = Profile.CurrentStarSystem.name;
-                    Profile.LastStation.outfitting = OutfittingFromProfile(json);
-                    Profile.LastStation.commodities = CommoditiesFromProfile(json);
                 }
             }
 

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -244,6 +244,7 @@ namespace EddiCompanionAppService
 
                 if (cachedProfile.LastStation.hasmarket ?? false)
                 {
+                    Logging.Debug("Getting station market data");
                     string market = obtainProfile(BASE_URL + MARKET_URL);
                     market = "{\"lastStarport\":" + market + "}";
                     JObject marketJson = JObject.Parse(market);
@@ -253,6 +254,7 @@ namespace EddiCompanionAppService
 
                 if (cachedProfile.LastStation.hasoutfitting ?? false)
                 {
+                    Logging.Debug("Getting station outfitting data");
                     string outfitting = obtainProfile(BASE_URL + SHIPYARD_URL);
                     outfitting = "{\"lastStarport\":" + outfitting + "}";
                     JObject outfittingJson = JObject.Parse(outfitting);
@@ -262,6 +264,7 @@ namespace EddiCompanionAppService
 
                 if (cachedProfile.LastStation.hasshipyard ?? false)
                 {
+                    Logging.Debug("Getting station shipyard data");
                     Thread.Sleep(5000);
                     string shipyard = obtainProfile(BASE_URL + SHIPYARD_URL);
                     shipyard = "{\"lastStarport\":" + shipyard + "}";

--- a/DataDefinitions/EddiDataDefinitions.csproj
+++ b/DataDefinitions/EddiDataDefinitions.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Blueprint.cs" />
     <Compile Include="DataScan.cs" />
     <Compile Include="Engineer.cs" />
+    <Compile Include="LaunchBay.cs" />
     <Compile Include="MaterialAmount.cs" />
     <Compile Include="Ring.cs" />
     <Compile Include="Cargo.cs" />

--- a/DataDefinitions/EddiDataDefinitions.csproj
+++ b/DataDefinitions/EddiDataDefinitions.csproj
@@ -83,6 +83,7 @@
     <Compile Include="EmpireRating.cs" />
     <Compile Include="ExplorationRating.cs" />
     <Compile Include="Role.cs" />
+    <Compile Include="Vehicle.cs" />
     <Compile Include="Volcanism.cs" />
     <Compile Include="VolcanismConverter.cs" />
     <Compile Include="Voucher.cs" />

--- a/DataDefinitions/LaunchBay.cs
+++ b/DataDefinitions/LaunchBay.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace EddiDataDefinitions
+{
+    ///<summary>A launchbay is an internal slot within a ship housing SRV or fighter vehicles</summary>
+    public class LaunchBay
+    {
+        // The name of the launchbay
+        public string name { get; set; }
+        /// <summary>The size of the launchbay</summary>
+        public int size { get; set; }
+        // The type of the launchbay ("SRV" or "Fighter")
+        public string type { get; set; }
+        /// <summary>The module residing in the launchbay (can be null)</summary>
+        public List <Vehicle> vehicles { get; set; }
+    }
+}

--- a/DataDefinitions/LaunchBay.cs
+++ b/DataDefinitions/LaunchBay.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using System.Collections.Generic;
 
 namespace EddiDataDefinitions
 {
@@ -16,7 +11,13 @@ namespace EddiDataDefinitions
         public int size { get; set; }
         // The type of the launchbay ("SRV" or "Fighter")
         public string type { get; set; }
-        /// <summary>The module residing in the launchbay (can be null)</summary>
-        public List <Vehicle> vehicles { get; set; }
+
+        /// <summary>The vehicles residing in the launchbay (can be null)</summary>
+        public List<Vehicle> vehicles { get; set; }
+
+        public LaunchBay()
+        {
+            vehicles = new List<Vehicle>();
+        }
     }
 }

--- a/DataDefinitions/ModuleDefinitions.cs
+++ b/DataDefinitions/ModuleDefinitions.cs
@@ -1001,6 +1001,7 @@ namespace EddiDataDefinitions
             Module Template;
             if (ModulesByEliteID.TryGetValue(id, out Template))
             {
+                Module.EDID = Template.EDID;
                 Module.EDName = Template.EDName;
                 Module.EDDBID = Template.EDDBID;
                 Module.name = Template.name;

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -238,6 +238,8 @@ namespace EddiDataDefinitions
         public decimal? fueltanktotalcapacity { get; set; } // Capacity including additional tanks
         public List<Hardpoint> hardpoints { get; set; }
         public List<Compartment> compartments { get; set; }
+        public List<LaunchBay> launchbays { get; set; }
+
         public string paintjob { get; set; }
 
         // Admin
@@ -252,6 +254,7 @@ namespace EddiDataDefinitions
         {
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
+            launchbays = new List<LaunchBay>();
             cargo = new List<Cargo>();
         }
 
@@ -267,6 +270,7 @@ namespace EddiDataDefinitions
             militarysize = MilitarySize;
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
+            launchbays = new List<LaunchBay>();
         }
 
         public string SpokenName(string defaultname = null)

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -18,23 +18,30 @@ namespace EddiDataDefinitions
 
         /// <summary>the ID of this ship for this commander</summary>
         public int LocalId { get; set; }
+
         /// <summary>the manufacturer of the ship (Lakon, CoreDynamics etc.)</summary>
         [JsonIgnore]
         public string manufacturer { get; set; }
+
         /// <summary>the spoken manufacturer of the ship (Lakon, CoreDynamics etc.)</summary>
         [JsonIgnore]
         public List<Translation> phoneticmanufacturer { get; set; }
+
         /// <summary>the spoken model of the ship (Python, Anaconda, etc.)</summary>
         [JsonIgnore]
         public List<Translation> phoneticmodel { get; set; }
+
         /// <summary>the size of this ship</summary>
         [JsonIgnore]
         public string size { get; set; }
+
         /// <summary>the size of the military compartment slots</summary>
         [JsonIgnore]
         public int? militarysize { get; set; }
+
         /// <summary>the total tonnage cargo capacity</summary>
         public int cargocapacity { get; set; }
+
         /// <summary>the current tonnage cargo carried</summary>
         [JsonIgnore]
         public int cargocarried { get; set; }

--- a/DataDefinitions/Vehicle.cs
+++ b/DataDefinitions/Vehicle.cs
@@ -9,6 +9,7 @@ namespace EddiDataDefinitions
         public string EDName { get; set; }
         public string name { get; set; }
         public string loadout { get; set; }
+        public string  mount{ get; set; }
         public int subslot { get; set; }
         public int rebuilds { get; set; }
 
@@ -19,15 +20,17 @@ namespace EddiDataDefinitions
             this.EDName = Vehicle.EDName;
             this.name = Vehicle.name;
             this.loadout = Vehicle.loadout;
+            this.mount = Vehicle.mount;
             this.subslot = Vehicle.subslot;
             this.rebuilds = Vehicle.rebuilds;
         }
 
-        public Vehicle(string EDName, string Name, string Loadout, int SubSlot, int Rebuilds)
+        public Vehicle(string EDName, string Name, string Loadout, string Mount, int SubSlot, int Rebuilds)
         {
             this.EDName = EDName;
             this.name = Name;
             this.loadout = Loadout;
+            this.mount = Mount;
             this.subslot = SubSlot;
             this.rebuilds = Rebuilds;
         }

--- a/DataDefinitions/Vehicle.cs
+++ b/DataDefinitions/Vehicle.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+
+namespace EddiDataDefinitions
+{
+    public class Vehicle
+    {
+        // Definition of the vehicle
+        public string EDName { get; set; }
+        public string name { get; set; }
+        public string loadout { get; set; }
+        public int subslot { get; set; }
+        public int rebuilds { get; set; }
+
+        public Vehicle() { }
+
+        public Vehicle(Vehicle Vehicle)
+        {
+            this.EDName = Vehicle.EDName;
+            this.name = Vehicle.name;
+            this.loadout = Vehicle.loadout;
+            this.subslot = Vehicle.subslot;
+            this.rebuilds = Vehicle.rebuilds;
+        }
+
+        public Vehicle(string EDName, string Name, string Loadout, int SubSlot, int Rebuilds)
+        {
+            this.EDName = EDName;
+            this.name = Name;
+            this.loadout = Loadout;
+            this.subslot = SubSlot;
+            this.rebuilds = Rebuilds;
+        }
+    }
+}

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,7 +3,7 @@
 ### 2.4.0-b6
   * Core
     * EDDI will now take commander ratings/rankings from the journal in addition to from the API.
-	* EDDN market and outfitting updating restored, accomodating 2.4 cAPI changes. Bonus - now sending shipyard data to EDDN!
+    * EDDN market and outfitting updating restored, accomodating 2.4 cAPI changes. Bonus - now sending shipyard data to EDDN!
     * Updated Variables.md to include a description of commodities objects and their available properties.
   * Coriolis Export
     * Fixed a bug that was preventing EDDI from retaining full data from the API, thus mucking up exports to Coriolis.

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -140,7 +140,7 @@ namespace EddiShipMonitor
                         Ship.fueltankcapacity = (decimal)Math.Pow(2, Ship.fueltank.@class);
                     }
                     Ship.fueltanktotalcapacity = Ship.fueltankcapacity;
-                    Ship.paintjob = (string)(json["modules"]?["PaintJob"]?[ "name"] ?? null);
+                    Ship.paintjob = (string)(json["modules"]?["PaintJob"]?["name"] ?? null);
 
                     // Obtain the hardpoints.  Hardpoints can come in any order so first parse them then second put them in the correct order
                     Dictionary<string, Hardpoint> hardpoints = new Dictionary<string, Hardpoint>();

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -338,11 +338,11 @@ namespace EddiShipMonitor
                 if (json.Value is JObject)
                 {
                     JToken value;
-                    for (int i = 0; i <= 4; i++)
+                    for (int subslot = 0; subslot <= 5; subslot++)
                     {
-                        if (json.Value.TryGetValue("SubSlot" + i, out value))
+                        if (json.Value.TryGetValue("SubSlot" + subslot, out value))
                         {
-                            launchbay.vehicles.Add(VehicleFromJson(i, value));
+                            launchbay.vehicles.Add(VehicleFromJson(subslot, value));
                         }
                     }
                 }
@@ -360,7 +360,7 @@ namespace EddiShipMonitor
             vehicle.name = (string)json["locName"];
             vehicle.rebuilds = (int)json["rebuilds"];
             vehicle.loadout = (string)json["loadoutName"];
-            vehicle.loadout = vehicle.loadout.Replace("&NBSP;", " ");
+            vehicle.loadout = vehicle.loadout.Replace("(", "").Replace("&NBSP;", " ").Replace(")", "");
 
             return vehicle;
         }

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -140,7 +140,7 @@ namespace EddiShipMonitor
                         Ship.fueltankcapacity = (decimal)Math.Pow(2, Ship.fueltank.@class);
                     }
                     Ship.fueltanktotalcapacity = Ship.fueltankcapacity;
-                    Ship.paintjob = (string)(json["modules"]?["PaintJob"]?[ "name"] ?? "");
+                    Ship.paintjob = (string)(json["modules"]?["PaintJob"]?[ "name"] ?? null);
 
                     // Obtain the hardpoints.  Hardpoints can come in any order so first parse them then second put them in the correct order
                     Dictionary<string, Hardpoint> hardpoints = new Dictionary<string, Hardpoint>();

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -112,7 +112,6 @@ namespace EddiShipMonitor
 
                 Ship.value = (long)(json["value"]?["hull"] ?? 0) + (long)(json["value"]?["modules"] ?? 0);
                 Ship.cargocapacity = 0;
-                Ship.cargocarried = (int)(json["cargo"]?["qty"] ?? 0);
 
                 // Be sensible with health - round it unless it's very low
                 decimal Health = (decimal)(json["health"]?["hull"] ?? 0) / 10000;
@@ -141,6 +140,7 @@ namespace EddiShipMonitor
                         Ship.fueltankcapacity = (decimal)Math.Pow(2, Ship.fueltank.@class);
                     }
                     Ship.fueltanktotalcapacity = Ship.fueltankcapacity;
+                    Ship.paintjob = (string)(json["modules"]?["PaintJob"]?[ "name"] ?? "");
 
                     // Obtain the hardpoints.  Hardpoints can come in any order so first parse them then second put them in the correct order
                     Dictionary<string, Hardpoint> hardpoints = new Dictionary<string, Hardpoint>();
@@ -297,6 +297,7 @@ namespace EddiShipMonitor
                 Logging.Error("No definition for ship module", json["module"].ToString(Formatting.None));
             }
 
+            module.EDID = id;
             module.price = (long)json["module"]["value"];
             module.enabled = (bool)json["module"]["on"];
             module.priority = (int)json["module"]["priority"];

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -297,7 +297,6 @@ namespace EddiShipMonitor
                 Logging.Error("No definition for ship module", json["module"].ToString(Formatting.None));
             }
 
-            module.EDID = id;
             module.price = (long)json["module"]["value"];
             module.enabled = (bool)json["module"]["on"];
             module.priority = (int)json["module"]["priority"];

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -696,6 +696,7 @@ namespace EddiShipMonitor
         {
             // Obtain the current ship from the profile
             Ship profileCurrentShip = FrontierApi.ShipFromJson((JObject)profile["ship"]);
+            Logging.Debug("Profile Current Ship is: " + JsonConvert.SerializeObject(profileCurrentShip));
 
             // Obtain the shipyard from the profile
             List<Ship> profileShipyard = FrontierApi.ShipyardFromJson(profileCurrentShip, profile);
@@ -730,6 +731,7 @@ namespace EddiShipMonitor
                 }
                 // Obtain items that we can't obtain from the journal
                 ship.value = profileCurrentShip.value;
+                ship.launchbays = profileCurrentShip.launchbays;
                 if (ship.cargohatch != null)
                 {
                     // Engineering info for each module isn't in the journal, but we only use this to pass on to Coriolis so don't

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -715,9 +715,9 @@ namespace EddiShipMonitor
             if (profileCurrentShip != null)
             {
                 Ship ship = GetShip(profileCurrentShip.LocalId);
-                if (ship == null)
+                if (ship == null || !(ship.raw.Equals(profileCurrentShip.raw, StringComparison.Ordinal)))
                 {
-                    // This means that we haven't seen the ship in the profile before.  Add it to the shipyard
+                    // Either we haven't seen the ship in the profile before or the ship has changed.  Add it to the shipyard
                     ship = profileCurrentShip;
                     AddShip(ship);
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -337,12 +337,9 @@ namespace EddiShipMonitor
                 ship.role = Role.MultiPurpose;
             }
 
-            // Update name and ident if required
+            // Update name, ident & paintjob if required
             setShipName(ship, @event.shipname);
             setShipIdent(ship, @event.shipident);
-            ship.model = template.model;
-            ship.Augment();
-
             ship.paintjob = @event.paintjob;
 
             // Set the standard modules

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -57,6 +57,7 @@ Any values might be missing, depending on EDDI's configuration.
     - `fueltanktotalcapacity` the capacity of the main fuel tank plus all secondary fuel tanks
     - `hardpoints` the ship's hardpoints (this is an array of HardPoint objects)
     - `compartments` the ship's internal compartments (this is an array of Compartment objects)
+    - `launchbays` the ship's internal hangars, containing SRV or Fighter 'vehicles' (this is an array of launchbay objects) 
 
 ## Current starsystem
 
@@ -149,6 +150,23 @@ A compartment, which may or may not contain a module.
 
     - `size` the numeric size of the compartment, from 1 to 8
     - `module` the module in the compartment
+
+## Vehicle
+
+An SRV or Fighter, within an associated launchbay.
+
+    - `name` the name of the vehicle, for example 'F63 Condor'
+    - `loadout` the loadout of the vehicle, for example 'Starter' for SRV or 'Gelid' for Fighter
+    - `mount` only for Fighters, this defines the type of mount ('F' = fixed, 'G' = gimballed)
+    - `rebuilds` the number of rebuilds remaining for the vehicle
+
+## Launchbay
+
+An SRV or Fighter hangar.
+
+    - `type` the of launchbay, 'SRV' of 'Fighter'
+    - `size` the numeric size of the launchbay
+    - `vehicles` the vehicles within the launchbay (this is an array of vehicle objects)
 
 ## Material
 


### PR DESCRIPTION
Added 2.4 cAPI 'Launch Bay' data to the Ship Object,

Tightened up Ship Monitor code to ensure updating of pertinent ship data only when current ship ID and cAPI /profile ship ID match, aided by modifying RefreshProfileDelayed() to query the cAPI until the ship IDs match.