### PR TITLE
Fix dispatcher timing for writing shipyard data

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,7 +1,7 @@
 ﻿# CHANGE LOG
 
 ### 2.4.6-b3
-
+  * Fixed a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships)
 
 ### 2.4.6-b2
   * Core

--- a/ShipMonitor/ConfigurationWindow.xaml.cs
+++ b/ShipMonitor/ConfigurationWindow.xaml.cs
@@ -109,13 +109,13 @@ namespace EddiShipMonitor
         private void shipsUpdated(object sender, DataTransferEventArgs e)
         {
             // Update the ship monitor's information
-            monitor.writeShips();
+            monitor.Save();
         }
 
         private void shipsUpdated(object sender, SelectionChangedEventArgs e)
         {
             // Update the ship monitor's information
-            monitor.writeShips();
+            monitor.Save();
         }
     }
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -583,9 +583,14 @@ namespace EddiShipMonitor
                 foreach (Hardpoint hpt in ship.hardpoints)
                 {
                     if (hpt.name == fromSlot)
+                    {
                         hpt.name = toSlot;
+                    }
+
                     if (hpt.name == toSlot)
+                    {
                         hpt.name = fromSlot;
+                    }
 
                     hardpoints.Add(hpt.name, hpt);
                 }
@@ -596,10 +601,11 @@ namespace EddiShipMonitor
                 {
                     for (int i = 1; i < 12; i++)
                     {
-                        Hardpoint hpt;
-                        hardpoints.TryGetValue(size + "Hardpoint" + i, out hpt);
+                        hardpoints.TryGetValue(size + "Hardpoint" + i, out Hardpoint hpt);
                         if (hpt != null)
+                        {
                             ship.hardpoints.Add(hpt);
+                        }
                     }
                 }
             }
@@ -612,9 +618,14 @@ namespace EddiShipMonitor
                 foreach (Compartment cpt in ship.compartments)
                 {
                     if (cpt.name == fromSlot)
+                    {
                         cpt.name = toSlot;
+                    }
+
                     if (cpt.name == toSlot)
+                    {
                         cpt.name = fromSlot;
+                    }
 
                     compartments.Add(cpt.name, cpt);
                 }
@@ -622,20 +633,24 @@ namespace EddiShipMonitor
                 // Clear ship compartments and repopulate in correct order
                 ship.compartments.Clear();
                 for (int i = 1; i <= 12; i++)
+                {
                     for (int j = 1; j <= 8; j++)
                     {
-                        Compartment cpt;
-                        compartments.TryGetValue("Slot" + i.ToString("00") + "_Size" + j, out cpt);
+                        compartments.TryGetValue("Slot" + i.ToString("00") + "_Size" + j, out Compartment cpt);
                         if (cpt != null)
+                        {
                             ship.compartments.Add(cpt);
+                        }
                     }
+                }
 
                 for (int i = 1; i <= 3; i++)
                 {
-                    Compartment cpt;
-                    compartments.TryGetValue("Military" + i.ToString("00"), out cpt);
+                    compartments.TryGetValue("Military" + i.ToString("00"), out Compartment cpt);
                     if (cpt != null)
+                    {
                         ship.compartments.Add(cpt);
+                    }
                 }
             }
             writeShips();

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -748,17 +748,17 @@ namespace EddiShipMonitor
                             // need to splice it in to our model.  We do, however, have cargo hatch information from the journal that we
                             // want to make avaialable to Coriolis so need to parse the raw data and add cargo hatch info as appropriate
                             JObject cargoHatchModule = new JObject
-                        {
-                            { "on", ship.cargohatch.enabled },
-                            { "priority", ship.cargohatch.priority },
-                            { "value", ship.cargohatch.price },
-                            { "health", ship.cargohatch.health },
-                            { "name", "ModularCargoBayDoor" }
-                        };
+                            {
+                                { "on", ship.cargohatch.enabled },
+                                { "priority", ship.cargohatch.priority },
+                                { "value", ship.cargohatch.price },
+                                { "health", ship.cargohatch.health },
+                                { "name", "ModularCargoBayDoor" }
+                            };
                             JObject cargoHatchSlot = new JObject
