### PR TITLE
Omit the contents of generic web responses from the debug log

### DIFF
--- a/Utilities/Net.cs
+++ b/Utilities/Net.cs
@@ -26,12 +26,11 @@ namespace Utilities
                         ? Encoding.UTF8
                         : Encoding.GetEncoding(response.CharacterSet);
 
-                Logging.Debug("Reading response");
+                Logging.Debug("Reading response from " + uri);
                 using (var stream = response.GetResponseStream())
                 {
                     var reader = new StreamReader(stream, encoding);
                     string data = reader.ReadToEnd();
-                    Logging.Debug("Data is: " + data);
                     return data;
                 }
             }


### PR DESCRIPTION
Fix for #352.
This function is used to retrieve material uses and blueprint info from the server.
Any error with parsing this data would throw an exception. The full contents do need not be included in the log.