### PR TITLE
Bugfix for #83 - materialsmonitor

### DIFF
--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -116,8 +116,8 @@ namespace EddiDataDefinitions
         public static readonly Material PeculiarShieldFrequencyData = new Material("shieldfrequencydata", "Data", "Peculiar Shield Frequency Data", Rarity.VeryRare);
 
         public static readonly Material BasicConductors = new Material("basicconductors", "Manufactured", "Basic Conductors", Rarity.VeryCommon);
-        public static readonly Material ChemicalStorageUnits = new Material("", "Manufactured", "Chemical Storage Units", Rarity.VeryCommon);
-        public static readonly Material CompactComposites = new Material("", "Manufactured", "Compact Composites", Rarity.VeryCommon);
+        public static readonly Material ChemicalStorageUnits = new Material("chemicalstorageunits", "Manufactured", "Chemical Storage Units", Rarity.VeryCommon);
+        public static readonly Material CompactComposites = new Material("compactcomposites", "Manufactured", "Compact Composites", Rarity.VeryCommon);
         public static readonly Material CrystalShards = new Material("crystalshards", "Manufactured", "Crystal Shards", Rarity.VeryCommon);
         public static readonly Material GridResistors = new Material("gridresistors", "Manufactured", "Grid Resistors", Rarity.VeryCommon);
         public static readonly Material HeatConductionWiring = new Material("heatconductionwiring", "Manufactured", "Heat Conduction Wiring", Rarity.VeryCommon);
@@ -128,7 +128,7 @@ namespace EddiDataDefinitions
 
         public static readonly Material ChemicalProcessors = new Material("chemicalprocessors", "Manufactured", "Chemical Processors", Rarity.Common);
         public static readonly Material ConductiveComponents = new Material("conductivecomponents", "Manufactured", "Conductive Components", Rarity.Common);
-        public static readonly Material FilamentComposites = new Material("", "Manufactured", "Filament Composites", Rarity.Common);
+        public static readonly Material FilamentComposites = new Material("filamentcomposites", "Manufactured", "Filament Composites", Rarity.Common);
         public static readonly Material FlawedFocusCrystals = new Material("uncutfocuscrystals", "Manufactured", "Flawed Focus Crystals", Rarity.Common);
         public static readonly Material GalvanisingAlloys = new Material("galvanisingalloys", "Manufactured", "Galvanising Alloys", Rarity.Common);
         public static readonly Material HeatDispersionPlate = new Material("heatdispersionplate", "Manufactured", "Heat Dispersion Plate", Rarity.Common);
@@ -228,6 +228,31 @@ namespace EddiDataDefinitions
                 Logging.Report("Unknown material symbol " + from);
             }
             return result;
+        }
+
+        public static bool DeprecatedMaterials(string name)
+        {
+            // These material names have been replaced / are no longer in use. Listed for reference so that they won't be retained by the material monitor.
+            if (name == null)
+            {
+                return false;
+            }
+            List<string> deprecatedMaterialsList = new List<string>
+            {
+                {"Thargoid Residue Data Analysis"},
+                {"Unknown Ship Signature"},
+                {"Unknown Wake Data"},
+                {"Unknown Fragment"},
+            };
+
+            if (deprecatedMaterialsList.Contains(name.Trim()))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -239,20 +239,13 @@ namespace EddiDataDefinitions
             }
             List<string> deprecatedMaterialsList = new List<string>
             {
-                {"Thargoid Residue Data Analysis"},
-                {"Unknown Ship Signature"},
-                {"Unknown Wake Data"},
-                {"Unknown Fragment"},
+                "Thargoid Residue Data Analysis",
+                "Unknown Ship Signature",
+                "Unknown Wake Data",
+                "Unknown Fragment",
             };
 
-            if (deprecatedMaterialsList.Contains(name.Trim()))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return deprecatedMaterialsList.Contains(name.Trim());
         }
     }
 }

