### PR TITLE
Feminine/neither grammar fixes

### DIFF
--- a/DataDefinitions/EmpireRating.cs
+++ b/DataDefinitions/EmpireRating.cs
@@ -19,10 +19,10 @@ namespace EddiDataDefinitions
 
         public int rank { get; private set; }
 
-        public EmpireRating(string edname, int rank, string name) : this(edname, rank, name, name)
+        private EmpireRating(string edname, int rank, string name) : this(edname, rank, name, name)
         {}
 
-        public EmpireRating(string edname, int rank, string name, string feminineName)
+        private EmpireRating(string edname, int rank, string name, string feminineName)
         {
             this.edname = edname;
             this.rank = rank;

--- a/DataDefinitions/EmpireRating.cs
+++ b/DataDefinitions/EmpireRating.cs
@@ -15,13 +15,19 @@ namespace EddiDataDefinitions
 
         public string name { get; private set; }
 
+        public string feminineName { get; private set; }
+
         public int rank { get; private set; }
 
-        private EmpireRating(string edname, int rank, string name)
+        public EmpireRating(string edname, int rank, string name) : this(edname, rank, name, name)
+        {}
+
+        public EmpireRating(string edname, int rank, string name, string feminineName)
         {
             this.edname = edname;
             this.rank = rank;
             this.name = name;
+            this.feminineName = feminineName;
 
             RATINGS.Add(this);
         }
@@ -29,18 +35,18 @@ namespace EddiDataDefinitions
         public static readonly EmpireRating None = new EmpireRating("None", 0, "None");
         public static readonly EmpireRating Outsider = new EmpireRating("Outsider", 1, "Outsider");
         public static readonly EmpireRating Serf = new EmpireRating("Serf", 2, "Serf");
-        public static readonly EmpireRating Master = new EmpireRating("Master", 3, "Master");
+        public static readonly EmpireRating Master = new EmpireRating("Master", 3, "Master", "Mistress");
         public static readonly EmpireRating Squire = new EmpireRating("Squire", 4, "Squire");
-        public static readonly EmpireRating Knight = new EmpireRating("Knight", 5, "Knight");
-        public static readonly EmpireRating Lord = new EmpireRating("Lord", 6, "Lord");
-        public static readonly EmpireRating Baron = new EmpireRating("Baron", 7, "Baron");
-        public static readonly EmpireRating Viscount = new EmpireRating("Viscount", 8, "Viscount");
-        public static readonly EmpireRating Count = new EmpireRating("Count", 9, "Count");
-        public static readonly EmpireRating Earl = new EmpireRating("Earl", 10, "Earl");
-        public static readonly EmpireRating Marquis = new EmpireRating("Marquis", 11, "Marquis");
-        public static readonly EmpireRating Duke = new EmpireRating("Duke", 12, "Duke");
-        public static readonly EmpireRating Prince = new EmpireRating("Prince", 13, "Prince");
-        public static readonly EmpireRating King = new EmpireRating("King", 14, "King");
+        public static readonly EmpireRating Knight = new EmpireRating("Knight", 5, "Knight", "Dame");
+        public static readonly EmpireRating Lord = new EmpireRating("Lord", 6, "Lord", "Lady");
+        public static readonly EmpireRating Baron = new EmpireRating("Baron", 7, "Baron", "Baroness");
+        public static readonly EmpireRating Viscount = new EmpireRating("Viscount", 8, "Viscount", "Viscountess");
+        public static readonly EmpireRating Count = new EmpireRating("Count", 9, "Count", "Countess");
+        public static readonly EmpireRating Earl = new EmpireRating("Earl", 10, "Earl"); // normally Countess, but we need to distinguish from rank 9
+        public static readonly EmpireRating Marquis = new EmpireRating("Marquis", 11, "Marquis", "Marquise"); // or Marchioness <https://en.wikipedia.org/wiki/Marquess>
+        public static readonly EmpireRating Duke = new EmpireRating("Duke", 12, "Duke", "Duchess");
+        public static readonly EmpireRating Prince = new EmpireRating("Prince", 13, "Prince", "Princess");
+        public static readonly EmpireRating King = new EmpireRating("King", 14, "King", "Queen");
 
         public static EmpireRating FromName(string from)
         {

--- a/DataDefinitions/EmpireRating.cs
+++ b/DataDefinitions/EmpireRating.cs
@@ -15,19 +15,19 @@ namespace EddiDataDefinitions
 
         public string name { get; private set; }
 
-        public string feminineName { get; private set; }
+        public string femininename { get; private set; }
 
         public int rank { get; private set; }
 
         private EmpireRating(string edname, int rank, string name) : this(edname, rank, name, name)
         {}
 
-        private EmpireRating(string edname, int rank, string name, string feminineName)
+        private EmpireRating(string edname, int rank, string name, string femininename)
         {
             this.edname = edname;
             this.rank = rank;
             this.name = name;
-            this.feminineName = feminineName;
+            this.femininename = femininename;
 
             RATINGS.Add(this);
         }

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -24,6 +24,7 @@
       * Updated 'Jumped' event to fix a typo that was preventing a call to the new 'Fuel check' script.
       * Refined script 'Module arrived'
       * Refined script 'Ship arrived'
+	  * Moved empire honorific logic into script 'Empire honorific'.
   * Galnet monitor
     * Only update the Galnet monitor if the game has posted a Galnet event in the last ten minutes. This prevents Galnet spam upon starting EDDI.
 

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -9,11 +9,12 @@
   * Speech Responder
     * Add new event 'Vehicle destroyed' *(it does not perfectly track vehicle destruction since there are no official player journal events for SRV or fighter destruction - we have to infer vehicle destruction)*.
     * Amended the descriptions for the 'Module arrived' and 'Ship arrived' station and system variables.
+    * Fixed a bug that was causing parsing all promotion events to fail.
     * Fixed a bug that was causing the 'Ship arrived' event to report bad arrival locations.
     * 'Mission completed' event:
       * Addded variables `rewardCommodity` and `rewardAmount`. Useful for cargo tracking.
-	* 'Search and rescue' event:
-	  * Added variable `commodityname` to provide the name of the commodity turned in, free of the commodity object. Accessible to VoiceAttack as `{TXT:EDDI search and rescue commodityname}` 
+    * 'Search and rescue' event:
+      * Added variable `commodityname` to provide the name of the commodity turned in, free of the commodity object. Accessible to VoiceAttack as `{TXT:EDDI search and rescue commodityname}` 
       * Updated 'Search and rescue' event to better distinguish between occupied and damaged escape pods, and to fix a bug in handling wreckage commodities.
     * Script changes
       * Add new script 'Vehicle destroyed'
@@ -24,7 +25,7 @@
       * Updated 'Jumped' event to fix a typo that was preventing a call to the new 'Fuel check' script.
       * Refined script 'Module arrived'
       * Refined script 'Ship arrived'
-	  * Moved empire honorific logic into script 'Empire honorific'.
+      * Moved empire honorific logic into new script 'Empire honorific'.
   * Galnet monitor
     * Only update the Galnet monitor if the game has posted a Galnet event in the last ten minutes. This prevents Galnet spam upon starting EDDI.
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -66,9 +66,13 @@ namespace Eddi
             {
                 eddiGenderFemale.IsChecked = true;
             }
-            else
+            else if (eddiConfiguration.Gender == "Male")
             {
                 eddiGenderMale.IsChecked = true;
+            }
+            else
+            {
+                eddiGenderNeither.IsChecked = true;
             }
 
             Logging.Verbose = eddiConfiguration.Debug;

--- a/Events/EmpirePromotionEvent.cs
+++ b/Events/EmpirePromotionEvent.cs
@@ -15,14 +15,17 @@ namespace EddiEvents
         static EmpirePromotionEvent()
         {
             VARIABLES.Add("rank", "The commander's new Empire rank");
+            VARIABLES.Add("feminineRank", "The feminine form of the commander's new Empire rank");
         }
 
         [JsonProperty("rating")]
         public string rank { get; private set; }
+        public string feminineRank { get; private set; }
 
         public EmpirePromotionEvent(DateTime timestamp, EmpireRating rating) : base(timestamp, NAME)
         {
             this.rank = rating.name;
+            this.feminineRank = rating.feminineName;
         }
     }
 }

