### PR TITLE
Exploration: Scan calculations

### DIFF
--- a/DataDefinitions/StarClass.cs
+++ b/DataDefinitions/StarClass.cs
@@ -128,6 +128,15 @@ namespace EddiDataDefinitions
             return (decimal)Math.Pow(((double)luminosity * solLuminosity) / (4 * Math.PI * Math.Pow((double)radius, 2) * stefanBoltzmann), 0.25);
         }
 
+        public static decimal HabitableZone(double targetTemp, double radius, double temperature)
+        {
+            double top = Math.Pow(radius, 2.0) * Math.Pow(temperature, 4.0);
+            double bottom = 4.0 * Math.Pow(targetTemp, 4.0);
+            double radiusMeters = Math.Pow(top / bottom, 0.5);
+            double radiusls = ( radiusMeters ) / 299792458; // convert result from meters to lightseconds by divinding by the speed of light
+            return Convert.ToDecimal(radiusls);
+        }
+
         public static decimal sanitiseCP(decimal cp)
         {
             // Trim decimal places appropriately

--- a/DataDefinitions/StarClass.cs
+++ b/DataDefinitions/StarClass.cs
@@ -107,7 +107,7 @@ namespace EddiDataDefinitions
         /// </summary>
         public static decimal solarradius(decimal radius)
         {
-            return radius / 695500000;
+            return radius / Constants.solarRadiusMeters;
         }
 
         /// <summary>
@@ -115,26 +115,23 @@ namespace EddiDataDefinitions
         /// </summary>
         public static decimal luminosity(decimal absoluteMagnitude)
         {
-            double solAbsoluteMagnitude = 4.83;
-
-            return (decimal)Math.Pow(Math.Pow(100, 0.2), (solAbsoluteMagnitude - (double)absoluteMagnitude));
+            return (decimal)Math.Pow(Math.Pow(100, 0.2), (Constants.solAbsoluteMagnitude - (double)absoluteMagnitude));
         }
 
         public static decimal temperature(decimal luminosity, decimal radius)
         {
-            double solLuminosity = 3.846e26;
-            double stefanBoltzmann = 5.670367e-8;
-
-            return (decimal)Math.Pow(((double)luminosity * solLuminosity) / (4 * Math.PI * Math.Pow((double)radius, 2) * stefanBoltzmann), 0.25);
+            return (decimal)Math.Pow(((double)luminosity * Constants.solLuminosity) / 
+                (4 * Math.PI * Math.Pow((double)radius, 2) * Constants.stefanBoltzmann), 0.25);
         }
 
-        public static decimal HabitableZone(double targetTemp, double radius, double temperature)
+        public static decimal DistanceFromStarForTemperature(double targetTempKelvin, double stellarRadiusMeters, double stellarTemperatureKelvin)
         {
-            double top = Math.Pow(radius, 2.0) * Math.Pow(temperature, 4.0);
-            double bottom = 4.0 * Math.Pow(targetTemp, 4.0);
-            double radiusMeters = Math.Pow(top / bottom, 0.5);
-            double radiusls = ( radiusMeters ) / 299792458; // convert result from meters to lightseconds by divinding by the speed of light
-            return Convert.ToDecimal(radiusls);
+            // Derived from Jackie Silver's Habitable Zone Calculator (https://forums.frontier.co.uk/showthread.php?t=127522&highlight=), used with permission
+            double top = Math.Pow(stellarRadiusMeters, 2.0) * Math.Pow(stellarTemperatureKelvin, 4.0);
+            double bottom = 4.0 * Math.Pow(targetTempKelvin, 4.0);
+            double distanceMeters = Math.Pow(top / bottom, 0.5);
+            double distancels = ( distanceMeters ) / Constants.lightSpeedMetersPerSecond; 
+            return Convert.ToDecimal(distancels);
         }
 
         public static decimal sanitiseCP(decimal cp)

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,5 +1,10 @@
 ﻿# CHANGE LOG
 
+### 2.4.5
+  * Speech Responder
+    * 'Body scanned' and 'Star scanned' events - added new calculated variable "estimatedvalue". 
+    * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of the scanned star. Calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less accurate).
+
 ### 2.4.4
   * Speech Responder
     * Fixed a bug that was causing some SSML related functions (e.g. Pause()) to not render correctly.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,6 @@
 ﻿# CHANGE LOG
 
