### PR TITLE
Translation work

### DIFF
--- a/EDDI/ChangeLog.xaml.cs
+++ b/EDDI/ChangeLog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Windows;
@@ -20,7 +20,7 @@ namespace Eddi
             try
             {
                 DirectoryInfo dir = new DirectoryInfo(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-                markdown = Files.Read(dir + @"\ChangeLog.md");
+                markdown = File.ReadAllText(dir + @"\ChangeLog.md");
             }
             catch (Exception ex)
             {
@@ -28,6 +28,7 @@ namespace Eddi
                 markdown = "";
             }
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);

--- a/SpeechResponder/HelpWindow.xaml.cs
+++ b/SpeechResponder/HelpWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Windows;
@@ -17,10 +17,11 @@ namespace EddiSpeechResponder
 
             // Read Markdown and convert it to HTML
             string markdown;
+            string blabla = "";
             try
             {
                 DirectoryInfo dir = new DirectoryInfo(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-                markdown = Files.Read(dir.FullName + @"\Help.md");
+                markdown = File.ReadAllText(dir.FullName + @"\Help.md"); //Files.Read(dir.FullName + @"\Help.md");
             }
             catch (Exception ex)
             {
@@ -28,6 +29,7 @@ namespace EddiSpeechResponder
                 markdown = "";
             }
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);

--- a/SpeechResponder/VariablesWindow.xaml.cs
+++ b/SpeechResponder/VariablesWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using EddiEvents;
+using EddiEvents;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -33,7 +33,7 @@ namespace EddiSpeechResponder
             try
             {
                 DirectoryInfo dir = new DirectoryInfo(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-                markdown = Files.Read(dir.FullName + @"\Variables.md");
+                markdown = File.ReadAllText(dir.FullName + @"\Variables.md");
             }
             catch (Exception ex)
             {
@@ -65,6 +65,7 @@ namespace EddiSpeechResponder
             }
 
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);


### PR DESCRIPTION
If someone translate the md file with charater like é,è û and other, they are changed.
for exemple é become Ã©, and ù become Ã¹

The little change of code is to correct that.