### PR TITLE
Hotfix/337 invalid json

### DIFF
--- a/DataDefinitions/CommodityDefinitions.cs
+++ b/DataDefinitions/CommodityDefinitions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 using Utilities;
 
 namespace EddiDataDefinitions
@@ -443,7 +444,10 @@ namespace EddiDataDefinitions
             }
             else
             {
-                Logging.Report("Unknown commodity", @"{""name"":""" + name + @"""}");
+                var badCommodity = new Dictionary<string, object>();
+                badCommodity["name"] = name;
+                string badCommodityJSON = JsonConvert.SerializeObject(badCommodity);
+                Logging.Report("Unknown commodity", badCommodityJSON);
 
                 // Put some basic information in place
                 Commodity.EDName = name;

--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -46,21 +46,23 @@ namespace EddiDataProviderService
             if (response == null || response == "")
             {
                 // No information found on this system, or some other issue.  Create a very basic response
-                response = @"{""name"":""" + system + @"""";
+                Dictionary<string, object> dummyData = new Dictionary<string, object>();
+                dummyData["name"] = system;
                 if (x.HasValue)
                 {
-                    response = response + @", ""x"":" + ((decimal)x).ToString(CultureInfo.InvariantCulture);
+                    dummyData["x"] = x.GetValueOrDefault();
                 }
                 if (y.HasValue)
                 {
-                    response = response + @", ""y"":" + ((decimal)y).ToString(CultureInfo.InvariantCulture);
+                    dummyData["y"] = y.GetValueOrDefault();
                 }
                 if (z.HasValue)
                 {
-                    response = response + @", ""z"":" + ((decimal)z).ToString(CultureInfo.InvariantCulture);
+                    dummyData["z"] = z.GetValueOrDefault();
                 }
-                response = response + @", ""stations"":[]";
-                response = response + @", ""bodies"":[]}";
+                dummyData["stations"] = new Dictionary<string, object>();
+                dummyData["bodies"] = new Dictionary<string, object>();
+                response = JsonConvert.SerializeObject(dummyData);
                 Logging.Info("Generating dummy response " + response);
             }
             return StarSystemFromEDDP(response, x, y, z);

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -5,6 +5,7 @@ using CSCore.Streams.Effects;
 using EddiDataDefinitions;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Security;
@@ -373,8 +374,12 @@ namespace EddiSpeechService
                 }
                 catch (Exception ex)
                 {
-                    Logging.Warn("speech failed: ", ex);
-                    Logging.Error("Speech failed", @"{""speech"":""" + speech + @"""}");
+                    Logging.Warn("Speech failed: ", ex);
+                    var badSpeech = new Dictionary<string, object>() {
+                        {"speech", speech},
+                    };
+                    string badSpeechJSON = JsonConvert.SerializeObject(badSpeech);
+                    Logging.Error("Speech failed", badSpeechJSON);
                 }
             });
             synthThread.Start();

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using EddiDataDefinitions;
+
+namespace Tests
+{
+    [TestClass]
+    public class CommodityTests
+    {
+        [TestMethod]
+        public void TestMalformedCommodityName()
+        {
+            string malformedCommodityName = "I gotta quote\" and a backslash\\, I'm really bad.";
+            var badCommoditity = CommodityDefinitions.FromName(malformedCommodityName);
+            Assert.AreEqual(badCommoditity.name, malformedCommodityName);
+        }
+    }
+}

--- a/Tests/DataProviderTests.cs
+++ b/Tests/DataProviderTests.cs
@@ -15,6 +15,13 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TestDataProviderMalformedSystem()
+        {
+            StarSystem starSystem = DataProviderService.GetSystemData("Malformed with quote\" and backslash\\. So evil", null, null, null);
+            Assert.IsNotNull(starSystem);
+        }
+
+        [TestMethod]
         public void TestDataProviderBodies()
         {
             // Force obtain the data from remote source

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -133,6 +133,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="CommodityTests.cs" />
     <Compile Include="DiffTests.cs" />
     <Compile Include="EddnTests.cs" />
     <Compile Include="DataDefinitionTests.cs" />


### PR DESCRIPTION
After investigation, this is the correct fix for #337.

The root cause was code that was creating malformed JSON by just putting quotes around strings rather than properly encoding them via Newtonsoft.JSON.

Note to team: (@Hoodathunk  @Tkael) 
This was informative. Lessons learned:
 
1. The obvious approach of banning the offending input is not necessarily the right answer and might even mask a deeper problem.
2. It is a mistake to write string manipulation code that makes JSON from untrusted input: use the provided libraries instead, even though it means creating an object and feeding it to the library.
3. Let's keep an eye out for similar code.
