### PR TITLE
Honour changes to home system and station immediately

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,8 @@
 ﻿# CHANGE LOG
 
 ### 2.4.6-b2
+  * Core
+    * Changes to your home system / station will now be honoured immediately rather than after the next app restart.
   * Speech Responder
     * Script changes
       * Updated 'Jumped' event to fix a typo that was preventing a call to the new 'Fuel check' script.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -149,29 +149,7 @@ namespace Eddi
 
                 // Set up the EDDI configuration
                 EDDIConfiguration configuration = EDDIConfiguration.FromFile();
-                Logging.Verbose = configuration.Debug;
-                if (configuration.HomeSystem != null && configuration.HomeSystem.Trim().Length > 0)
-                {
-                    HomeStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(configuration.HomeSystem.Trim());
-                    if (HomeStarSystem != null)
-                    {
-                        Logging.Debug("Home star system is " + HomeStarSystem.name);
-                        if (configuration.HomeStation != null && configuration.HomeStation.Trim().Length > 0)
-                        {
-                            string homeStationName = configuration.HomeStation.Trim();
-                            foreach (Station station in HomeStarSystem.stations)
-                            {
-                                if (station.name == homeStationName)
-                                {
-                                    HomeStation = station;
-                                    Logging.Debug("Home station is " + HomeStation.name);
-                                    break;
-
-                                }
-                            }
-                        }
-                    }
-                }
+                updateHomeSystemStation(configuration);
 
                 // Set up monitors and responders
                 monitors = findMonitors();
@@ -1818,5 +1796,30 @@ namespace Eddi
             RESTART_NO_REBOOT = 64
         }
 
+        public void updateHomeSystemStation(EDDIConfiguration configuration)
+        {
+            Logging.Verbose = configuration.Debug;
+            if (configuration.HomeSystem != null && configuration.HomeSystem.Trim().Length > 0)
+            {
+                HomeStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(configuration.HomeSystem.Trim());
+                if (HomeStarSystem != null)
+                {
+                    Logging.Debug("Home star system is " + HomeStarSystem.name);
+                    if (configuration.HomeStation != null && configuration.HomeStation.Trim().Length > 0)
+                    {
+                        string homeStationName = configuration.HomeStation.Trim();
+                        foreach (Station station in HomeStarSystem.stations)
+                        {
+                            if (station.name == homeStationName)
+                            {
+                                HomeStation = station;
+                                Logging.Debug("Home station is " + HomeStation.name);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -210,6 +210,7 @@ namespace Eddi
             EDDIConfiguration eddiConfiguration = EDDIConfiguration.FromFile();
             eddiConfiguration.HomeSystem = string.IsNullOrWhiteSpace(eddiHomeSystemText.Text) ? null : eddiHomeSystemText.Text.Trim();
             eddiConfiguration.ToFile();
+            EDDI.Instance.updateHomeSystemStation(eddiConfiguration);
         }
 
         private void homeStationChanged(object sender, TextChangedEventArgs e)
@@ -217,6 +218,7 @@ namespace Eddi
             EDDIConfiguration eddiConfiguration = EDDIConfiguration.FromFile();
             eddiConfiguration.HomeStation = string.IsNullOrWhiteSpace(eddiHomeStationText.Text) ? null : eddiHomeStationText.Text.Trim();
             eddiConfiguration.ToFile();
+            EDDI.Instance.updateHomeSystemStation(eddiConfiguration);
         }
 
         private void insuranceChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
Update as requested per #122 to honour changes to home systems and stations immediately upon changing the EDDI configuration, rather than after an app restart. 