### PR TITLE
Feature - Revamped bug reporting

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,6 +4,7 @@
   * Core
     * EDDI will now take commander ratings/rankings from the journal in addition to from the API.
     * EDDN market and outfitting updating restored, accomodating 2.4 cAPI changes. Bonus - now sending shipyard data to EDDN!
+    * Revised error reporting. The 'Send EDDI log to developers' button is now called 'Report an Issue' and routes users to our Github issues page. If verbose logging is enabled, a zipped and truncated log file is placed on the desktop so that it may be attached to the Github issue.
     * Updated Variables.md to include a description of commodities objects and their available properties.
     * Fixed a bug where some commanders weren't receiving updates to their EDSM profiles (by suppressing sending Coriolis links that were too long to EDSM). 
   * Shipyard

--- a/EDDI/EDDI.csproj
+++ b/EDDI/EDDI.csproj
@@ -118,6 +118,7 @@
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.104.0\lib\net451\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Speech" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -54,7 +54,7 @@
                         <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Enable verbose logging (only if you have been requested to do so by EDDI developers)" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiVerboseLogging" Grid.Row="0" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="verboseLoggingEnabled" Unchecked="verboseLoggingDisabled"/>
                         <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="If verbose logging is enabled, EDDI will prepare a truncated version of your log from the past hour and place it on your desktop. You may paste this log file into the Github Issue report. No personal information is sent in the log."/>
-                        <Button  x:Name="githubIssueButton" Grid.Row="1" Grid.Column="2" Content="Report an Issue" Margin="5" Click="createGithubIssueClicked"/>
+                        <Button  x:Name="githubIssueButton" Grid.Row="1" Grid.Column="2" Content="Report an Issue" Margin="5" Width="110"  Click="createGithubIssueClicked"/>
                         <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Access beta versions of EDDI" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiBetaProgramme" Grid.Row="2" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="betaProgrammeEnabled" Unchecked="betaProgrammeDisabled"/>
                     </Grid>

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -53,8 +53,8 @@
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Enable verbose logging (only if you have been requested to do so by EDDI developers)" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiVerboseLogging" Grid.Row="0" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="verboseLoggingEnabled" Unchecked="verboseLoggingDisabled"/>
-                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Upload log files (only if you have been requested to do so by EDDI developers).  No personal information is sent in the log.  Please note that uploading the log can take a number of minutes to complete."/>
-                        <Button  x:Name="sendLogButton" Grid.Row="1" Grid.Column="2" Content="Send EDDI log to developers" Margin="5" Click="sendLogsClicked"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="If verbose logging is enabled, EDDI will prepare a truncated version of your log from the past hour and place it on your desktop. You may paste this log file into the Github Issue report. No personal information is sent in the log."/>
+                        <Button  x:Name="githubIssueButton" Grid.Row="1" Grid.Column="2" Content="Report an Issue" Margin="5" Click="createGithubIssueClicked"/>
                         <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Access beta versions of EDDI" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiBetaProgramme" Grid.Row="2" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="betaProgrammeEnabled" Unchecked="betaProgrammeDisabled"/>
                     </Grid>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -580,24 +580,24 @@ namespace Eddi
         {
             try
             {
-                string IssueLogDir = Constants.DATA_DIR + @"\logexport\";
-                string IssueLogFile = IssueLogDir + @"eddi_issue.log";
-                string DesktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + @"\eddi_issue.zip";
+                string issueLogDir = Constants.DATA_DIR + @"\logexport\";
+                string issueLogFile = issueLogDir + @"eddi_issue.log";
+                string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + @"\eddi_issue.zip";
 
                 lock (logLock)
                 {
                     progress.Report("");
 
                     // Create a temporary issue log file, delete any remnants from prior issue reporting
-                    Directory.CreateDirectory(IssueLogDir);
-                    File.Create(IssueLogFile);
-                    File.Delete(DesktopPath);
+                    Directory.CreateDirectory(issueLogDir);
+                    File.Create(issueLogFile);
+                    File.Delete(desktopPath);
 
                     // Use regex to isolate DateTimes from the string
                     Regex recentLogsRegex = new Regex(@"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})");
 
                     var log = File.ReadAllLines(Constants.DATA_DIR + @"\\eddi.log");
-                    double elapsed_time = 0;
+                    double elapsedTime = 0;
 
                     foreach (string line in log)
                     {
@@ -606,12 +606,12 @@ namespace Eddi
                             // Parse log file lines so that we can examine DateTimes
                             string linedatestring = recentLogsRegex.Match(line).Value;
                             DateTime linedate = DateTime.Parse(linedatestring);
-                            elapsed_time = (DateTime.UtcNow - linedate).TotalHours;
+                            elapsedTime = (DateTime.UtcNow - linedate).TotalHours;
 
                             // Fill the issue log with log lines from the most recent hour only
-                            if (elapsed_time < 1)
+                            if (elapsedTime < 1)
                             {
-                                using (StreamWriter file = new StreamWriter(IssueLogFile, true))
+                                using (StreamWriter file = new StreamWriter(issueLogFile, true))
                                 {
                                     file.WriteLine(line);
                                 }
@@ -624,11 +624,11 @@ namespace Eddi
                     }
                 }
                 // Copy the issue log & zip it to the desktop so that it can be added to the Github issue
-                ZipFile.CreateFromDirectory(IssueLogDir, DesktopPath);
+                ZipFile.CreateFromDirectory(issueLogDir, desktopPath);
 
                 // Clear the temporary issue log file & directory
-                File.Delete(IssueLogFile);
-                Directory.Delete(IssueLogDir);
+                File.Delete(issueLogFile);
+                Directory.Delete(issueLogDir);
 
                 progress.Report("done");
             }


### PR DESCRIPTION
Revised bug reporting to address issue #91.
The button now routes users to a new Github issue. 
If verbose logging is enabled, a truncated log (1 hour max) is zipped and dropped onto the desktop so that it can be attached to the new issue at the user's option.