### PR TITLE
Multi monitor size position

### DIFF
--- a/EDDI/App.config
+++ b/EDDI/App.config
@@ -34,26 +34,8 @@
   </system.data>
   <userSettings>
     <Eddi.Properties.Settings>
-      <setting name="Top" serializeAs="String">
-        <value>0</value>
-      </setting>
-      <setting name="Left" serializeAs="String">
-        <value>0</value>
-      </setting>
-      <setting name="Height" serializeAs="String">
-        <value>600</value>
-      </setting>
-      <setting name="Width" serializeAs="String">
-        <value>800</value>
-      </setting>
       <setting name="Maximized" serializeAs="String">
         <value>False</value>
-      </setting>
-      <setting name="ScreensHeight" serializeAs="String">
-        <value>1920</value>
-      </setting>
-      <setting name="ScreensWidth" serializeAs="String">
-        <value>1080</value>
       </setting>
       <setting name="Minimized" serializeAs="String">
         <value>False</value>

--- a/EDDI/App.config
+++ b/EDDI/App.config
@@ -61,6 +61,9 @@
       <setting name="SelectedTab" serializeAs="String">
         <value>0</value>
       </setting>
+      <setting name="WindowPosition" serializeAs="String">
+        <value>40,40,800,600</value>
+      </setting>
     </Eddi.Properties.Settings>
   </userSettings>
 </configuration>

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,8 +1,10 @@
 ﻿# CHANGE LOG
 
 ### 2.4.6-b3
-  # Core
-    * Save/restore EDDI window size and position (multi-display aware), and activates the last selected tab page. If EDDI is run directly, minimize/maximize state is preserved. If called up from VoiceAttack, only the maximized state is preserved.
+  * Core
+    * Improved window size and position handling for multi-display setups. 
+    * Minimum window size refined to match designed window size. 
+    * If EDDI is run directly, minimize/maximize state are preserved. If invoked via the VoiceAttack 'Configure EDDI' command, only the maximized state is preserved.
 
 ### 2.4.6-b2
   * Core

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,7 +1,8 @@
 ﻿# CHANGE LOG
 
 ### 2.4.6-b3
-
+  # Core
+    * Save/restore EDDI window size and position (multi-display aware), and activates the last selected tab page. If EDDI is run directly, minimize/maximize state is preserved. If called up from VoiceAttack, only the maximized state is preserved.
 
 ### 2.4.6-b2
   * Core
@@ -25,7 +26,7 @@
     * 'Docked' event:
       * New variables 'allegiance' and 'state'. 'State' is a new variable that is currently used to describe damaged stations and stations under repair.
     * 'Mission completed' event:
-      * Addded variables `rewardCommodity` and `rewardAmount`. Useful for cargo tracking.
+      * Added variables `rewardCommodity` and `rewardAmount`. Useful for cargo tracking.
     * 'Search and rescue' event:
       * Added variable `commodityname` to provide the name of the commodity turned in, free of the commodity object. Accessible to VoiceAttack as `{TXT:EDDI search and rescue commodityname}` 
       * Updated 'Search and rescue' event to better distinguish between occupied and damaged escape pods, and to fix a bug in handling wreckage commodities.

--- a/EDDI/EDDI.csproj
+++ b/EDDI/EDDI.csproj
@@ -77,6 +77,10 @@
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>
+    </StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="CommonMark, Version=0.1.0.0, Culture=neutral, PublicKeyToken=001ef8810438905d, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonMark.NET.0.15.1\lib\net45\CommonMark.dll</HintPath>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -71,6 +71,7 @@ namespace Eddi
             const int designedWidth = 800;
 
             Rect windowPosition = Properties.Settings.Default.WindowPosition;
+            Visibility = Visibility.Collapsed;
 
             if (windowPosition != Rect.Empty && isWindowValid(windowPosition))
             {
@@ -319,16 +320,17 @@ namespace Eddi
             {
                 // Hide/show helps reduce window flicker when EDDI is run stand-alone,
                 // but it bombs if the window is started from VoiceAttack.
-                if (!fromVA)
-                    Visibility = Visibility.Hidden;
+                //if (!fromVA)
+                //    Visibility = Visibility.Hidden;
 
                 if (Properties.Settings.Default.Minimized)
                     senderWindow.WindowState = WindowState.Minimized;
                 else if (Properties.Settings.Default.Maximized)
                     senderWindow.WindowState = WindowState.Maximized;
 
-                if (!fromVA)
-                    Visibility = Visibility.Visible;
+                //if (!fromVA)
+                //    Visibility = Visibility.Visible;
+                Visibility = Visibility.Visible;
             }
         }
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -318,18 +318,11 @@ namespace Eddi
 
             if (Properties.Settings.Default.Maximized || Properties.Settings.Default.Minimized)
             {
-                // Hide/show helps reduce window flicker when EDDI is run stand-alone,
-                // but it bombs if the window is started from VoiceAttack.
-                //if (!fromVA)
-                //    Visibility = Visibility.Hidden;
-
                 if (Properties.Settings.Default.Minimized)
                     senderWindow.WindowState = WindowState.Minimized;
                 else if (Properties.Settings.Default.Maximized)
                     senderWindow.WindowState = WindowState.Maximized;
 
-                //if (!fromVA)
-                //    Visibility = Visibility.Visible;
                 Visibility = Visibility.Visible;
             }
         }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace Eddi
                     savePosition = new Rect(RestoreBounds.Left, RestoreBounds.Top, RestoreBounds.Width, RestoreBounds.Height);
                     Properties.Settings.Default.Maximized = false;
 