-### 2.4.56-b1
+### 2.4.6-b1
   * Speech Responder
     * 'Body scanned' and 'Star scanned' events - added new calculated variable "estimatedvalue". 
     * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of a scanned star. Note: calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less reliable).

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,6 +4,9 @@
   * Speech Responder
     * 'Body scanned' and 'Star scanned' events - added new calculated variable "estimatedvalue". 
     * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of a scanned star. Note: calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less reliable).
+  * Script changes
+    * 'Body scanned' - revised to report estimated scan value
+    * 'Star scanned' - revised to report estimated scan value and calculated habitable zone 
 
 ### 2.4.4
   * Speech Responder

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,7 +3,7 @@
 ### 2.4.5
   * Speech Responder
     * 'Body scanned' and 'Star scanned' events - added new calculated variable "estimatedvalue". 
-    * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of the scanned star. Calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less accurate).
+    * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of a scanned star. Note: calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less reliable).
 
 ### 2.4.4
   * Speech Responder

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,6 @@
 ﻿# CHANGE LOG
 
-### 2.4.5
+### 2.4.56-b1
   * Speech Responder
     * 'Body scanned' and 'Star scanned' events - added new calculated variable "estimatedvalue". 
     * 'Star scanned' event - added new calculated variables "estimatedhabzoneinner" and "estimatedhabzoneouter" to provide calculated values for the habitable zone of a scanned star. Note: calculations are most accurate for star systems containing a single star (multiple close proximity stars will make these calculations less reliable).

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -114,6 +114,7 @@ namespace Eddi
 
         // Current vehicle of player
         public string Vehicle { get; private set; } = Constants.VEHICLE_SHIP;
+        public Ship CurrentShip { get; set; }
 
         // Session state
         public ObservableConcurrentDictionary<string, object> State = new ObservableConcurrentDictionary<string, object>();

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -13,7 +13,6 @@ namespace EddiEvents
     {
         public const string NAME = "Star scanned";
         public const string DESCRIPTION = "Triggered when you complete a scan of a stellar body";
-        // public static string SAMPLE = "{ \"timestamp\":\"2016-10-05T10:13:55Z\", \"event\":\"Scan\", \"BodyName\":\"Col 285 Sector RS-K c8-5 A\", \"DistanceFromArrivalLS\":0.000000, \"StarType\":\"TTS\", \"StellarMass\":0.449219, \"Radius\":458926400.000000, \"AbsoluteMagnitude\":8.287720, \"Age_MY\":51, \"SurfaceTemperature\":3209.000000, \"Luminosity\":\"Va\", \"SemiMajorAxis\":352032544.000000, \"Eccentricity\":0.027010, \"OrbitalInclination\":74.195038, \"Periapsis\":330.750244, \"OrbitalPeriod\":36441.519531, \"RotationPeriod\":203102.843750 }";
         public static string SAMPLE = "{ \"timestamp\":\"2017-08-28T01:06:03Z\", \"event\":\"Scan\", \"BodyName\":\"LFT 926 B\", \"DistanceFromArrivalLS\":353.886200, \"StarType\":\"L\", \"StellarMass\":0.121094, \"Radius\":202889536.000000, \"AbsoluteMagnitude\":12.913437, \"Age_MY\":9828, \"SurfaceTemperature\":1664.000000, \"Luminosity\":\"V\", \"SemiMajorAxis\":78877065216.000000, \"Eccentricity\":0.037499, \"OrbitalInclination\":33.005280, \"Periapsis\":338.539429, \"OrbitalPeriod\":30585052.000000, \"RotationPeriod\":91694.914063, \"AxialTilt\":0.000000, \"Rings\":[ { \"Name\":\"LFT 926 B A Belt\", \"RingClass\":\"eRingClass_MetalRich\", \"MassMT\":1.4034e+13, \"InnerRad\":3.24e+08, \"OuterRad\":1.1938e+09 } ] }";
 
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
@@ -28,7 +27,7 @@ namespace EddiEvents
             VARIABLES.Add("radius", "The radius of the star that has been scanned, in metres");
             VARIABLES.Add("solarradius", "The radius of the star that has been scanned, compared to Sol");
             VARIABLES.Add("radiusprobability", "The probablility of finding a star of this class with this radius");
-            VARIABLES.Add("absolutemagnitude", "The absolute magnitude of the star that has been scanned");
+            VARIABLES.Add("absolutemagnitude", "The absolute (bolometric) magnitude of the star that has been scanned");
             VARIABLES.Add("luminosity", "The luminosity of the star that has been scanned");
             VARIABLES.Add("luminosityclass", "The luminosity class of the star that has been scanned");            
             VARIABLES.Add("tempprobability", "The probablility of finding a star of this class with this temperature");
@@ -43,6 +42,9 @@ namespace EddiEvents
             VARIABLES.Add("orbitalinclination", "");
             VARIABLES.Add("periapsis", "");
             VARIABLES.Add("rings", "The star's rings");
+            VARIABLES.Add("estimatedvalue", "The estimated value of the current scan");
+            VARIABLES.Add("estimatedhabzoneinner", "The estimated inner radius of the habitable zone of the scanned star, in light seconds, not considering other stars in the system");
+            VARIABLES.Add("estimatedhabzoneouter", "The estimated outer radius of the habitable zone of the scanned star, in light seconds, not considering other stars in the system");
         }
 
         public string name { get; private set; }
