### PR TITLE
Stellar age fix

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,5 +1,9 @@
 ﻿# CHANGE LOG
 
+### 2.4.4
+  * Speech Responder
+    * Fixed our fix. Star scans should no longer report every star as "one of the oldest".
+
 ### 2.4.3
   * Core
     * We will no longer ask users to send logs for commodity definition errors (and there was much rejoicing). 

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -32,7 +32,7 @@ namespace EddiEvents
             VARIABLES.Add("luminosity", "The luminosity of the star that has been scanned");
             VARIABLES.Add("luminosityclass", "The luminosity class of the star that has been scanned");            
             VARIABLES.Add("tempprobability", "The probablility of finding a star of this class with this temperature");
-            VARIABLES.Add("age", "The age of the star that has been scanned, in years (rounded to millions of years)");
+            VARIABLES.Add("age", "The age of the star that has been scanned, in millions of years");
             VARIABLES.Add("ageprobability", "The probablility of finding a star of this class with this age");
             VARIABLES.Add("temperature", "The temperature of the star that has been scanned");
             VARIABLES.Add("distancefromarrival", "The distance in LS from the main star");

--- a/Installer.iss
+++ b/Installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "EDDI"
-#define MyAppVersion "2.4.3"
+#define MyAppVersion "2.4.4"
 #define MyAppPublisher "Elite Dangerous Community Developers (EDCD)"
 #define MyAppURL "https://github.com/EDCD/EDDI/"
 #define MyAppExeName "EDDI.exe"

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -587,7 +587,7 @@ namespace EddiJournalMonitor
                                     decimal absoluteMagnitude = getDecimal(data, "AbsoluteMagnitude");
                                     string luminosityClass = getString(data, "Luminosity");
                                     data.TryGetValue("Age_MY", out val);
-                                    long age = (long)val * 1000000;
+                                    long age = (long)val;
                                     decimal temperature = getDecimal(data, "SurfaceTemperature");
 
                                     events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, age, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings) { raw = line });

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -587,10 +587,10 @@ namespace EddiJournalMonitor
                                     decimal absoluteMagnitude = getDecimal(data, "AbsoluteMagnitude");
                                     string luminosityClass = getString(data, "Luminosity");
                                     data.TryGetValue("Age_MY", out val);
-                                    long age = (long)val;
+                                    long ageMegaYears = (long)val;
                                     decimal temperature = getDecimal(data, "SurfaceTemperature");
 
-                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, age, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings) { raw = line });
+                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, ageMegaYears, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings) { raw = line });
                                     handled = true;
                                 }
                                 else

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -12,7 +12,7 @@ namespace Utilities
     public class Constants
     {
         public const string EDDI_NAME = "EDDI";
-        public const string EDDI_VERSION = "2.4.3";
+        public const string EDDI_VERSION = "2.4.4";
         public const string EDDI_SERVER_URL = "http://edcd.github.io/EDDP/";
 
         public static readonly string DATA_DIR = Environment.GetEnvironmentVariable("AppData") + "\\" + EDDI_NAME;


### PR DESCRIPTION
Fix for #213. We updated the script to handle the way age is reported from the server by multiplying by 1,000,000 there, but the age reported from the journal is already multiplied by 1,000,000 so it's compounding, making every star impossibly old.