-                    // If running from VoiceAttack, don't save the minimized state
+                    // If opened from VoiceAttack, don't allow minimized state
                     Properties.Settings.Default.Minimized = fromVA ? false: true;
 
                     break;

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -675,8 +675,8 @@ namespace Eddi
             {
                 // When in OnClosed(), if the EDDI window was closed while minimized
                 // (under debugger), monitorThread.Join() would block waiting for a
-                // thread to terminate. Strange, because it did not happen when the
-                // window was closed in the normal or maximized state.
+                // thread(s) to terminate. Strange, because it does not block when the
+                // window is closed in the normal or maximized state.
                 EDDI.Instance.Stop();
             }
         }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -295,8 +295,8 @@ namespace Eddi
 
             if (Properties.Settings.Default.Maximized || Properties.Settings.Default.Minimized)
             {
-                // Hide/show helps reduce window flicker when EDDI is run stand-along,
-                // but it bombs if the UI is called up from VoiceAttack.
+                // Hide/show helps reduce window flicker when EDDI is run stand-alone,
+                // but it bombs if the window is started from VoiceAttack.
                 if (!fromVA)
                     Visibility = Visibility.Hidden;
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -28,10 +28,7 @@ namespace Eddi
 
         private bool fromVA;
 
-        public MainWindow() : this(false)
-        {
-            RestoreWindowState();
-        }
+        public MainWindow() : this(false) { }
 
         private void SaveWindowState()
         {
@@ -298,6 +295,7 @@ namespace Eddi
                 tabControl.Items.Add(item);
             }
 
+            RestoreWindowState();
             EDDI.Instance.Start();
         }
 

--- a/EDDI/Properties/Settings.Designer.cs
+++ b/EDDI/Properties/Settings.Designer.cs
@@ -25,54 +25,6 @@ namespace Eddi.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public double Top {
-            get {
-                return ((double)(this["Top"]));
-            }
-            set {
-                this["Top"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public double Left {
-            get {
-                return ((double)(this["Left"]));
-            }
-            set {
-                this["Left"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("600")]
-        public double Height {
-            get {
-                return ((double)(this["Height"]));
-            }
-            set {
-                this["Height"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("800")]
-        public double Width {
-            get {
-                return ((double)(this["Width"]));
-            }
-            set {
-                this["Width"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool Maximized {
             get {
@@ -80,30 +32,6 @@ namespace Eddi.Properties {
             }
             set {
                 this["Maximized"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1920")]
-        public int ScreensHeight {
-            get {
-                return ((int)(this["ScreensHeight"]));
-            }
-            set {
-                this["ScreensHeight"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1080")]
-        public int ScreensWidth {
-            get {
-                return ((int)(this["ScreensWidth"]));
-            }
-            set {
-                this["ScreensWidth"] = value;
             }
         }
         

--- a/EDDI/Properties/Settings.Designer.cs
+++ b/EDDI/Properties/Settings.Designer.cs
@@ -130,5 +130,17 @@ namespace Eddi.Properties {
                 this["SelectedTab"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("40,40,800,600")]
+        public global::System.Windows.Rect WindowPosition {
+            get {
+                return ((global::System.Windows.Rect)(this["WindowPosition"]));
+            }
+            set {
+                this["WindowPosition"] = value;
+            }
+        }
     }
 }

--- a/EDDI/Properties/Settings.settings
+++ b/EDDI/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="SelectedTab" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="WindowPosition" Type="System.Windows.Rect" Scope="User">
+      <Value Profile="(Default)">40,40,800,600</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EDDI/Properties/Settings.settings
+++ b/EDDI/Properties/Settings.settings
@@ -2,26 +2,8 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="Eddi.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="Top" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">0</Value>
-    </Setting>
-    <Setting Name="Left" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">0</Value>
-    </Setting>
-    <Setting Name="Height" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">600</Value>
-    </Setting>
-    <Setting Name="Width" Type="System.Double" Scope="User">
-      <Value Profile="(Default)">800</Value>
-    </Setting>
     <Setting Name="Maximized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
-    </Setting>
-    <Setting Name="ScreensHeight" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">1920</Value>
-    </Setting>
-    <Setting Name="ScreensWidth" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">1080</Value>
     </Setting>
     <Setting Name="Minimized" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>


### PR DESCRIPTION
Big fan of EDDI. EDDI-2.4.6-b2 working well, but I have a dual monitor setup and the saved window position/size would always render on the primary monitor, instead of the second monitor where EDDI and/or VoiceAttack are usually run from.

Hope this code (or portions) can help move the EDDI project forward.
