### PR TITLE
Jetcone damage event

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,5 +1,11 @@
 ﻿# CHANGE LOG
 
+### 2.4.5
+  * Speech Responder
+    * Added 'Jet cone damage' event
+    * Script changes
+      * Added new script 'Jet cone damage'
+
 ### 2.4.4
   * Speech Responder
     * Fixed a bug that was causing some SSML related functions (e.g. Pause()) to not render correctly.

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -66,6 +66,7 @@
     <Compile Include="DatalinkMessageEvent.cs" />
     <Compile Include="CommunityGoalEvent.cs" />
     <Compile Include="DataVoucherAwardedEvent.cs" />
+    <Compile Include="JetConeDamageEvent.cs" />
     <Compile Include="NavBeaconScanEvent.cs" />
     <Compile Include="CrewMemberRoleChangedEvent.cs" />
     <Compile Include="CrewMemberLaunchedEvent.cs" />
@@ -197,6 +198,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="ClassDiagram1.cd" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Events/JetConeDamageEvent.cs
+++ b/Events/JetConeDamageEvent.cs
@@ -1,0 +1,34 @@
+using EddiDataDefinitions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EddiEvents
+{
+    public class JetConeDamageEvent : Event
+    {
+        public const string NAME = "Jet cone damage";
+        public const string DESCRIPTION = "Triggered when passing through the jet cone from a white dwarf or neutron star has caused damage to a ship module";
+        public const string SAMPLE = "";
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static JetConeDamageEvent()
+        {
+            VARIABLES.Add("modulename", "the value of the boost");
+            VARIABLES.Add("module", "the module that was damaged (this is a module object)");
+        }
+
+        public string modulename { get; private set; }
+
+        public Module module { get; private set; }
+
+        public JetConeDamageEvent(DateTime timestamp, string modulename, Module module) : base(timestamp, NAME)
+        {
+            this.modulename = modulename;
+            this.module = module;
+        }
+    }
+}

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1811,7 +1811,41 @@ namespace EddiJournalMonitor
                                 events.Add(new FriendsEvent(timestamp, status, friend) { raw = line });
                                 handled = true;
                                 break;
-                            }                            
+                            }
+                        case "JetConeDamage":
+                            {
+                                string modulename = getString(data, "Module");
+                                Module module = ModuleDefinitions.fromEDName(modulename);
+                                if (module != null)
+                                {
+                                    if (module.mount != null)
+                                    {
+                                        // This is a weapon so provide a bit more information
+                                        string mount;
+                                        if (module.mount == Module.ModuleMount.Fixed)
+                                        {
+                                            mount = "fixed";
+                                        }
+                                        else if (module.mount == Module.ModuleMount.Gimballed)
+                                        {
+                                            mount = "gimballed";
+                                        }
+                                        else
+                                        {
+                                            mount = "turreted";
+                                        }
+                                        modulename = "" + module.@class.ToString() + module.grade + " " + mount + " " + module.name;
+                                    }
+                                    else
+                                    {
+                                        modulename = module.name;
+                                    }
+                                }
+
+                                events.Add(new JetConeDamageEvent(timestamp, modulename, module) { raw = line });
+                                handled = true;
+                                break;
+                            }
                         case "RedeemVoucher":
                             {
                                 object val;

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -704,6 +704,15 @@
       "name": "Insurance check",
       "description": "Check for enough credits to cover your insurance"
     },
+    "Jet cone damage": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Jet cone damage",
+      "description": "Triggered when passing through the jet cone from a white dwarf or neutron star has caused damage to a ship module"
+    },
     "Jumped": {
       "enabled": true,
       "priority": 3,


### PR DESCRIPTION
Delivering on #20.
Placing on hold, with no default script or sample (but otherwise complete), because this event appears to currently be bugged. No 'JetConeDamage' events were generated in the player journal during testing. 
Bug report opened with FDev. https://forums.frontier.co.uk/showthread.php/390196-Player-journal-JetConeDamage-not-recorded?p=6125922#post6125922