@@ -91,7 +93,13 @@ namespace EddiEvents
 
         public List<Ring> rings { get; private set; }
 
-        public StarScannedEvent(DateTime timestamp, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings) : base(timestamp, NAME)
+        public decimal? estimatedhabzoneinner { get; private set; }
+
+        public decimal? estimatedhabzoneouter { get; private set; }
+
+        public long? estimatedvalue { get; private set; }
+
+        public StarScannedEvent(DateTime timestamp, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings, bool? dssequipped) : base(timestamp, NAME)
         {
             this.name = name;
             this.stellarclass = stellarclass;
@@ -119,7 +127,46 @@ namespace EddiEvents
                 tempprobability = StarClass.sanitiseCP(starClass.tempCP(this.temperature));
                 ageprobability = StarClass.sanitiseCP(starClass.ageCP(this.age));
                 chromaticity = starClass.chromaticity;
+                if (radius != 0 && temperature != 0)
+                {
+                    // Minimum estimated single-star habitable zone (target black body temperature of 315°K / 42°C / 107°F or less)
+                    estimatedhabzoneinner = StarClass.HabitableZone(315, Convert.ToDouble(radius), Convert.ToDouble(temperature));
+                    this.estimatedhabzoneinner = estimatedhabzoneinner;
+
+                    // Maximum estimated single-star habitable zone (target black body temperature of 223.15°K / -50°C / -58°F or more)
+                    estimatedhabzoneouter = StarClass.HabitableZone(223.15, Convert.ToDouble(radius), Convert.ToDouble(temperature));
+                    this.estimatedhabzoneouter = estimatedhabzoneouter;
+                }
             }
+            this.estimatedvalue = estimatevalue(dssequipped);
+        }
+
+        private long? estimatevalue(bool? dssequipped)
+        {
+            int bodydataconstant = 2880;
+            double value;
+
+            // Override constants for specific types of bodies
+            if ((stellarclass == "H") || (stellarclass == "N"))
+            {
+                // Black holes and Neutron stars
+                bodydataconstant = 54309;
+            }
+            else if (stellarclass.StartsWith("D") && (stellarclass.Length <= 3))
+            {
+                // White dwarves
+                bodydataconstant = 33737;
+            }
+
+            // Calculate exploration scan values
+            value = bodydataconstant + ((double)solarmass * bodydataconstant / 66.25);
+
+            if ((dssequipped == false) || (dssequipped == null) )
+            {
+                value = value / 2.4;
+            }
+            
+            return (long?)Math.Round(value, 0);
         }
     }
 }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -563,13 +563,13 @@ namespace EddiJournalMonitor
                                 decimal? periapsis = getOptionalDecimal(data, "Periapsis");
 
                                 // Check whether we have a detailed discovery scanner on board the current ship
-                                bool? dssequipped = false;
+                                bool dssEquipped = false;
                                 Ship ship = EDDI.Instance.CurrentShip;
                                 foreach (Compartment compartment in ship.compartments)
                                 {
                                     if ((compartment.module.name == "Detailed Surface Scanner") && (compartment.module.enabled))
                                     {
-                                        dssequipped = true;
+                                        dssEquipped = true;
                                     }
                                 }
 
