### PR TITLE
Modify Humanise()

### DIFF
--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -679,7 +679,7 @@ Console.WriteLine("Results[" + i + "][" + j + "] is *" + match.Groups[i].Capture
                     case 2:
                         return "well over " + number + " " + order;
                     case 3:
-                        return "about " + number + " and a half " + order;
+                        return "almost " + number + " and a half " + order;
                     case 4:
                         return "nearly " + number + " and a half " + order;
                     case 5:
@@ -689,7 +689,7 @@ Console.WriteLine("Results[" + i + "][" + j + "] is *" + match.Groups[i].Capture
                     case 7:
                         return "well over " + number + " and a half " + order;
                     case 8:
-                        return "about " + (number + 1) + " " + order;
+                        return "almost " + (number + 1) + " " + order;
                     case 9:
                         return "nearly " + (number + 1) + " " + order;
                     default:

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -679,7 +679,7 @@ Console.WriteLine("Results[" + i + "][" + j + "] is *" + match.Groups[i].Capture
                     case 2:
                         return "well over " + number + " " + order;
                     case 3:
-                        return "on the way to " + number + " and a half " + order;
+                        return "about " + number + " and a half " + order;
                     case 4:
                         return "nearly " + number + " and a half " + order;
                     case 5:
@@ -689,7 +689,7 @@ Console.WriteLine("Results[" + i + "][" + j + "] is *" + match.Groups[i].Capture
                     case 7:
                         return "well over " + number + " and a half " + order;
                     case 8:
-                        return "on the way to " + (number + 1) + " " + order;
+                        return "about " + (number + 1) + " " + order;
                     case 9:
                         return "nearly " + (number + 1) + " " + order;
                     default:


### PR DESCRIPTION
A change to the Humanise() function to allow a better fit grammatically into most sentences. 
Simply changes the '_on the way to_' cases wording to _'about'_.

As discussed in PR #259: 
```
Humanise() nonsense example in S&R script:
"Two damage escape pods salvaged for on the way to five and a half thousand credits"

*After looking at the "Humanize" function, it may be worthwhile to get rid of the "on the way to" cases. That would make Humanise()'ed values better able to fit grammatically into any sentence.
*or change "on the way to" to "almost", that might work.
```