### PR TITLE
Galnet updating - refinements

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,7 @@
 ﻿# CHANGE LOG
 
 ### 2.4.6-b2
+  * Further changes to check for recent activity prior to updating the Galnet monitor
   * Speech Responder
     * Script changes
       * Updated 'Jumped' event to fix a typo that was preventing a call to the new 'Fuel check' script.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -106,7 +106,7 @@ namespace Eddi
         public StarSystem LastStarSystem { get; private set; }
 
         // Information obtained from the player journal
-        public DateTime? JournalTimeStamp { get; set; } = null;
+        public DateTime JournalTimeStamp { get; set; } = DateTime.MinValue;
 
         // Current vehicle of player
         public string Vehicle { get; private set; } = Constants.VEHICLE_SHIP;

--- a/GalnetMonitor/GalnetMonitor.cs
+++ b/GalnetMonitor/GalnetMonitor.cs
@@ -113,7 +113,7 @@ namespace GalnetMonitor
             while (running)
             {
                 // We'll update the Galnet Monitor only if a journal event has taken place within the specified number of minutes
-                if ((DateTime.UtcNow - EDDI.Instance.JournalTimeStamp).Value.Minutes < 10)
+                if ((DateTime.UtcNow - EDDI.Instance.JournalTimeStamp).TotalMinutes < 10)
                 {
                     List<News> newsItems = new List<News>();
                     string firstUid = null;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -58,7 +58,6 @@ namespace EddiJournalMonitor
                     {
                         Logging.Warn("Event without timestamp; using current time");
                     }
-                    EDDI.Instance.JournalTimeStamp = timestamp;
 
                     // Every event has an event field
                     if (!data.ContainsKey("event"))
@@ -70,6 +69,15 @@ namespace EddiJournalMonitor
                     bool handled = false;
 
                     string edType = getString(data, "event");
+                    if (edType == "Fileheader")
+                    {
+                        EDDI.Instance.JournalTimeStamp = DateTime.MinValue;
+                    }
+                    else
+                    {
+                        EDDI.Instance.JournalTimeStamp = timestamp;
+                    }
+
                     switch (edType)
                     {
                         case "Docked":


### PR DESCRIPTION
Fix for #265 to ensure that 'Fileheader' events do not trigger the Galnet Monitor.
Revised EDDI.Instance.JournalTimeStamp to no longer be a nullable value.