### PR TITLE
Feature/app mutex

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,7 +5,7 @@
     * Improved window size and position handling for multi-display setups. 
     * Minimum window size refined to match designed window size. 
     * If EDDI is run as a standalone app, its entire window state is preserved. If EDDI is invoked via the VoiceAttack 'Configure EDDI' command, only the maximized state is preserved.
-  * Fixed a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships)
+  * Fixed a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships).
 
 ### 2.4.6-b2
   * Core

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,10 +2,13 @@
 
 ### 2.4.6-b3
   * Core
+    * Running multiple instances of EDDI (e.g. both standalone and VoiceAttack) for the same Windows user has been found to mess up your EDDI's storage directory, so EDDI will now politely warn and exit if you try to do that.
+  * Layout
     * Improved window size and position handling for multi-display setups. 
     * Minimum window size refined to match designed window size. 
     * If EDDI is run as a standalone app, its entire window state is preserved. If EDDI is invoked via the VoiceAttack 'Configure EDDI' command, only the maximized state is preserved.
-  * Fixed a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships).
+  * Shipyard
+    * Speculative fix for a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships). Probably the above fix that bars multiple instances will prevent it.
 
 ### 2.4.6-b2
   * Core

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -155,31 +155,7 @@ namespace Eddi
                 monitors = findMonitors();
                 responders = findResponders();
 
-                // Set up the app service
-                if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.READY)
-                {
-                    // Carry out initial population of profile
-                    try
-                    {
-                        refreshProfile();
-                    }
-                    catch (Exception ex)
-                    {
-                        Logging.Debug("Failed to obtain profile: " + ex);
-                    }
-                }
-
-                Cmdr.insurance = configuration.Insurance;
-                Cmdr.gender = configuration.Gender;
-                if (Cmdr.name != null)
-                {
-                    Logging.Info("EDDI access to the companion app is enabled");
-                }
-                else
-                {
-                    // If InvokeUpdatePlugin failed then it will have have left an error message, but this once we ignore it
-                    Logging.Info("EDDI access to the companion app is disabled");
-                }
+                SetupCompanionAPI(configuration);
 
                 SetupEDSM();
 
@@ -191,6 +167,35 @@ namespace Eddi
             catch (Exception ex)
             {
                 Logging.Error("Failed to initialise", ex);
+            }
+        }
+
+        private void SetupCompanionAPI(EDDIConfiguration configuration)
+        {
+            // Set up the companion app service
+            if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.READY)
+            {
+                // Carry out initial population of profile
+                try
+                {
+                    refreshProfile();
+                }
+                catch (Exception ex)
+                {
+                    Logging.Debug("Failed to obtain profile: " + ex);
+                }
+            }
+
+            Cmdr.insurance = configuration.Insurance;
+            Cmdr.gender = configuration.Gender;
+            if (Cmdr.name != null)
+            {
+                Logging.Info("EDDI access to the companion app is enabled");
+            }
+            else
+            {
+                // If InvokeUpdatePlugin failed then it will have have left an error message, but this once we ignore it
+                Logging.Info("EDDI access to the companion app is disabled");
             }
         }
 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -181,34 +181,7 @@ namespace Eddi
                     Logging.Info("EDDI access to the companion app is disabled");
                 }
 
-                // Set up the star map service
-                StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
-                if (starMapCredentials != null && starMapCredentials.apiKey != null)
-                {
-                    // Commander name might come from star map credentials or the companion app's profile
-                    string commanderName = null;
-                    if (starMapCredentials.commanderName != null)
-                    {
-                        commanderName = starMapCredentials.commanderName;
-                    }
-                    else if (Cmdr != null && Cmdr.name != null)
-                    {
-                        commanderName = Cmdr.name;
-                    }
-                    if (commanderName != null)
-                    {
-                        starMapService = new StarMapService(starMapCredentials.apiKey, commanderName);
-                        Logging.Info("EDDI access to EDSM is enabled");
-                    }
-                    // Spin off a thread to download & sync EDSM flight logs & system comments in the background
-                    Thread updateThread = new Thread(() => starMapService.Sync(starMapCredentials.lastSync));
-                    updateThread.IsBackground = true;
-                    updateThread.Start();
-                }
-                if (starMapService == null)
-                {
-                    Logging.Info("EDDI access to EDSM is disabled");
-                }
+                SetupEDSM();
 
                 // We always start in normal space
                 Environment = Constants.ENVIRONMENT_NORMAL_SPACE;
@@ -218,6 +191,38 @@ namespace Eddi
             catch (Exception ex)
             {
                 Logging.Error("Failed to initialise", ex);
+            }
+        }
+
+        private void SetupEDSM()
+        {
+            // Set up the star map service
+            StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
+            if (starMapCredentials != null && starMapCredentials.apiKey != null)
+            {
+                // Commander name might come from star map credentials or the companion app's profile
+                string commanderName = null;
+                if (starMapCredentials.commanderName != null)
+                {
+                    commanderName = starMapCredentials.commanderName;
+                }
+                else if (Cmdr != null && Cmdr.name != null)
+                {
+                    commanderName = Cmdr.name;
+                }
+                if (commanderName != null)
+                {
+                    starMapService = new StarMapService(starMapCredentials.apiKey, commanderName);
+                    Logging.Info("EDDI access to EDSM is enabled");
+                }
+                // Spin off a thread to download & sync EDSM flight logs & system comments in the background
+                Thread updateThread = new Thread(() => starMapService.Sync(starMapCredentials.lastSync));
+                updateThread.IsBackground = true;
+                updateThread.Start();
+            }
+            if (starMapService == null)
+            {
+                Logging.Info("EDDI access to EDSM is disabled");
             }
         }
 

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -12,6 +12,7 @@ namespace Utilities
         public const string EDDI_SERVER_URL = "http://edcd.github.io/EDDP/";
 
         public static readonly string DATA_DIR = Environment.GetEnvironmentVariable("AppData") + "\\" + EDDI_NAME;
+        public static readonly string USER_CONCURRENCY_TOKEN = EDDI_SERVER_URL + "/EDDI/" + Environment.GetEnvironmentVariable("UserName");
 
         public const string ENVIRONMENT_WITCH_SPACE = "Witch space";
         public const string ENVIRONMENT_SUPERCRUISE = "Supercruise";


### PR DESCRIPTION
This branch makes any instantiation of EDDI request a system-wide per-user mutex, and bails out with an apologetic alert box if another EDDI instance already holds said mutex.

This should put a stop to multiple instances of EDDI (standalone and VA) fighting over the settings dir and messing it up.

Please test by running VA first, and running EDDI first.