-                        {
-                            { "module", cargoHatchModule }
-                        };
+                            {
+                                { "module", cargoHatchModule }
+                            };
                             JObject parsedRaw = JObject.Parse(profileCurrentShip.raw);
                             parsedRaw["modules"]["CargoHatch"] = cargoHatchSlot;
                             ship.raw = parsedRaw.ToString(Formatting.None);
@@ -789,6 +789,7 @@ namespace EddiShipMonitor
                     AddShip(profileShip);
                 }
             }
+
             writeShips();
         }
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -830,22 +830,10 @@ namespace EddiShipMonitor
                 ShipMonitorConfiguration configuration = ShipMonitorConfiguration.FromFile();
 
                 // Build a new shipyard
-                List<Ship> newShipyard = new List<Ship>();
-                foreach (Ship ship in configuration.shipyard)
-                {
-                    newShipyard.Add(ship);
-                }
-
-                // Now order the list by model
-                newShipyard = newShipyard.OrderBy(s => s.model).ToList();
+                List<Ship> newShiplist = configuration.shipyard.OrderBy(s => s.model).ToList();
 
                 // Update the shipyard
-                shipyard.Clear();
-                foreach (Ship ship in newShipyard)
-                {
-                    AddShip(ship);
-                }
-
+                shipyard = new ObservableCollection<Ship>(newShiplist);
                 currentShipId = configuration.currentshipid;
             }
         }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -25,7 +25,6 @@ namespace EddiShipMonitor
         // The ID of the current ship; can be null
         private int? currentShipId;
         private int? currentProfileId;
-        private int dispatcherTasks = 0;
         private static readonly object shipyardLock = new object();
 
         public string MonitorName()
@@ -785,15 +784,8 @@ namespace EddiShipMonitor
             return variables;
         }
 
-        public async void writeShips()
+        public void writeShips()
         {
-            do
-            {
-                // Make sure the dispatcher has finished prior to writing the shipyard.
-                await Task.Delay(TimeSpan.FromSeconds(1));
-            }
-            while (dispatcherTasks != 0);
-            Dispatcher.CurrentDispatcher.Hooks.
             lock (shipyardLock)
             {
                 // Write ship configuration with current inventory
@@ -863,9 +855,7 @@ namespace EddiShipMonitor
             {
                 Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
                 {
-                    dispatcherTasks += 1;
                     _AddShip(ship);
-                    dispatcherTasks -= 1;
                 }));
             }
         }
@@ -897,9 +887,7 @@ namespace EddiShipMonitor
             {
                 Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
                 {
-                    dispatcherTasks += 1;
                     _RemoveShip(localid);
-                    dispatcherTasks -= 1;
                 }));
             }
         }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -562,7 +562,9 @@ namespace EddiShipMonitor
         private void handleModulesStoredEvent(ModulesStoredEvent @event)
         {
             foreach (string slot in @event.slots)
+            {
                 RemoveModule((int)@event.shipid, slot);
+            }
             writeShips();
         }
 
@@ -573,8 +575,7 @@ namespace EddiShipMonitor
             string fromSlot = @event.fromslot;
             string toSlot = @event.toslot;
 
-            // Module is a hardpoint
-            if (fromSlot.Contains("Hardpoint"))
+            if (fromSlot.Contains("Hardpoint")) // Module is a hardpoint
             {
                 // Build new dictionary of ship hardpoints, excepting the swapped hardpoints
                 // Save ship hardpoints which match the 'From' and 'To' slots
@@ -603,9 +604,7 @@ namespace EddiShipMonitor
                     }
                 }
             }
-
-            //Module is a compartment
-            else
+            else //Module is a compartment
             {
                 // Build new dictionary of ship compartments, excepting the swapped compartments
                 // Save ship compartments which match the 'From' and 'To' slots
@@ -1024,7 +1023,9 @@ namespace EddiShipMonitor
             }
 
             if (slot.Contains("PaintJob"))
