### PR TITLE
Modify Mission Completed Event

### DIFF
--- a/Events/MissionCompletedEvent.cs
+++ b/Events/MissionCompletedEvent.cs
@@ -47,7 +47,7 @@ namespace EddiEvents
 
         public string rewardCommodity { get; private set; }
 
-        public int? rewardAmount { get; private set; }
+        public int rewardAmount { get; private set; }
 
         public MissionCompletedEvent(DateTime timestamp, long? missionid, string name, string faction, Commodity commodity, int? amount, bool communal, long reward, List<CommodityAmount> commodityrewards, long donation) : base(timestamp, NAME)
         {

--- a/Events/MissionCompletedEvent.cs
+++ b/Events/MissionCompletedEvent.cs
@@ -23,7 +23,7 @@ namespace EddiEvents
             VARIABLES.Add("reward", "The monetary reward for completing the mission");
             VARIABLES.Add("commodityrewards", "The commodity rewards for completing the mission");
             VARIABLES.Add("donation", "The monetary donation when completing the mission");
-            VARIABLES.Add("rewardCommodity", "The commodity reward (if applicable)");
+            VARIABLES.Add("rewardCommodity", "The commodity reward name (if applicable)");
             VARIABLES.Add("rewardAmount", "The amount of the commodity reward (if applicable)");
         }
 

--- a/Events/MissionCompletedEvent.cs
+++ b/Events/MissionCompletedEvent.cs
@@ -23,6 +23,8 @@ namespace EddiEvents
             VARIABLES.Add("reward", "The monetary reward for completing the mission");
             VARIABLES.Add("commodityrewards", "The commodity rewards for completing the mission");
             VARIABLES.Add("donation", "The monetary donation when completing the mission");
+            VARIABLES.Add("rewardCommodity", "The commodity reward (if applicable)");
+            VARIABLES.Add("rewardAmount", "The amount of the commodity reward (if applicable)");
         }
 
         public long? missionid { get; private set; }
@@ -43,6 +45,10 @@ namespace EddiEvents
 
         public long donation { get; private set; }
 
+        public string rewardCommodity { get; private set; }
+
+        public int? rewardAmount { get; private set; }
+
         public MissionCompletedEvent(DateTime timestamp, long? missionid, string name, string faction, Commodity commodity, int? amount, bool communal, long reward, List<CommodityAmount> commodityrewards, long donation) : base(timestamp, NAME)
         {
             this.missionid = missionid;
@@ -54,6 +60,11 @@ namespace EddiEvents
             this.reward = reward;
             this.commodityrewards = commodityrewards;
             this.donation = donation;
+            if (commodityrewards.Count > 0)
+            {
+                this.rewardCommodity = commodityrewards[0].commodity;
+                this.rewardAmount = commodityrewards[0].amount;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds two variables for VoiceAttack to describe the mission commodity reward (if rewarded).
_{TXT:EDDI mission completed rewardCommodity}_ and _{INT:EDDI mission completed rewardAmount}_

The commodity reward is  passed to the Speech Responder in a list of objects, so is unavailable to VA. I don't know why, I searched through 5 months of journal logs and couldn't find an instance of being rewarded more than one type of commodity for a mission. 
Perhaps the game did in the past, or the material reward was once combined with the commodity (It appears now to be sent as a separate MaterialCollected event when you turn in the mission) 

At any rate, these changes will assign the values of the first commodity in that list to the VA variables. 
I think this is the last piece of the puzzle to having VA keep track of cargo in the hold. 
