### PR TITLE
Fix for #362

### DIFF
--- a/DataDefinitions/ModuleDefinitions.cs
+++ b/DataDefinitions/ModuleDefinitions.cs
@@ -882,13 +882,11 @@ namespace EddiDataDefinitions
                 {128777344, new Module(128777344, "Int_DroneControl_Repair_Size7_Class3", 1611, "Repair Limpet Controller", 7, "C", 1749600) },
                 {128777345, new Module(128777345, "Int_DroneControl_Repair_Size7_Class4", 1612, "Repair Limpet Controller", 7, "B", 3499200) },
                 {128777346, new Module(128777346, "Int_DroneControl_Repair_Size7_Class5", 1613, "Repair Limpet Controller", 7, "A", 6998400) },
-                {128785621, new Module(128785621, "Type9_Military_Armour_Grade1", -1, "Lightweight Alloy", 1, "I", 0, 128785619) },
-                {128785622, new Module(128785622, "Type9_Military_Armour_Grade2", -1, "Reinforced Alloy", 1, "I", 48654583, 128785619) },
-                {128785623, new Module(128785623, "Type9_Military_Armour_Grade3", -1, "Military Grade Composite", 1, "I", 109472813, 128785619) },
-                {128785624, new Module(128785624, "Type9_Military_Armour_Mirrored", -1, "Mirrored Surface Composite", 1, "I", 258720748, 128785619) },
-                {128785625, new Module(128785625, "Type9_Military_Armour_Reactive", -1, "Reactive Surface Composite", 1, "I", 283830162, 128785619) },
-
-                // 2.4 Update modules. If the EDDB is '-1', an EDDB ID has yet to be assigned. See <https://eddb.io/archive/v5/modules.json>
+                {128785621, new Module(128785621, "Type9_Military_Armour_Grade1", 1627, "Lightweight Alloy", 1, "I", 0, 128785619) },
+                {128785622, new Module(128785622, "Type9_Military_Armour_Grade2", 1628, "Reinforced Alloy", 1, "I", 48654583, 128785619) },
+                {128785623, new Module(128785623, "Type9_Military_Armour_Grade3", 1629, "Military Grade Composite", 1, "I", 109472813, 128785619) },
+                {128785624, new Module(128785624, "Type9_Military_Armour_Mirrored", 1630, "Mirrored Surface Composite", 1, "I", 258720748, 128785619) },
+                {128785625, new Module(128785625, "Type9_Military_Armour_Reactive", 1631, "Reactive Surface Composite", 1, "I", 283830162, 128785619) },
                 {128788699, new Module(128788699, "Hpt_ATDumbfireMissile_Fixed_Medium", 1614, "AX Missile Rack", 2, "B", 540900, Module.ModuleMount.Fixed) },
                 {128788704, new Module(128788704, "Hpt_ATDumbfireMissile_Turret_Medium", 1615, "AX Missile Rack", 2, "B", 2022700, Module.ModuleMount.Turreted) },
                 {128793115, new Module(128793115, "Hpt_XenoScanner_Basic_Tiny", 1616, "Xeno Scanner", 0, "E", 365700) },
@@ -902,6 +900,10 @@ namespace EddiDataDefinitions
                 {128788705, new Module(128788705, "Hpt_ATDumbfireMissile_Turret_Large", 1624, "AX Missile Rack", 3, "A", 3866338, Module.ModuleMount.Turreted) },
                 {128788702, new Module(128788702, "Hpt_ATMultiCannon_Fixed_Large", 1625, "AX Multi-Cannon", 3, "C", 1126044, Module.ModuleMount.Fixed) },
                 {128793060, new Module(128793060, "Hpt_ATMultiCannon_Turret_Large", 1626, "AX Multi-Cannon", 3, "E", 3642224, Module.ModuleMount.Turreted) },
+                {128793941, new Module(128793941, "Int_DroneControl_Decontamination", 1632, "Decontamination Limpet Controller", 1, "E", 3600) },
+                {128793942, new Module(128793942, "Int_DroneControl_Decontamination", 1633, "Decontamination Limpet Controller", 3, "E", 16201) },
+                {128793943, new Module(128793943, "Int_DroneControl_Decontamination", 1634, "Decontamination Limpet Controller", 5, "E", 145801) },
+                {128793944, new Module(128793944, "Int_DroneControl_Decontamination", 1635, "Decontamination Limpet Controller", 7, "E", 1312201) },
 
                 // Various free modules that show up in SRVs, fighters and training; not used anywhere but note them here so that they do not throw errors when encountered
                 {128666643, new Module(128666643, "Int_CargoRack_Size2_Class1_free", -1, "Cargo Rack", 2, "E", 0) },

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ### 2.4.6-b3
   * Core
+    * Added decontamination limpets
     * Improved window size and position handling for multi-display setups. 
     * Minimum window size refined to match designed window size. 
     * If EDDI is run as a standalone app, its entire window state is preserved. If EDDI is invoked via the VoiceAttack 'Configure EDDI' command, only the maximized state is preserved.


### PR DESCRIPTION
Add decontamination limpets to module definitions and assign missing eddb ids for type 10 Defender