### PR TITLE
Text-to-Speech distortion effects

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -6,6 +6,9 @@
     * Minimum window size refined to match designed window size. 
     * If EDDI is run as a standalone app, its entire window state is preserved. If EDDI is invoked via the VoiceAttack 'Configure EDDI' command, only the maximized state is preserved.
   * Fixed a bug that would cause EDDI to write to the shipyard before it had finished processing shipyard related actions (adding and removing ships)
+  * Text-to-Speech
+    * Re-enabled text-to-speech distortion on ship damage. If this option is enabled, EDDI will now increase voice processing effects as damage to the ship increases.
+    * Revised text-to-speech audio gain to compensate for volume losses when voice processing effects are applied.
 
 ### 2.4.6-b2
   * Core

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -73,7 +73,7 @@ namespace Tests
         public void TestSsml4()
         {
             Logging.Verbose = true;
-            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049309), @"<break time=""100ms""/>We're on our way to " + Translations.StarSystem("i Bootis") + ".", true);
+            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049309), @"<break time=""100ms""/>We're on our way to " + Translations.StarSystem("i Bootis",
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfecrtly correct    
@@ -126,16 +126,24 @@ namespace Tests
         [TestMethod]
         public void TestPowerplay()
         {
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Aisling Duval") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Archon Delaine") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Arissa Lavigny-Duval") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Denton Patreus") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Edmund Mahon") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Felicia Winters") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Pranav Antal") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Zachary Hudson") + ".");
-            //SpeechService.Say(ShipDefinitions.ShipFromEliteID(128049363), Translations.Power("Zemina Torval") + ".");
-            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049363), Translations.Power("Li Yong-Rui") + ".", true);
+            var ship = ShipDefinitions.FromEliteID(128049363);
+            var speaker = SpeechService.Instance;
+            string[] powerNames = {
+                "Aisling Duval",
+                "Archon Delaine",
+                "Arissa Lavigny-Duval",
+                "Denton Patreus",
+                "Edmund Mahon",
+                "Felicia Winters",
+                "Pranav Antal",
+                "Zachary Hudson",
+                "Zemina Torval",
+                "Li Yong-Rui"
+            };
+            foreach(string powerName in powerNames)
+            {
+                speaker.Say(ship, Translations.Power(powerName) + ".", true);
+            }
         }
 
         [TestMethod]

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -168,6 +168,7 @@ namespace Tests
         public void TestDamage()
         {
             Ship ship = ShipDefinitions.FromEliteID(128049363);
+            var origHealth = ship.health;
             ship.health = 100;
             SpeechService.Instance.Say(ship, "Systems fully operational.", true);
             ship.health = 80;
@@ -180,6 +181,7 @@ namespace Tests
             SpeechService.Instance.Say(ship, "Systems at 20%.", true);
             ship.health = 0;
             SpeechService.Instance.Say(ship, "Systems critical.", true);
+            ship.health = origHealth;
         }
 
         [TestMethod]


### PR DESCRIPTION
Revise TTS distortion effect per #326.

Make the distortion effect a modifier that increases the level of voice processing, rather than a separate effect. Thus, the effects level set by the user becomes a floor and the actual effects level increases with damage to the ship if this option is enabled.

Also adjusted audio gain for volume loss that occurs as the effects level increases.