### PR TITLE
Possible fixes for crashing after updating to the latest version

### DIFF
--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -24,7 +24,7 @@ namespace Eddi
 
         /// <summary>the current export target for the shipyard</summary>
         [JsonProperty("exporttarget")]
-        public string exporttarget { get; set; }
+        public string exporttarget { get; set; } = "Coriolis";
 
         [JsonIgnore]
         private string dataPath;

--- a/StarMapService/StarMapConfiguration.cs
+++ b/StarMapService/StarMapConfiguration.cs
@@ -13,7 +13,7 @@ namespace EddiStarMapService
         [JsonProperty("commanderName")]
         public string commanderName { get; set; }
         [JsonProperty("lastSync")]
-        public DateTime lastSync { get; set; }
+        public DateTime lastSync { get; set; } = DateTime.MinValue;
 
         [JsonIgnore]
         private string dataPath;


### PR DESCRIPTION
I have noticed with issues #218, #222, & #223 that the files causing EDDI to crash after upgrades seem to be the same files where I added new keys in recent updates. So I'm adding some default values in the hope of preventing future similar crashes.