### PR TITLE
Improved Cereproc support

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -6,6 +6,7 @@
     * You can now specify your commander's gender in the "Commander Details" tab. Currently this is only relevant for titles of nobility in the Empire. You can specify "Neither" if you prefer to be addressed as "Commander" in situations where convention would otherwise require a gendered form of address.
     * Hardened EDDI against a crash that could occur if the folder containing player journals doesn't exist.
     * Smarter vehicle state tracking.
+    * Found a way to improve support for Cereproc voices. These should now support more of the functions described in [the SpeechResponder documentation](https://github.com/EDCD/EDDI/blob/master/SpeechResponder/Help.md)
   * Speech Responder
     * Add new event 'Vehicle destroyed' *(it does not perfectly track vehicle destruction since there are no official player journal events for SRV or fighter destruction - we have to infer vehicle destruction)*.
     * Amended the descriptions for the 'Module arrived' and 'Ship arrived' station and system variables.

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -394,7 +394,7 @@ namespace EddiSpeechService
                 {
                     if (synth.Voice.Name.Contains("CereVoice"))
                     {
-                        /// Cereproc voices do not support the normal xml:lang attribute country/region codes (like EN-GB) 
+                        /// Cereproc voices do not support the normal xml:lang attribute country/region codes (like en-GB) 
                         /// (see https://www.cereproc.com/files/CereVoiceCloudGuide.pdf), 
                         /// but it does support two letter country codes so we will use those instead
                         guess = synth.Voice.Culture.Parent.Name;

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -356,18 +356,10 @@ namespace EddiSpeechService
                         if (speech.Contains("<"))
                         {
                             Logging.Debug("Obtaining best guess culture");
-                            string culture = bestGuessCulture(synth);
-                            if (culture.Length > 0)
-                            {
-                                culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
-                                Logging.Debug("Best guess culture is " + culture);
-                            }
-                            else
-                            {
-                                Logging.Debug("SSML attribute xml:lang not applicable for Cereproc voices, no culture applies (not standards compliant).");
-                            }
+                            string culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
+                            Logging.Debug("Best guess culture is " + culture);
                             speech = @"<?xml version=""1.0"" encoding=""UTF-8""?><speak version=""1.0"" xmlns=""http://www.w3.org/2001/10/synthesis""" + culture + ">" + escapeSsml(speech) + @"</speak>";
-                            Logging.Debug("Feeding SSML to synthesizer: " + speech);
+                            Logging.Debug("Feeding SSML to synthesizer: " + escapeSsml(speech));
                             synth.SpeakSsml(speech);
                         }
                         else
@@ -402,12 +394,14 @@ namespace EddiSpeechService
                 {
                     if (synth.Voice.Name.Contains("CereVoice"))
                     {
-                        // Cereproc voices do not support the xml:lang attribute, so no language code should be applied
-                        guess = string.Empty;
+                        /// Cereproc voices do not support the normal xml:lang attribute country/region codes (like EN-GB) 
+                        /// (see https://www.cereproc.com/files/CereVoiceCloudGuide.pdf), 
+                        /// but it does support two letter country codes so we will use those instead
+                        guess = synth.Voice.Culture.Parent.Name;
                     }
                     else
                     {
-                        // Trust the voice's information
+                        // Trust the voice's information (with the complete country/region code)
                         guess = synth.Voice.Culture.Name;
                     }
                 }


### PR DESCRIPTION
Today I stumbled across this article: https://msdn.microsoft.com/en-us/library/hh378389(v=office.14).aspx

After doing some testing, I found that Cereproc accepts the two letter country codes (en) but not the more traditional country/region codes (EN-GB). This change eliminates exceptions from the speech synthesizer for the xml:lang tag being undefined and consequently improves SSML support for Cereproc voices.

Consider this an update on issue #208.