--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -198,7 +198,7 @@ namespace EddiDataDefinitions
             if (result == null)
             {
                 Logging.Report("Unknown material name " + from);
-                result = new Material(tidiedFrom, "Unknown", from, Rarity.Unknown);
+                result = new Material(null, "Unknown", from, Rarity.Unknown);
             }
             return result;
         }

--- a/DataDefinitions/MaterialAmount.cs
+++ b/DataDefinitions/MaterialAmount.cs
@@ -10,7 +10,27 @@ namespace EddiDataDefinitions
 {
     public class MaterialAmount : INotifyPropertyChanged
     {
-        public string material { get; private set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(null)]
+        public string edname { get; private set; }
+
+        [JsonIgnore]
+        private string _material;
+        public string material
+        {
+            get
+            {
+                return _material;
+            }
+            set
+            {
+                if (_material != value)
+                {
+                    _material = value;
+                    NotifyPropertyChanged("material");
+                }
+            }
+        }
 
         [JsonIgnore]
         private int _amount;
@@ -101,17 +121,19 @@ namespace EddiDataDefinitions
 
         public MaterialAmount(Material material, int amount)
         {
-            Material My_material = Material.FromName(material.name);
-            this.material = material.name;
+            Material My_material = Material.FromEDName(material.EDName);
+            this.material = My_material.name;
+            this.edname = My_material.EDName;
             this.amount = amount;
             this.Category = My_material.category;
         }
 
-        public MaterialAmount(Material material, int? minimum, int? desired, int? maximum)
+        public MaterialAmount(Material material, int amount, int? minimum, int? desired, int? maximum)
         {
-            Material My_material = Material.FromName(material.name);
-            this.material = material.name;
-            amount = 0;
+            Material My_material = Material.FromEDName(material.EDName);
+            this.material = My_material.name;
+            this.edname = My_material.EDName;
+            this.amount = amount;
             this.minimum = minimum;
             this.desired = desired;
             this.maximum = maximum;
@@ -123,6 +145,7 @@ namespace EddiDataDefinitions
         {
             Material My_material = Material.FromName(material);
             this.material = material;
+            this.edname = My_material.EDName;
             this.amount = amount;
             this.minimum = minimum;
             this.desired = desired;

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,6 +3,8 @@
 ### 2.4.2-b1
   * Core
     * Revised error reporting. The 'Send EDDI log to developers' button is now called 'Report an Issue' and routes users to our Github issues page. If verbose logging is enabled, a zipped and truncated log file is placed on the desktop so that it may be attached to the Github issue.
+  * Material Monitor
+    * Fixed a bug that prevented EDDI from recognizing and removing old versions of some data from the Material Monitor.
 
 ### 2.4.1
   * We just needed to bump the version number to flush out 2.4.0 builds that didn't understand that 'rc' means 'release candidate'. (Because it's a computer and, guess what, we have to tell it stuff like that.)

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -118,7 +118,7 @@ namespace EddiEdsmResponder
                     Dictionary<string, int> data = new Dictionary<string, int>();
                     foreach (MaterialAmount ma in materialInventoryEvent.inventory)
                     {
-                        Material material = Material.FromName(ma.material);
+                        Material material = Material.FromEDName(ma.edname);
                         if (material.category == "Element" || material.category == "Manufactured")
                         {
                             materials.Add(material.EDName, ma.amount);

--- a/Events/MaterialCollectedEvent.cs
+++ b/Events/MaterialCollectedEvent.cs
@@ -34,9 +34,9 @@ namespace EddiEvents
 
         public MaterialCollectedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
-            this.name = (material == null ? null : material.name);
+            this.name = material?.name;
             this.amount = amount;
-            this.edname = (material == null ? null : material.EDName);
+            this.edname = material?.EDName;
         }
     }
 }

--- a/Events/MaterialCollectedEvent.cs
+++ b/Events/MaterialCollectedEvent.cs
@@ -28,10 +28,15 @@ namespace EddiEvents
         [JsonProperty("amount")]
         public int amount { get; private set; }
 
+        // Admin
+        [JsonProperty("edname")]
+        public string edname { get; private set; }
+
         public MaterialCollectedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
             this.name = (material == null ? null : material.name);
             this.amount = amount;
+            this.edname = (material == null ? null : material.EDName);
         }
     }
 }