+            {
                 ship.paintjob = module.EDName;
+            }
             else if (slot.Contains("Hardpoint"))
             {
                 // This is a hardpoint

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -81,6 +81,11 @@ namespace EddiShipMonitor
             return new ConfigurationWindow();
         }
 
+        public void Save()
+        {
+            uiSyncContext.Post(_ => writeShips(), null);
+        }
+
         /// <summary>
         /// We pre-handle the events to ensure that the data is up-to-date when it hits the responders
         /// </summary>
@@ -803,7 +808,7 @@ namespace EddiShipMonitor
             return variables;
         }
 
-        public void writeShips()
+        private void writeShips()
         {
             lock (shipyardLock)
             {

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -863,12 +863,12 @@ namespace EddiShipMonitor
 
         private void _AddShip(Ship ship)
         {
+            if (ship == null)
+            {
+                return;
+            }
             lock (shipyardLock)
             {
-                if (ship == null)
-                {
-                    return;
-                }
                 // Remove the ship first (just in case we are trying to add a ship that already exists)
                 RemoveShip(ship.LocalId);
                 shipyard.Add(ship);
@@ -880,6 +880,10 @@ namespace EddiShipMonitor
         /// </summary>
         private void RemoveShip(int? localid)
         {
+            if(localid == null)
+            {
+                return;
+            }
             // Run this on the UI syncContext to ensure that we can update it whilst reflecting changes in the UI
             uiSyncContext.Post(_ => _RemoveShip(localid), null);
         }
@@ -889,17 +893,18 @@ namespace EddiShipMonitor
         /// </summary>
         private void _RemoveShip(int? localid)
         {
+            if (localid == null)
+            {
+                return;
+            }
             lock (shipyardLock)
             {
-                if (localid.HasValue)
+                for (int i = 0; i < shipyard.Count; i++)
                 {
-                    for (int i = 0; i < shipyard.Count; i++)
+                    if (shipyard[i].LocalId == localid)
                     {
-                        if (shipyard[i].LocalId == localid)
-                        {
-                            shipyard.RemoveAt(i);
-                            break;
-                        }
+                        shipyard.RemoveAt(i);
+                        break;
                     }
                 }
             }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -930,8 +930,9 @@ namespace EddiShipMonitor
         /// </summary>
         public Ship GetCurrentShip()
         {
-            EDDI.Instance.CurrentShip = GetShip(currentShipId);
-            return GetShip(currentShipId);
+            Ship currentShip = GetShip(currentShipId);
+            EDDI.Instance.CurrentShip = currentShip;
+            return currentShip;
         }
 
         /// <summary>
@@ -943,7 +944,12 @@ namespace EddiShipMonitor
             {
                 return null;
             }
-            return shipyard.FirstOrDefault(s => s.LocalId == localId);
+            Ship ship;
+            lock (shipyardLock)
+            {
+                ship = shipyard.FirstOrDefault(s => s.LocalId == localId);
+            }
+            return ship;
         }
 
         public void SetCurrentShip(int? localId, string model = null)

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -866,6 +866,7 @@ namespace EddiShipMonitor
                 // Remove the ship first (just in case we are trying to add a ship that already exists)
                 RemoveShip(ship.LocalId);
                 shipyard.Add(ship);
+                writeShips();
             }
         }
 
@@ -898,6 +899,7 @@ namespace EddiShipMonitor
                     if (shipyard[i].LocalId == localid)
                     {
                         shipyard.RemoveAt(i);
+                        writeShips();
                         break;
                     }
                 }
@@ -966,6 +968,7 @@ namespace EddiShipMonitor
                     ship.station = null;
                     EDDI.Instance.CurrentShip = ship;
                 }
+                writeShips();
             }
         }
 


### PR DESCRIPTION
Fix #305 by checking to make sure all dispatcher actions are completed prior to writing to the shipyard.
Though this solution works, there may be a more elegant way to code this (perhaps using Dispatcher.CurrentDispatcher.Hooks.DispatcherInactive)?