### PR TITLE
Fix for #184, empty truncated error logs

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+### 2.4.2.1
+  * Core
+    * Fixed a bug that was causing the "Report an issue" button to export empty log files.
+
 ### 2.4.2
   * Core
     * Revised EDDN updating for naming changes in ED 2.4. This makes EDDI 2.4.2 a mandatory update.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,6 @@
 # CHANGE LOG
 
-### 2.4.2.1
+### 2.4.3
   * Core
     * Fixed a bug that was causing the "Report an issue" button to export empty log files.
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -562,6 +562,7 @@ namespace Eddi
             // Prepare a truncated log file for export if verbose logging is enabled
             if (eddiVerboseLogging.IsChecked.Value)
             {
+                Logging.Debug("Preparing log for export.");
                 var progress = new Progress<string>(s => githubIssueButton.Content = "Preparing log..." + s);
                 await Task.Factory.StartNew(() => prepareLog(progress), TaskCreationOptions.LongRunning);
             }
@@ -604,6 +605,7 @@ namespace Eddi
                         string formatString = "s"; // i.e. DateTimeFormatInfo.SortableDateTimePattern
                         if (DateTime.TryParseExact(linedatestring, formatString, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime linedate))
                         {
+                            linedate = linedate.ToUniversalTime();
                             double elapsedHours = (DateTime.UtcNow - linedate).TotalHours;
                             // Fill the issue log with log lines from the most recent hour only
                             if (elapsedHours < 1.0)
@@ -617,6 +619,8 @@ namespace Eddi
                         // Do nothing, adding to the debug log creates a feedback loop
                     }
                 }
+                if (outputLines.Count == 0) { Logging.Error("Error parsing log. Algorithm failed to return any matches."); return; }
+
                 // Create a temporary issue log file, delete any remnants from prior issue reporting
                 Directory.CreateDirectory(issueLogDir);
                 File.WriteAllLines(issueLogFile, outputLines);
@@ -634,7 +638,7 @@ namespace Eddi
             catch (Exception ex)
             {
                 progress.Report("failed");
-                Logging.Error("Failed to upload log", ex);
+                Logging.Error("Failed to prepare log", ex);
 
             }
         }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -619,7 +619,11 @@ namespace Eddi
                         // Do nothing, adding to the debug log creates a feedback loop
                     }
                 }
-                if (outputLines.Count == 0) { Logging.Error("Error parsing log. Algorithm failed to return any matches."); return; }
+                if (outputLines.Count == 0)
+                {
+                    Logging.Error("Error parsing log. Algorithm failed to return any matches.");
+                    return;
+                }
 
                 // Create a temporary issue log file, delete any remnants from prior issue reporting
                 Directory.CreateDirectory(issueLogDir);

--- a/Installer.iss
+++ b/Installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "EDDI"
-#define MyAppVersion "2.4.2"
+#define MyAppVersion "2.4.3"
 #define MyAppPublisher "Elite Dangerous Community Developers (EDCD)"
 #define MyAppURL "https://github.com/EDCD/EDDI/"
 #define MyAppExeName "EDDI.exe"

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -12,7 +12,7 @@ namespace Utilities
     public class Constants
     {
         public const string EDDI_NAME = "EDDI";
-        public const string EDDI_VERSION = "2.4.2";
+        public const string EDDI_VERSION = "2.4.3";
         public const string EDDI_SERVER_URL = "http://edcd.github.io/EDDP/";
 
         public static readonly string DATA_DIR = Environment.GetEnvironmentVariable("AppData") + "\\" + EDDI_NAME;


### PR DESCRIPTION
Bugfix for #184. ensures output of "linedate" is in UTC and prevents the creation of a truncated log zip file if the algorithm returns zero matches. See also comments on commit https://github.com/EDCD/EDDI/commit/c0f89725803e100b3949f7649372e95e40344258 for rational on this change.