### PR TITLE
International characters & UTF formatting

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,4 +1,4 @@
-#Contributors
+﻿#Contributors
 
 
   * [Cmdr McDonald](https://github.com/cmdrmcdonald)

--- a/EDDI/ChangeLog.xaml.cs
+++ b/EDDI/ChangeLog.xaml.cs
@@ -28,6 +28,7 @@ namespace Eddi
                 markdown = "";
             }
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Apache License
+ÔªøApache License
 ==============
 
 _Version 2.0, January 2004_  
@@ -8,55 +8,55 @@ _&lt;<http://www.apache.org/licenses/>&gt;_
 
 #### 1. Definitions
 
-ìLicenseî shall mean the terms and conditions for use, reproduction, and
+‚ÄúLicense‚Äù shall mean the terms and conditions for use, reproduction, and
 distribution as defined by Sections 1 through 9 of this document.
 
-ìLicensorî shall mean the copyright owner or entity authorized by the copyright
+‚ÄúLicensor‚Äù shall mean the copyright owner or entity authorized by the copyright
 owner that is granting the License.
 
-ìLegal Entityî shall mean the union of the acting entity and all other entities
+‚ÄúLegal Entity‚Äù shall mean the union of the acting entity and all other entities
 that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, ìcontrolî means **(i)** the power, direct or
+For the purposes of this definition, ‚Äúcontrol‚Äù means **(i)** the power, direct or
 indirect, to cause the direction or management of such entity, whether by
 contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
 outstanding shares, or **(iii)** beneficial ownership of such entity.
 
-ìYouî (or ìYourî) shall mean an individual or Legal Entity exercising
+‚ÄúYou‚Äù (or ‚ÄúYour‚Äù) shall mean an individual or Legal Entity exercising
 permissions granted by this License.
 
-ìSourceî form shall mean the preferred form for making modifications, including
+‚ÄúSource‚Äù form shall mean the preferred form for making modifications, including
 but not limited to software source code, documentation source, and configuration
 files.
 
-ìObjectî form shall mean any form resulting from mechanical transformation or
+‚ÄúObject‚Äù form shall mean any form resulting from mechanical transformation or
 translation of a Source form, including but not limited to compiled object code,
 generated documentation, and conversions to other media types.
 
-ìWorkî shall mean the work of authorship, whether in Source or Object form, made
+‚ÄúWork‚Äù shall mean the work of authorship, whether in Source or Object form, made
 available under the License, as indicated by a copyright notice that is included
 in or attached to the work (an example is provided in the Appendix below).
 
-ìDerivative Worksî shall mean any work, whether in Source or Object form, that
+‚ÄúDerivative Works‚Äù shall mean any work, whether in Source or Object form, that
 is based on (or derived from) the Work and for which the editorial revisions,
 annotations, elaborations, or other modifications represent, as a whole, an
 original work of authorship. For the purposes of this License, Derivative Works
 shall not include works that remain separable from, or merely link (or bind by
 name) to the interfaces of, the Work and Derivative Works thereof.
 
-ìContributionî shall mean any work of authorship, including the original version
+‚ÄúContribution‚Äù shall mean any work of authorship, including the original version
 of the Work and any modifications or additions to that Work or Derivative Works
 thereof, that is intentionally submitted to Licensor for inclusion in the Work
 by the copyright owner or by an individual or Legal Entity authorized to submit
 on behalf of the copyright owner. For the purposes of this definition,
-ìsubmittedî means any form of electronic, verbal, or written communication sent
+‚Äúsubmitted‚Äù means any form of electronic, verbal, or written communication sent
 to the Licensor or its representatives, including but not limited to
 communication on electronic mailing lists, source code control systems, and
 issue tracking systems that are managed by, or on behalf of, the Licensor for
 the purpose of discussing and improving the Work, but excluding communication
 that is conspicuously marked or otherwise designated in writing by the copyright
-owner as ìNot a Contribution.î
+owner as ‚ÄúNot a Contribution.‚Äù
 
-ìContributorî shall mean Licensor and any individual or Legal Entity on behalf
+‚ÄúContributor‚Äù shall mean Licensor and any individual or Legal Entity on behalf
 of whom a Contribution has been received by Licensor and subsequently
 incorporated within the Work.
 
@@ -97,7 +97,7 @@ changed the files; and
 all copyright, patent, trademark, and attribution notices from the Source form
 of the Work, excluding those notices that do not pertain to any part of the
 Derivative Works; and
-* **(d)** If the Work includes a ìNOTICEî text file as part of its distribution, then any
+* **(d)** If the Work includes a ‚ÄúNOTICE‚Äù text file as part of its distribution, then any
 Derivative Works that You distribute must include a readable copy of the
 attribution notices contained within such NOTICE file, excluding those notices
 that do not pertain to any part of the Derivative Works, in at least one of the
@@ -136,7 +136,7 @@ reproducing the content of the NOTICE file.
 #### 7. Disclaimer of Warranty
 
 Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an ìAS ISî BASIS,
+Work (and each Contributor provides its Contributions) on an ‚ÄúAS IS‚Äù BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
 including, without limitation, any warranties or conditions of TITLE,
 NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
@@ -176,7 +176,7 @@ notice, with the fields enclosed by brackets `[]` replaced with your own
 identifying information. (Don't include the brackets!) The text should be
 enclosed in the appropriate comment syntax for the file format. We also
 recommend that a file or class name and description of purpose be included on
-the same ìprinted pageî as the copyright notice for easier identification within
+the same ‚Äúprinted page‚Äù as the copyright notice for easier identification within
 third-party archives.
 
     Copyright [yyyy] [name of copyright owner]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EDDI: The Elite Dangerous Data Interface
+﻿# EDDI: The Elite Dangerous Data Interface
 
 EDDI is a companion application for Elite: Dangerous, providing responses to events that occur in-game using data from the game as well as various third-party tools.
 

--- a/SpeechResponder/HelpWindow.xaml.cs
+++ b/SpeechResponder/HelpWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace EddiSpeechResponder
                 markdown = "";
             }
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);

--- a/SpeechResponder/VariablesWindow.xaml.cs
+++ b/SpeechResponder/VariablesWindow.xaml.cs
@@ -65,6 +65,7 @@ namespace EddiSpeechResponder
             }
 
             string html = CommonMark.CommonMarkConverter.Convert(markdown);
+            html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;
 
             // Insert the HTML
             textBrowser.NavigateToString(html);

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,4 +1,4 @@
-# Troubleshooting
+﻿# Troubleshooting
 
 # General Issues
 

--- a/VoiceAttack.md
+++ b/VoiceAttack.md
@@ -1,3 +1,3 @@
-# Using EDDI with VoiceAttack
+﻿# Using EDDI with VoiceAttack
 
 Please refer to the EDDI wiki at https://github.com/EDCD/EDDI/wiki/VoiceAttack-Integration


### PR DESCRIPTION
My take on PR #188. Re-saved .md files with UTF-8 encoding and added 'html = "<head>  <meta charset=\"UTF-8\"> </head> " + html;' to html headers. From my testing, this solution appears to work well.