### PR TITLE
Vehicle destroyed event

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,9 +5,9 @@
     * Changes to your home system / station will now be honoured immediately rather than after the next app restart.
     * You can now specify your commander's gender in the "Commander Details" tab. Currently this is only relevant for titles of nobility in the Empire. You can specify "Neither" if you prefer to be addressed as "Commander" in situations where convention would otherwise require a gendered form of address.
     * Hardened EDDI against a crash that could occur if the folder containing player journals doesn't exist.
-    * Smarter vehicle state tracking *(it still does not perfectly track vehicle destruction since there are no official player journal events for SRV or fighter destruction)*.
+    * Smarter vehicle state tracking.
   * Speech Responder
-    * Add new event 'Vehicle destroyed'
+    * Add new event 'Vehicle destroyed' *(it does not perfectly track vehicle destruction since there are no official player journal events for SRV or fighter destruction - we have to infer vehicle destruction)*.
     * Amended the descriptions for the 'Module arrived' and 'Ship arrived' station and system variables.
     * Fixed a bug that was causing the 'Ship arrived' event to report bad arrival locations.
 	* 'Search and rescue' event:

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,13 +5,16 @@
     * Changes to your home system / station will now be honoured immediately rather than after the next app restart.
     * You can now specify your commander's gender in the "Commander Details" tab. Currently this is only relevant for titles of nobility in the Empire. You can specify "Neither" if you prefer to be addressed as "Commander" in situations where convention would otherwise require a gendered form of address.
     * Hardened EDDI against a crash that could occur if the folder containing player journals doesn't exist.
+    * Smarter vehicle state tracking *(it still does not perfectly track vehicle destruction since there are no official player journal events for SRV or fighter destruction)*.
   * Speech Responder
+    * Add new event 'Vehicle destroyed'
     * Amended the descriptions for the 'Module arrived' and 'Ship arrived' station and system variables.
     * Fixed a bug that was causing the 'Ship arrived' event to report bad arrival locations.
 	* 'Search and rescue' event:
 	  * Added variable `commodityname` to provide the name of the commodity turned in, free of the commodity object. Accessible to VoiceAttack as `{TXT:EDDI search and rescue commodityname}` 
       * Updated 'Search and rescue' event to better distinguish between occupied and damaged escape pods, and to fix a bug in handling wreckage commodities.
     * Script changes
+      * Add new script 'Vehicle destroyed'
       * Updated 'Data voucher redeemed' script for events where the faction is not defined (such as INRA sites).
       * Removed deprecated 'Jumping' script (replaced by 'FSD engaged' in prior updates)
       * Renamed 'Crew member role change' event to 'Crew member role changed' to correct a bug that caused the event to be un-editable. Since the VoiceAttack documentation already indicated to use 'Crew member role changed', there should be no affect on VoiceAttack configurations. 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -716,6 +716,10 @@ namespace Eddi
                     {
                         passEvent = eventBodyScanned((BodyScannedEvent)journalEvent);
                     }
+                    else if (journalEvent is VehicleDestroyedEvent)
+                    {
+                        passEvent = eventVehicleDestroyed((VehicleDestroyedEvent)journalEvent);
+                    }
                     // Additional processing is over, send to the event responders if required
                     if (passEvent)
                     {
@@ -887,6 +891,9 @@ namespace Eddi
                 Logging.Debug("Already at station " + theEvent.station);
                 return false;
             }
+            
+            // We are in the ship
+            Vehicle = Constants.VEHICLE_SHIP;
 
             // Update the station
             Logging.Debug("Now at station " + theEvent.station);
@@ -1004,6 +1011,9 @@ namespace Eddi
                 Environment = Constants.ENVIRONMENT_WITCH_SPACE;
             }
 
+            // We are in the ship
+            Vehicle = Constants.VEHICLE_SHIP;
+
             return true;
         }
 
@@ -1116,6 +1126,10 @@ namespace Eddi
         {
             Environment = Constants.ENVIRONMENT_SUPERCRUISE;
             updateCurrentSystem(theEvent.system);
+
+            // We are in the ship
+            Vehicle = Constants.VEHICLE_SHIP;
+
             return true;
         }
 
@@ -1266,6 +1280,13 @@ namespace Eddi
         }
 
         private bool eventFighterDocked(FighterDockedEvent theEvent)
+        {
+            // We are back in the ship
+            Vehicle = Constants.VEHICLE_SHIP;
+            return true;
+        }
+
+        private bool eventVehicleDestroyed(VehicleDestroyedEvent theEvent)
         {
             // We are back in the ship
             Vehicle = Constants.VEHICLE_SHIP;

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BeltScannedEvent.cs" />
+    <Compile Include="VehicleDestroyedEvent.cs" />
     <Compile Include="DatalinkMessageEvent.cs" />
     <Compile Include="CommunityGoalEvent.cs" />
     <Compile Include="DataVoucherAwardedEvent.cs" />

--- a/Events/VehicleDestroyedEvent.cs
+++ b/Events/VehicleDestroyedEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class VehicleDestroyedEvent : Event
+    {
+        public const string NAME = "Vehicle destroyed";
+        public const string DESCRIPTION = "Triggered when your vehicle (fighter or SRV) is destroyed";
+        public const string SAMPLE = "{\"timestamp\":\"2016-07-22T10:53:19Z\",\"event\":\"VehicleSwitch\"}";
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static VehicleDestroyedEvent()
+        {
+        }
+
+        public VehicleDestroyedEvent(DateTime timestamp) : base(timestamp, NAME)
+        {
+        }
+    }
+}

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1125,6 +1125,15 @@ namespace EddiJournalMonitor
                                     events.Add(new ControllingShipEvent(timestamp) { raw = line });
                                     handled = true;
                                 }
+                                else if (to == null)
+                                {
+                                    // The variable 'to' may be blank if this event is written after a fighter or SRV is destroyed. In either case, we are back in our ship.
+                                    if (EDDI.Instance.Vehicle == Constants.VEHICLE_FIGHTER || EDDI.Instance.Vehicle == Constants.VEHICLE_SRV)
+                                    {
+                                        events.Add(new VehicleDestroyedEvent(timestamp) { raw = line });
+                                        handled = true;
+                                    }
+                                }
                             }
                             break;
                         case "Interdicted":

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1639,6 +1639,15 @@
       "default": true,
       "name": "Undocked",
       "description": "Triggered when your ship undocks from a station or outpost"
+    },
+    "Vehicle destroyed": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{Pause(2000)}\r\n{OneOf(\"Neural link\", \"Link\", \"Uplink\")} {OneOf(\"terminated\", \"disengaged\")}.",
+      "default": true,
+      "name": "Vehicle destroyed",
+      "description": "Triggered when your vehicle is destroyed"
     }
   }
 }


### PR DESCRIPTION
Update per #285, improving vehicle tracking and adding a 'Vehicle destroyed' event. In testing, this event appears to always trigger for fighter destruction. It also occasionally triggers for SRV destruction. 