### PR TITLE
Feature - Revamped bug reporting (revised)

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,7 +1,8 @@
 # CHANGE LOG
 
 ### 2.4.2-b1
-  * placeholder
+  * Core
+    * Revised error reporting. The 'Send EDDI log to developers' button is now called 'Report an Issue' and routes users to our Github issues page. If verbose logging is enabled, a zipped and truncated log file is placed on the desktop so that it may be attached to the Github issue.
 
 ### 2.4.1
   * We just needed to bump the version number to flush out 2.4.0 builds that didn't understand that 'rc' means 'release candidate'. (Because it's a computer and, guess what, we have to tell it stuff like that.)

--- a/EDDI/EDDI.csproj
+++ b/EDDI/EDDI.csproj
@@ -118,6 +118,7 @@
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.104.0\lib\net451\System.Data.SQLite.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Speech" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -53,8 +53,8 @@
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Enable verbose logging (only if you have been requested to do so by EDDI developers)" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiVerboseLogging" Grid.Row="0" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="verboseLoggingEnabled" Unchecked="verboseLoggingDisabled"/>
-                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Upload log files (only if you have been requested to do so by EDDI developers).  No personal information is sent in the log.  Please note that uploading the log can take a number of minutes to complete."/>
-                        <Button  x:Name="sendLogButton" Grid.Row="1" Grid.Column="2" Content="Send EDDI log to developers" Margin="5" Click="sendLogsClicked"/>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="If verbose logging is enabled, EDDI will prepare a truncated version of your log from the past hour and place it on your desktop. You may paste this log file into the Github Issue report. No personal information is sent in the log."/>
+                        <Button  x:Name="githubIssueButton" Grid.Row="1" Grid.Column="2" Content="Report an Issue" Margin="5" Width="110" Click="createGithubIssueClicked"/>
                         <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Access beta versions of EDDI" VerticalAlignment="Top"/>
                         <CheckBox x:Name="eddiBetaProgramme" Grid.Row="2" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="betaProgrammeEnabled" Unchecked="betaProgrammeDisabled"/>
                     </Grid>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -588,6 +588,8 @@ namespace Eddi
                 {
                     log = File.ReadAllLines(Constants.DATA_DIR + @"\eddi.log");
                 }
+                if (log.Length == 0) { return; }
+
                 progress.Report("");
                 List<string> outputLines = new List<string>();
                 // Use regex to isolate DateTimes from the string

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Speech.Synthesis;
 using System.Text.RegularExpressions;
@@ -31,6 +32,8 @@ namespace Eddi
         public MainWindow() : this(false) { }
 
         private bool runBetaCheck = false;
+
+        private static readonly object logLock = new object();
 
         public MainWindow(bool fromVA = false)
         {
@@ -550,13 +553,20 @@ namespace Eddi
             e.Handled = !regex.IsMatch(e.Text);
         }
 
-        private async void sendLogsClicked(object sender, RoutedEventArgs e)
+        private async void createGithubIssueClicked(object sender, RoutedEventArgs e)
         {
             // Write out useful information to the log before procedding
             Logging.Info("EDDI version: " + Constants.EDDI_VERSION);
             Logging.Info("Commander name: " + (EDDI.Instance.Cmdr != null ? EDDI.Instance.Cmdr.name : "unknown"));
-            var progress = new Progress<string>(s => sendLogButton.Content = "Uploading log..." + s);
-            await Task.Factory.StartNew(() => uploadLog(progress), TaskCreationOptions.LongRunning);
+
+            // Prepare a truncated log file for export if verbose logging is enabled
+            if (eddiVerboseLogging.IsChecked.Value)
+            {
+                var progress = new Progress<string>(s => githubIssueButton.Content = "Preparing log..." + s);
+                await Task.Factory.StartNew(() => prepareLog(progress), TaskCreationOptions.LongRunning);
+            }
+            
+            createGithubIssue();
         }
 
         private void ChangeLog_Click(object sender, RoutedEventArgs e)
@@ -565,43 +575,88 @@ namespace Eddi
             changeLog.Show();
         }
 
-        public static void uploadLog(IProgress<string> progress)
+        public static void prepareLog(IProgress<string> progress)
         {
-            using (WebClient client = new WebClient())
+            try
             {
-                try
+                string issueLogDir = Constants.DATA_DIR + @"\logexport\";
+                string issueLogFile = issueLogDir + @"eddi_issue.log";
+                string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + @"\eddi_issue.zip";
+
+                lock (logLock)
                 {
                     progress.Report("");
-                    client.UploadFile("http://api.eddp.co/log", Constants.DATA_DIR + @"\\eddi.log");
-                    progress.Report("done");
-                    if (false) // temporarily disabled while we fix #91
+
+                    // Create a temporary issue log file, delete any remnants from prior issue reporting
+                    Directory.CreateDirectory(issueLogDir);
+                    File.Create(issueLogFile);
+                    File.Delete(desktopPath);
+
+                    // Use regex to isolate DateTimes from the string
+                    Regex recentLogsRegex = new Regex(@"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})");
+
+                    var log = File.ReadAllLines(Constants.DATA_DIR + @"\\eddi.log");
+                    double elapsedTime = 0;
+
+                    foreach (string line in log)
                     {
                         try
                         {
-                            File.Delete(Constants.DATA_DIR + @"\\eddi.log");
+                            // Parse log file lines so that we can examine DateTimes
+                            string linedatestring = recentLogsRegex.Match(line).Value;
+                            DateTime linedate = DateTime.SpecifyKind(DateTime.Parse(linedatestring, CultureInfo.InvariantCulture), DateTimeKind.Utc);
+                            elapsedTime = (DateTime.UtcNow - linedate).TotalHours;
+
+                            // Fill the issue log with log lines from the most recent hour only
+                            if (elapsedTime < 1)
+                            {
+                                using (StreamWriter file = new StreamWriter(issueLogFile, true))
+                                {
+                                    file.WriteLine(line);
+                                }
+                            }
+
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
-                            Logging.Error("Failed to delete file after upload", ex);
+                            // Do nothing, adding to the debug log creates a feedback loop
                         }
                     }
+
                 }
-                catch (Exception ex)
-                {
-                    progress.Report("failed");
-                    Logging.Error("Failed to upload log", ex);
-                }
+
+                // Copy the issue log & zip it to the desktop so that it can be added to the Github issue
+                ZipFile.CreateFromDirectory(issueLogDir, desktopPath);
+
+                // Clear the temporary issue log file & directory
+                File.Delete(issueLogFile);
+                Directory.Delete(issueLogDir);
+
+                progress.Report("done");
             }
+            catch (Exception ex)
+            {
+                progress.Report("failed");
+                Logging.Error("Failed to upload log", ex);
+
+            }
+        }
+
+        private void createGithubIssue()
+        {
+            Process.Start("https://github.com/EDCD/EDDI/issues/new");
         }
 
         private void upgradeClicked(object sender, RoutedEventArgs e)
         {
             EDDI.Instance.Upgrade();
         }
+
         private void EDDIClicked(object sender, RoutedEventArgs e)
         {
             Process.Start("https://github.com/EDCD/EDDI/blob/master/README.md");
         }
+
         private void WikiClicked(object sender, RoutedEventArgs e)
         {
             Process.Start("https://github.com/EDCD/EDDI/wiki");


### PR DESCRIPTION
Revised bug reporting to address issue #91.
The button now routes users to a new Github issue.
If verbose logging is enabled, a truncated log (1 hour max) is zipped and dropped onto the desktop so that it can be attached to the new issue at the user's option.

Updated to better handle timezone issues in parsing. Replaces PR #166.