### PR TITLE
Correct 'Crew member role changed' script

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,6 +3,8 @@
 ### 2.4.6-b2
   * Speech Responder
     * Script changes
+      * Remove deprecated 'Jumping' script (replaced by 'FSD engaged' in prior updates)
+      * Renamed 'Crew member role change' event to 'Crew member role change***d***' to correct a bug that caused the event to be un-editable. Since the VoiceAttack documentation already indicated to use 'Crew member role changed', there should be no affect on VoiceAttack configurations. 
       * Updated 'Jumped' event to fix a typo that was preventing a call to the new 'Fuel check' script.
 
 ### 2.4.6-b1

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -222,6 +222,24 @@ namespace EddiSpeechResponder
             }
             if (!personality.IsDefault)
             {
+                // Remove deprecated scripts from the list
+                List<string> scriptHolder = new List<string>();
+                foreach (KeyValuePair<string, Script> kv in fixedScripts)
+                {
+                    if (kv.Key == "Jumping") // Replaced by "FSD engaged" script
+                    {
+                        scriptHolder.Add(kv.Key);
+                    }
+                    else if (kv.Value.Name == "Crew member role change") // This name is mismatched to the key (should be "changed"), 
+                        // so EDDI couldn't match the script name to the .json key correctly. The default script has been corrected.
+                    {
+                        scriptHolder.Add(kv.Key);
+                    }
+                }
+                foreach (string script in scriptHolder)
+                {
+                    fixedScripts.Remove(script);
+                }
                 // Also add any secondary scripts in the default personality that aren't present in the list
                 foreach (KeyValuePair<string, Script> kv in defaultPersonality.Scripts)
                 {

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -341,7 +341,7 @@
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'crew')}\r\n{SetState('eddi_context_last_action', 'role')}\r\n{SetState('eddi_context_crew_name', event.crew)}\r\n{SetState('eddi_context_crew_role', event.role)}\r\n\r\n{if event.role = 'Idle':\r\n    {event.crew} is no longer manning a position\r\n|elif event.role = 'Fighter':\r\n    {event.crew} is now manning the fighter\r\n|elif event.role = 'Gunner':\r\n    {event.crew} is now manning the guns\r\n}.\r\n",
       "default": true,
-      "name": "Crew member role change",
+      "name": "Crew member role changed",
       "description": "Triggered when a crew member changes their role"
     },
     "Crew role changed": {
@@ -739,15 +739,6 @@
       "default": true,
       "name": "Jumped",
       "description": "Triggered when you complete a jump to another system"
-    },
-    "Jumping": {
-      "enabled": true,
-      "priority": 3,
-      "responder": true,
-      "script": null,
-      "default": true,
-      "name": "Jumping",
-      "description": "NO LONGER IN USE"
     },
     "Killed": {
       "enabled": true,


### PR DESCRIPTION
Fix for #277. The script name of 'Crew member role change' was mismatched with the key: 'Crew member role changed', causing EDDI to fail to lookup the script correctly.

Since the old script had to be removed so that a new script with the same key but a different script name could be written, I also deprecated and removed the 'Jumping' event that JGM retired some time ago.