### PR TITLE
Troubleshooting

### DIFF
--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -39,7 +39,7 @@
                             </Paragraph>
                             <Paragraph>
                                 You can read more about how EDDI functions on the
-                                <Hyperlink Click="WikiClicked">project wiki</Hyperlink> .
+                                <Hyperlink Click="WikiClicked">project wiki</Hyperlink>.
                             </Paragraph>
                         </FlowDocument>
                     </RichTextBox>
@@ -52,13 +52,18 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Enable verbose logging (only if you have been requested to do so by EDDI developers)" VerticalAlignment="Top"/>
-                        <CheckBox x:Name="eddiVerboseLogging" Grid.Row="0" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="verboseLoggingEnabled" Unchecked="verboseLoggingDisabled"/>
-                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="If verbose logging is enabled, EDDI will prepare a truncated version of your log from the past hour and place it on your desktop. You may paste this log file into the Github Issue report. No personal information is sent in the log."/>
-                        <Button  x:Name="githubIssueButton" Grid.Row="1" Grid.Column="2" Content="Report an Issue" Margin="5" Width="110" Click="createGithubIssueClicked"/>
-                        <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Access beta versions of EDDI" VerticalAlignment="Top"/>
-                        <CheckBox x:Name="eddiBetaProgramme" Grid.Row="2" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="betaProgrammeEnabled" Unchecked="betaProgrammeDisabled"/>
+                        <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" TextWrapping="Wrap" VerticalAlignment="Top">
+                            <Hyperlink Click="TroubleshootClicked">Troubleshoot</Hyperlink>
+                             common issues
+                        </TextBlock>
+                        <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Enable verbose logging (only if you have been requested to do so by EDDI developers)" VerticalAlignment="Top"/>
+                        <CheckBox x:Name="eddiVerboseLogging" Grid.Row="1" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="verboseLoggingEnabled" Unchecked="verboseLoggingDisabled"/>
+                        <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="If verbose logging is enabled, EDDI will prepare a truncated version of your log from the past hour and place it on your desktop. You may paste this log file into the Github Issue report. No personal information is sent in the log."/>
+                        <Button  x:Name="githubIssueButton" Grid.Row="2" Grid.Column="2" Content="Report an Issue" Margin="5" Width="110" Click="createGithubIssueClicked"/>
+                        <TextBlock Grid.Row="3" Grid.Column="0" Margin="5" TextWrapping="Wrap" Text="Access beta versions of EDDI" VerticalAlignment="Top"/>
+                        <CheckBox x:Name="eddiBetaProgramme" Grid.Row="3" Grid.Column="1" Margin="5" VerticalAlignment="Center" Checked="betaProgrammeEnabled" Unchecked="betaProgrammeDisabled"/>
                     </Grid>
                     <TextBlock x:Name="heroText" DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5" FontSize="20" FontStyle="Italic" FontWeight="Bold" VerticalAlignment="Center" TextAlignment="Center"/>
                 </DockPanel>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -839,5 +839,10 @@ namespace Eddi
         {
             Process.Start("https://github.com/EDCD/EDDI/wiki");
         }