@@ -602,7 +602,7 @@ namespace EddiJournalMonitor
                                     long ageMegaYears = (long)val;
                                     decimal temperature = getDecimal(data, "SurfaceTemperature");
 
-                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, ageMegaYears, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, dssequipped) { raw = line });
+                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, ageMegaYears, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, dssEquipped) { raw = line });
                                     handled = true;
                                 }
                                 else
@@ -662,7 +662,7 @@ namespace EddiJournalMonitor
                                     string atmosphere = getString(data, "Atmosphere");
                                     Volcanism volcanism = Volcanism.FromName(getString(data, "Volcanism"));
 
-                                    events.Add(new BodyScannedEvent(timestamp, name, bodyClass, earthMass, radius, gravity, temperature, pressure, tidallyLocked, landable, atmosphere, volcanism, distancefromarrival, (decimal)orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, reserves, materials, terraformState, axialTilt, dssequipped) { raw = line });
+                                    events.Add(new BodyScannedEvent(timestamp, name, bodyClass, earthMass, radius, gravity, temperature, pressure, tidallyLocked, landable, atmosphere, volcanism, distancefromarrival, (decimal)orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, reserves, materials, terraformState, axialTilt, dssEquipped) { raw = line });
                                     handled = true;
                                 }
                             }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -562,6 +562,18 @@ namespace EddiJournalMonitor
                                 decimal? orbitalinclination = getOptionalDecimal(data, "OrbitalInclination");
                                 decimal? periapsis = getOptionalDecimal(data, "Periapsis");
 
+                                // Check whether we have a detailed discovery scanner on board the current ship
+                                bool? dssequipped = false;
+                                Ship ship = EDDI.Instance.CurrentShip;
+                                foreach (Compartment compartment in ship.compartments)
+                                {
+                                    if ((compartment.module.name == "Detailed Surface Scanner") && (compartment.module.enabled))
+                                    {
+                                        dssequipped = true;
+                                    }
+                                }
+
+                                // Rings
                                 data.TryGetValue("Rings", out val);
                                 List<object> ringsData = (List<object>)val;
                                 List<Ring> rings = new List<Ring>();
@@ -590,7 +602,7 @@ namespace EddiJournalMonitor
                                     long ageMegaYears = (long)val;
                                     decimal temperature = getDecimal(data, "SurfaceTemperature");
 
-                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, ageMegaYears, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings) { raw = line });
+                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radius, absoluteMagnitude, luminosityClass, ageMegaYears, temperature, distancefromarrival, orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, dssequipped) { raw = line });
                                     handled = true;
                                 }
                                 else
@@ -650,7 +662,7 @@ namespace EddiJournalMonitor
                                     string atmosphere = getString(data, "Atmosphere");
                                     Volcanism volcanism = Volcanism.FromName(getString(data, "Volcanism"));
 
-                                    events.Add(new BodyScannedEvent(timestamp, name, bodyClass, earthMass, radius, gravity, temperature, pressure, tidallyLocked, landable, atmosphere, volcanism, distancefromarrival, (decimal)orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, reserves, materials, terraformState, axialTilt) { raw = line });
+                                    events.Add(new BodyScannedEvent(timestamp, name, bodyClass, earthMass, radius, gravity, temperature, pressure, tidallyLocked, landable, atmosphere, volcanism, distancefromarrival, (decimal)orbitalperiod, rotationperiod, semimajoraxis, eccentricity, orbitalinclination, periapsis, rings, reserves, materials, terraformState, axialTilt, dssequipped) { raw = line });
                                     handled = true;
                                 }
                             }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -422,6 +422,9 @@ namespace EddiShipMonitor
             // Cargo capacity
             ship.cargocapacity = (int)ship.compartments.Where(c => c.module != null && c.module.name.EndsWith("Cargo Rack")).Sum(c => Math.Pow(2, c.module.@class));
 
+            // Update the global variable
+            EDDI.Instance.CurrentShip = ship;
+
             AddShip(ship);
             writeShips();
         }
@@ -916,6 +919,7 @@ namespace EddiShipMonitor
         /// </summary>
         public Ship GetCurrentShip()
         {
+            EDDI.Instance.CurrentShip = GetShip(currentShipId);
             return GetShip(currentShipId);
         }
 