--- a/Events/EmpirePromotionEvent.cs
+++ b/Events/EmpirePromotionEvent.cs
@@ -15,17 +15,17 @@ namespace EddiEvents
         static EmpirePromotionEvent()
         {
             VARIABLES.Add("rank", "The commander's new Empire rank");
-            VARIABLES.Add("feminineRank", "The feminine form of the commander's new Empire rank");
+            VARIABLES.Add("femininerank", "The feminine form of the commander's new Empire rank");
         }
 
         [JsonProperty("rating")]
         public string rank { get; private set; }
-        public string feminineRank { get; private set; }
+        public string femininerank { get; private set; }
 
         public EmpirePromotionEvent(DateTime timestamp, EmpireRating rating) : base(timestamp, NAME)
         {
             this.rank = rating.name;
-            this.feminineRank = rating.feminineName;
+            this.femininerank = rating.femininename;
         }
     }
 }

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -121,7 +121,7 @@ A rating, for example a combat rating or empire rating.
 
     - `rank` the numeric rank of the rating, for example 0
     - `name` the name of the rating, for example 'Harmless'
-    - `feminineName` the feminine name of the rating, for example 'Baroness' if it differs, otherwise the same as `name`
+    - `femininename` the feminine name of the rating, for example 'Baroness' if it differs, otherwise the same as `name`
 
 ## Module
 

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -119,8 +119,9 @@ The event that triggered the speech responder.  Information held in here is even
 
 A rating, for example a combat rating or empire rating.
 