+
+        private void TroubleshootClicked(object sender, RoutedEventArgs e)
+        {
+            Process.Start("https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md");
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,22 +32,19 @@ Initial EDDI integration with VoiceAttack is automatic, but there is a lot that 
 
 If you are upgrading from EDDI 1 EDDI it is recommended that you uninstall your existing version of EDDI and remove your %APPDATA%\EDDI directory prior to upgrading to the new one.  This ensures that there is a clean installation and reduces the chances of problems occurring.
 
-If you used EDDI 1 with VoiceAttack then please follow the instructions at [https://github.com/EDCD/EDDI/wiki/VoiceAttack-Integration](https://github.com/EDCD/EDDI/wiki/VoiceAttack-Integration).
-
 If you are upgrading from another version of EDDI 2 the installer will take care of changes so you just need to run it.
 
 ## EDDI Voices
 
-EDDI uses the standard Windows TTS (text-to-speech) voices.  To be eligible for use in EDDI the voice needs to support phonetic speech.  Apart from Windows' default voices there are commercial voices available from IVONA and Cereproc, amongst others, that can be used.  The voice needs to be visible to Windows' TTS system to be made available to EDDI: this usually takes place when you install the voice.  If you cannot see a voice in EDDI then check the Windows TTS settings.
+EDDI uses the standard Windows TTS (text-to-speech) voices.  The voice needs to be visible to Windows' TTS system to be made available to EDDI: this usually takes place when you install the voice.  If you cannot see a voice in EDDI then check the Windows TTS settings.
+
+If you want to have a high-quality voice other than that available with Windows then the best choices are to purchase voices from either Ivona or Cereproc.  Though both provide great voices, Ivona voices typically adhere more closely to published SSML standards and provide fuller functionality for phonetic speech and other advanced features like pauses in the middle of speech and correct pronunciation of names (ships, powers, systems, etc.).
 
 # Troubleshooting
 
 If you are experiencing problems with EDDI then your first port of call should be the [troubleshooting page](https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md).  If this does not fix your problem then please check the Known issues below:
 
-  * EDDI relies on the Elite: Dangerous companion app API for a lot of its information.  Sometimes EDDI loses connection to the API and needs to re-authenticate.  If you think that this is a problem you can re-run the 'EDDI.exe' and if the connection is bad it will ask for re-authentication
-  * EDDI is unable to know for sure if you have provided the correct path to the Logs directory.  The only way of knowing this for sure is to jump and see if EDDI tells you about your destination when you make a jump
-
-If you have an issue with EDDI then please report it at https://github.com/EDCD/EDDI/issues  If you have encountered a problem then please provide the output of the error report (shift-control-alt-e) to aid in fixing the issue.
+If you have an issue with EDDI then please [report it](https://github.com/EDCD/EDDI/issues). 
 
 # Uninstalling EDDI
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,8 +1,11 @@
 ﻿# Troubleshooting
 
-# General Issues
+This troubleshooting guide is divided into three sections:
+- [General Issues](https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md#general-issues)
+- [Specific Issues](https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md#specific-issues)
+- [Issues with VoiceAttack Integration](https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md#issues-with-voiceattack-integration).
 
-If EDDI is not working properly then there are a number of items you should check.
+# General Issues
 
 ## Ensure that EDDI is running
 
@@ -14,30 +17,30 @@ EDDI has a number of configuration items.  Although they are not required, parts
 
 # Specific Issues
 
-## EDDI is not saying anything when I jump to another system
+## EDDI doesn't start or crashes on startup
 
-The common cause of this problem is that you have not configured your netlog monitor.  To configure your netlog:
+Check whether you are running the latest version of EDDI. On older versions of EDDI (prior to version 2.4.6-b2), EDDI would crash or fail to start if Elite Dangerous had not been run previously and the folder containing the player's journal files could not be located. 
 
-  - shut down VoiceAttack if running
-  - start up EDDI
-  - in the "Netlog monitor" tab ensure that "plugin enabled" is checked
-  - in the "Product logs directory" ensure that you are pointing to your product logs
-  - shut down EDDI
-  - restart EDDI (or VoiceAttack if you are using that)
+If you are already running the latest version of EDDI and EDDI either fails to run or crashes on startup, you may have a problem with your configuration files. To identify a configuration which has become corrupted and is preventing EDDI from working correctly:
 
-## EDDI is not giving me suggestions of which commodities to purchase when I dock at a station
+1. Navigate to %APPDATA%/EDDI
+2. Cut all of the files and paste them to another location
+3. Attempt to start EDDI. EDDI should open with the default configuration.
+4. Exit EDDI.
+5. Cut and paste one of your configuration files into %APPDATA%/EDDI (overwrite as required)
+6. Repeat steps 3 - 5 until EDDI fails to start. Remove the offending file(s) and reconfigure as necessary.
+
+## EDDI is (or is not) giving me suggestions of which commodities to purchase when I dock at a station
 
 To obtain the commodity information EDDI needs access to the companion API.  This requires that the user has configured their "Companion App" tab on the EDDI interface.
 
-If this has been done then the other common problem is that you are flying in a ship that is set for trading.  Ensure that your ship is configured for either "Trading" or "Multi-purpose" in the "Shipyard" tab on the EDDI interface.
+EDDI will only provide this information if you are flying in a ship that is configured for trading.  Ensure that your ship is configured for either "Trading" or "Multi-purpose" in the "Shipyard" tab on the EDDI interface.
 
 ## EDDI is not using the voice that I configured for it
 
 Windows comes with a small number of text-to-speech voices, most of which can be used for EDDI.  There are a number of methods to obtain additional free voices on the internet but these often result in voices that do not provide the full range of functionality, specifically they do not have the ability to provide phonetic pronunciation.  If EDDI detects that a chosen voice is failing to use phonetic pronunciation it will fall back to using normal speech, or halt the voice entirely depending on the error found.
 
-If you want to have a high-quality voice other than that available with Windows then the best choices are to purchase voices from either Ivona or Cereproc.  These provide full functionality for phonetic speech and will give the best result with EDDI.
-
-An alternative is to disable phonetic speech yourself and use one of the other free voices.  To disable phonetic speech:
+It is possible (though not typically recommended) to disable phonetic speech if the voice you are using is not compatible with SSML markups.  With phonetic speech disabled, advanced features like vocal pauses will be less accurate and may cease to function entirely. To disable phonetic speech:
 
   - shut down VoiceAttack if running
   - start up EDDI
@@ -45,11 +48,8 @@ An alternative is to disable phonetic speech yourself and use one of the other f
   - shut down EDDI
   - restart EDDI (or VoiceAttack if you are using that)
 
-However be aware that with phonetic speech disabled a number of advanced features such as pauses in the middle of speech and correct pronunciation of names (ships, powers, systems, etc.) will not be as accurate as would be with phonetic speech.
-
 # Issues with VoiceAttack Integration
 
-If EDDI is not working with VoiceAttack then there are a number of additional items you should check.
 ## Ensure EDDI is in the correct place
 
 EDDI should be in the "Apps" subdirectory of your VoiceAttack directory.  The directory structure should look like this:
@@ -75,3 +75,7 @@ To ensure that plugins are enabled first select the configuration button on the 
 Then confirm that plugin support is enabled.
 
 ![](images/OptionsPluginSupport.jpg)
+
+## Further questions about integration with VoiceAttack?
+
+Read the wiki entry describing [VoiceAttack Integration](https://github.com/EDCD/EDDI/wiki/VoiceAttack-Integration) with EDDI.


### PR DESCRIPTION
Guidance on fixing common issues should be more readily available, but is currently buried within a link from ReadMe.md where it can easily be missed and is rarely updated.

This change adds a UI link to troubleshooting.md and updates the information available in both ReadMe.md and troubleshooting.md.