@@ -964,6 +968,7 @@ namespace EddiShipMonitor
                     // Location for the current ship is always null, as it's with us
                     ship.starsystem = null;
                     ship.station = null;
+                    EDDI.Instance.CurrentShip = ship;
                 }
             }
         }

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -42,7 +42,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'body')}\r\n{SetState('eddi_context_last_action', 'scan')}\r\n{SetState('eddi_context_body_system', system.name)}\r\n{SetState('eddi_context_body_name', event.name)}\r\n\r\n{Pause(1000)}\r\n\r\nScan {Occasionally(3,  \"of body\")} {OneOf(\"complete\", \"completed\", \"finished\")}.\r\n\r\n{F(\"Body report\")}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'body')}\r\n{SetState('eddi_context_last_action', 'scan')}\r\n{SetState('eddi_context_body_system', system.name)}\r\n{SetState('eddi_context_body_name', event.name)}\r\n\r\n{Pause(1000)}\r\n\r\nScan {Occasionally(3,  \"of body\")} {OneOf(\"complete\", \"completed\", \"finished\")}.\r\n\r\n{F(\"Body report\")}\r\n\r\n{if event.estimatedvalue:\r\n   Estimated scan value: {event.estimatedvalue} credits\r\n}",
       "default": true,
       "name": "Body scanned",
       "description": "Triggered when you complete a scan of a planetary body"
@@ -1464,7 +1464,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'star')}\r\n{SetState('eddi_context_last_action', 'scan')}\r\n{SetState('eddi_context_star_system', system.name)}\r\n{SetState('eddi_context_star_star', event.name)}\r\n\r\n{Pause(1000)}\r\n\r\nScan of {event.stellarclass}-class star {OneOf(\"complete\", \"completed\", \"finished\")}.\r\n\r\n{F(\"Star report\")}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'star')}\r\n{SetState('eddi_context_last_action', 'scan')}\r\n{SetState('eddi_context_star_system', system.name)}\r\n{SetState('eddi_context_star_star', event.name)}\r\n\r\n{Pause(1000)}\r\n\r\nScan of {event.stellarclass}-class star {OneOf(\"complete\", \"completed\", \"finished\")}.\r\n\r\n{F(\"Star report\")}\r\n\r\n{if event.estimatedvalue:\r\n   Estimated scan value: {Humanise(event.estimatedvalue)} credits.\r\n}\r\n\r\n{if (event.estimatedhabzoneinner && event.estimatedhabzoneouter) && \r\n (event.estimatedhabzoneinner > 0 && event.estimatedhabzoneouter> 0):\r\n   Habitable zone\r\n   {Occasionally(2, OneOf(\"calculated at\", \"calculated to fall from\"))}: \r\n   {Humanise(event.estimatedhabzoneinner)} \r\n   to {Humanise(event.estimatedhabzoneouter)} \r\n   lightseconds.\r\n|elif event.estimatedhabzoneouter && event.estimatedhabzoneouter > 0:\r\n   Habitable zone\r\n   {Occasionally(2, OneOf(\"calculated at\", \"calculated to fall from\"))}: \r\n   {Humanise(event.estimatedhabzoneouter)} \r\n   lightseconds maximum.\r\n}",
       "default": true,
       "name": "Star scanned",
       "description": "Triggered when you complete a scan of a stellar body"

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -24,5 +24,12 @@ namespace Utilities
         public const string VEHICLE_SHIP = "Ship";
         public const string VEHICLE_SRV = "SRV";
         public const string VEHICLE_FIGHTER = "Fighter";
+
+        // Physical Constants
+        public const int lightSpeedMetersPerSecond = 299792458;
+        public const int solarRadiusMeters = 695500000;
+        public const double solAbsoluteMagnitude = 4.83;
+        public const double solLuminosity = 3.846e26;
+        public const double stefanBoltzmann = 5.670367e-8;
     }
 }


### PR DESCRIPTION
Adds calculated variables to the 'Body scanned' and 'Star scanned' events containing the estimated value of the scan and, for stars, the estimated habitable zone for that star system.

I've been doing both of these calculations via Cottle scripts for a while now, but PR #207 prompted me to incorporate them as calculated variables that can be made more accessible to others.

Calculation results tested against EDDiscovery and look good. :-)