-    - `name` the name of the rating, for example 'Harmless'
     - `rank` the numeric rank of the rating, for example 0
+    - `name` the name of the rating, for example 'Harmless'
+    - `feminineName` the feminine name of the rating, for example 'Baroness' if it differs, otherwise the same as `name`
 
 ## Module
 

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -28,7 +28,7 @@ Any values might be missing, depending on EDDI's configuration.
     - `federationrating` the current Federation rating of the commander (this is a Rating object)
     - `credits` the number of credits the commander owns
     - `debt` the amount of debt the commander owes
-    - `gender` the gender of the commander, as selected in EDDI's configuration (string, either 'Male' or 'Female')
+    - `gender` the gender of the commander, as selected in EDDI's configuration (string, either 'Male', 'Female' or 'Neither')
 
 ## Ship
 

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -474,7 +474,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{F(\"Empire honorific\")},\r\nthe Imperial Navy has \r\n{OneOf(\"granted you a promotion\", \"promoted you\", \"advanced you\", \"named you\")}\r\nto the rank of\r\n{when(cmdr.gender = \"Female\", event.feminineRank, event.rank)}\r\n{Occasionally(2, \"for your service to the Empire\")}.",
+      "script": "{F(\"Empire honorific\")},\r\nthe Imperial Navy has \r\n{OneOf(\"granted you a promotion\", \"promoted you\", \"advanced you\", \"named you\")}\r\nto the rank of\r\n{when(cmdr.gender = \"Female\", event.femininerank, event.rank)}\r\n{Occasionally(2, \"for your service to the Empire\")}.",
       "default": true,
       "name": "Empire promotion",
       "description": "Triggered when your rank increases with the Empire"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -474,7 +474,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.rank = \"Knight\":\r\n    sir\r\n|elif event.rank = \"Lord\":\r\n    my lord\r\n|elif event.rank = \"Baron\":\r\n    my lord\r\n|elif event.rank = \"Viscount\":\r\n    my lord\r\n|elif event.rank = \"Count\":\r\n    my lord\r\n|elif event.rank = \"Earl\":\r\n    my lord\r\n|elif event.rank = \"Marquis\":\r\n    my lord\r\n|elif event.rank = \"Duke\":\r\n    your grace\r\n|elif event.rank = \"Prince\":\r\n    your royal highness\r\n|elif event.rank = \"King\":\r\n    your majesty\r\n|else:\r\n    commander\r\n},\r\nthe Empirial Navy has \r\n{OneOf(\"granted you a promotion\", \"promoted you\", \"advanced you\", \"named you\")}\r\nto the rank of\r\n{event.rank}\r\n{Occasionally(2, \"for your service to the Empire\")}.",
+      "script": "{F(\"Empire honorific\")},\r\nthe Imperial Navy has \r\n{OneOf(\"granted you a promotion\", \"promoted you\", \"advanced you\", \"named you\")}\r\nto the rank of\r\n{when(cmdr.gender = \"Female\", event.feminineRank, event.rank)}\r\n{Occasionally(2, \"for your service to the Empire\")}.",
       "default": true,
       "name": "Empire promotion",
       "description": "Triggered when your rank increases with the Empire"
@@ -708,7 +708,7 @@
       "enabled": true,
       "priority": 3,
       "responder": false,
-      "script": "{if system.allegiance = \"Empire\":\r\n    {_ Forms of address taken from <https://en.wikipedia.org/wiki/Forms_of_address_in_the_United_Kingdom>}\r\n    {if cmdr.empirerating.rank <= 4: {_ Commoner }\r\n       commander\r\n    |elif cmdr.empirerating.rank = 5: {_ Knight / Dame }\r\n        {if cmdr.gender = \"Male\": \r\n            sir \r\n        |elif cmdr.gender = \"Female\": \r\n            madam\r\n        |else: \r\n            commander\r\n        }\r\n    |elif cmdr.empirerating.rank <= 11: {_ Peer / Peeress }\r\n        {if cmdr.gender = \"Male\": \r\n            {OneOf(\"my lord\", \"your lordship\")}\r\n        |elif cmdr.gender = \"Female\": \r\n            {OneOf(\"my lady\", \"your ladyship\")}\r\n        |else: \r\n            commander\r\n        }\r\n    |elif cmdr.empirerating.rank = 12:\r\n        your grace\r\n    |elif cmdr.empirerating.rank = 13:\r\n        your royal highness\r\n    |elif cmdr.empirerating.rank = 14:\r\n        your majesty\r\n    }\r\n|elif system.allegiance = \"Federation\":\r\n    {if cmdr.federationrating.rank = 0:\r\n        commander\r\n    |else:\r\n        {cmdr.federationrating.name}\r\n    }\r\n|else:\r\n    commander\r\n}\r\n",
+      "script": "{if system.allegiance = \"Empire\":\r\n    {F(\"Empire honorific\")}\r\n|elif system.allegiance = \"Federation\":\r\n    {if cmdr.federationrating.rank = 0:\r\n        commander\r\n    |else:\r\n        {cmdr.federationrating.name}\r\n    }\r\n|else:\r\n    commander\r\n}\r\n",
       "default": true,
       "name": "Honorific",
       "description": "Function to provide a suitable honorific for your commander"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -461,6 +461,15 @@
       "name": "Docking timed out",
       "description": "Triggered when your docking request times out"
     },
+    "Empire honorific": {
+      "enabled": true,
+      "priority": 3,
+      "responder": false,
+      "script": "{_ Forms of address taken from <https://en.wikipedia.org/wiki/Forms_of_address_in_the_United_Kingdom>}\r\n{if cmdr.empirerating.rank <= 4: {_ Commoner }\r\n   commander\r\n|elif cmdr.empirerating.rank = 5: {_ Knight / Dame }\r\n    {if cmdr.gender = \"Male\": \r\n        sir \r\n    |elif cmdr.gender = \"Female\": \r\n        madam\r\n    |else: \r\n        commander\r\n    }\r\n|elif cmdr.empirerating.rank <= 11: {_ Peer / Peeress }\r\n    {if cmdr.gender = \"Male\": \r\n        {OneOf(\"my lord\", \"your lordship\")}\r\n    |elif cmdr.gender = \"Female\": \r\n        {OneOf(\"my lady\", \"your ladyship\")}\r\n    |else: \r\n        commander\r\n    }\r\n|elif cmdr.empirerating.rank = 12:\r\n    your grace\r\n|elif cmdr.empirerating.rank = 13:\r\n    your royal highness\r\n|elif cmdr.empirerating.rank = 14:\r\n    your majesty\r\n}\r\n",
+      "default": true,
+      "name": "Empire honorific",
+      "description": "Function to provide a suitable honorific for your commander when in the empire"
+    },
     "Empire promotion": {
       "enabled": true,
       "priority": 3,


### PR DESCRIPTION
This PR completes #115 by:

- providing feminine names for all applicable ranks (in practice these are all Empire)
- supporting the 'Neither' option -- this will fall back to "Commander" where only gendered terms are available

The Empire honorific is now in its own script on the "Don't Repeat Yourself" principle.