--- a/Events/MaterialDiscardedEvent.cs
+++ b/Events/MaterialDiscardedEvent.cs
@@ -33,9 +33,9 @@ namespace EddiEvents
 
         public MaterialDiscardedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
-            this.name = (material == null ? null : material.name);
+            this.name = material?.name;
             this.amount = amount;
-            this.edname = (material == null ? null : material.EDName);
+            this.edname = material?.EDName;
         }
     }
 }

--- a/Events/MaterialDiscardedEvent.cs
+++ b/Events/MaterialDiscardedEvent.cs
@@ -27,10 +27,15 @@ namespace EddiEvents
         [JsonProperty("amount")]
         public int amount { get; private set; }
 
+        // Admin
+        [JsonProperty("edname")]
+        public string edname { get; private set; }
+
         public MaterialDiscardedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
             this.name = (material == null ? null : material.name);
             this.amount = amount;
+            this.edname = (material == null ? null : material.EDName);
         }
     }
 }

--- a/Events/MaterialDiscoveredEvent.cs
+++ b/Events/MaterialDiscoveredEvent.cs
@@ -25,7 +25,7 @@ namespace EddiEvents
 
         public MaterialDiscoveredEvent(DateTime timestamp, Material material) : base(timestamp, NAME)
         {
-            this.name = (material == null ? null : material.name);
+            this.name = material?.name;
         }
     }
 }

--- a/Events/MaterialDonatedEvent.cs
+++ b/Events/MaterialDonatedEvent.cs
@@ -34,9 +34,9 @@ namespace EddiEvents
 
         public MaterialDonatedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
-            this.name = (material == null ? null : material.name);
+            this.name = material?.name;
             this.amount = amount;
-            this.edname = (material == null ? null : material.EDName);
+            this.edname = material?.EDName;
         }
     }
 }

--- a/Events/MaterialDonatedEvent.cs
+++ b/Events/MaterialDonatedEvent.cs
@@ -28,10 +28,15 @@ namespace EddiEvents
         [JsonProperty("amount")]
         public int amount { get; private set; }
 
+        // Admin
+        [JsonProperty("edname")]
+        public string edname { get; private set; }
+
         public MaterialDonatedEvent(DateTime timestamp, Material material, int amount) : base(timestamp, NAME)
         {
             this.name = (material == null ? null : material.name);
             this.amount = amount;
+            this.edname = (material == null ? null : material.EDName);
         }
     }
 }

--- a/MaterialMonitor/MaterialMonitorConfiguration.cs
+++ b/MaterialMonitor/MaterialMonitorConfiguration.cs
@@ -54,16 +54,6 @@ namespace EddiMaterialMonitor
                 configuration = new MaterialMonitorConfiguration();
             }
 
-            //// We fully populate the list with all known materials
-            //foreach (Material material in Material.MATERIALS)
-            //{
-            //    Limits cur;
-            //    if (!configuration.limits.TryGetValue(material.EDName, out cur))
-            //    {
-            //        configuration.limits[material.EDName] = new Limits(null, null, null);
-            //    }
-            //}
-
             configuration.dataPath = filename;
             return configuration;
         }


### PR DESCRIPTION
This should be safe, but backup your materialsmonitor.json before testing just in case.

- Revises the material so that it consistently uses the edname as a key, rather than using a mixture of the material name and the material edname (collectively: material). Add edname to the json.
- Preserves current user settings while converting to the new edname version of the json
- Adds a DeprecatedMaterials function to Materials.cs to identify and prune old data (this will be obsolete / no longer required once everyone is transitioned from the current json format)
- Revises logic to make the materialsmonitor more "self-healing". The 1st time is is run it'll add an EDName to all of the entries in materialmonitor.json. The 2nd time, it'll identify any entries with the duplicate EDNames and select entries such that only one EDName shall be allowed for each material. (This happens often enough naturally that programming a loop to iterate through this process isn't necessary.)