### PR TITLE
Hotfix 395 voiceattack events

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,8 @@
 ﻿# CHANGE LOG
 
 ### 3.0.0-b2
+  * Core
+    * Squashed a bug with the status monitor that was preventing events from being detected in VoiceAttack and was messing up some other variables.
 
 ### 3.0.0-b1
   * UI

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -115,10 +115,6 @@ namespace Eddi
         public string Vehicle { get; private set; } = Constants.VEHICLE_SHIP;
         public Ship CurrentShip { get; set; }
 
-        // Session state
-        public Status CurrentStatus { get; private set; } = new Status();
-        public Status LastStatus { get; private set; } = new Status();
-
         public ObservableConcurrentDictionary<string, object> State = new ObservableConcurrentDictionary<string, object>();
 
         /// <summary>
@@ -1305,35 +1301,11 @@ namespace Eddi
 
         private bool eventStatus(StatusEvent theEvent)
         {
-            if (Instance.CurrentStatus != theEvent.status)
+            if (theEvent.status.supercruise == true)
             {
-                // Update global variables
-
-                Instance.LastStatus = Instance.CurrentStatus;
-                Instance.CurrentStatus = theEvent.status;
-                if (theEvent.status.supercruise == true)
-                {
-                    Instance.Environment = Constants.ENVIRONMENT_SUPERCRUISE;
-                }
-                Instance.Vehicle = theEvent.status.vehicle;
-
-                // Trigger events for changed status, as applicable
-
-                if (Instance.LastStatus.near_surface != Instance.CurrentStatus.near_surface)
-                {
-                    Instance.eventHandler(new NearSurfaceEvent(theEvent.timestamp, theEvent.status.near_surface));
-                }
-
-                if (Instance.LastStatus.srv_turret_deployed != Instance.CurrentStatus.srv_turret_deployed)
-                {
-                    Instance.eventHandler(new SRVTurretEvent(theEvent.timestamp, theEvent.status.srv_turret_deployed));
-                }
-
-                if (Instance.LastStatus.srv_under_ship != Instance.CurrentStatus.srv_under_ship)
-                {
-                    Instance.eventHandler(new SRVUnderShipEvent(theEvent.timestamp));
-                }
+                Environment = Constants.ENVIRONMENT_SUPERCRUISE;
             }
+            Vehicle = theEvent.status.vehicle;
             return true;
         }
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -198,11 +198,6 @@ namespace EddiShipMonitor
             {
                 handleModuleTransferEvent((ModuleTransferEvent)@event);
             }
-            else if (@event is StatusEvent)
-            {
-                handleStatusEvent((StatusEvent)@event);
-            }
-
         }
 
         // Set the ship name conditionally, avoiding filtered names
@@ -669,27 +664,6 @@ namespace EddiShipMonitor
         private void handleModuleTransferEvent(ModuleTransferEvent @event)
         {
             // We don't do anything here as the ship object is unaffected
-        }
-
-        private void handleStatusEvent(StatusEvent @event)
-        {
-            // Trigger events for changed status, as applicable
-
-            if (EDDI.Instance.LastStatus.fsd_status != EDDI.Instance.CurrentStatus.fsd_status)
-            {
-                if (@event.status.fsd_status != "ready") // Don't trigger events for "ready" status
-                {
-                    EDDI.Instance.eventHandler(new ShipFsdEvent(@event.timestamp, @event.status.fsd_status));
-                }
-            }
-
-            if (EDDI.Instance.LastStatus.low_fuel != EDDI.Instance.CurrentStatus.low_fuel)
-            {
-                if (@event.status.low_fuel) // Don't trigger 'low fuel' event when fuel exceeds 25%
-                {
-                    EDDI.Instance.eventHandler(new ShipLowFuelEvent(@event.timestamp));
-                }
-            }
         }
 
         public void PostHandle(Event @event)

--- a/SpeechResponder/EddiSpeechResponder.csproj
+++ b/SpeechResponder/EddiSpeechResponder.csproj
@@ -140,6 +140,10 @@
       <Project>{19572A69-C13A-459D-AB72-2B0F034AC27F}</Project>
       <Name>EddiSpeechService</Name>
     </ProjectReference>
+    <ProjectReference Include="..\StatusMonitor\EddiStatusMonitor.csproj">
+      <Project>{fec7ba2b-23c3-4f4f-96ef-bf1f1909eb03}</Project>
+      <Name>EddiStatusMonitor</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Utilities\Utilities.csproj">
       <Project>{CD71DD2A-86AC-44A8-959B-E1C3069966BD}</Project>
       <Name>Utilities</Name>

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.IO;
 using EddiDataDefinitions;
 using EddiShipMonitor;
+using EddiStatusMonitor;
 
 namespace EddiSpeechResponder
 {
@@ -227,9 +228,9 @@ namespace EddiSpeechResponder
                 dict["station"] = new ReflectionValue(EDDI.Instance.CurrentStation);
             }
 
-            if (EDDI.Instance.CurrentStatus != null)
+            if (StatusMonitor.currentStatus != null)
             {
-                dict["status"] = new ReflectionValue(EDDI.Instance.CurrentStatus);
+                dict["status"] = new ReflectionValue(StatusMonitor.currentStatus);
             }
 
             if (theEvent != null)

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using Eddi;
 using EddiEvents;
+using EddiShipMonitor;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -11,7 +12,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Utilities;
 using EddiDataDefinitions;
-using EddiShipMonitor;
 
 namespace EddiStatusMonitor
 {
@@ -22,7 +22,8 @@ namespace EddiStatusMonitor
         private static Regex JsonRegex = new Regex(@"^{.*}$");
         private string Directory = GetSavedGamesDir();
         private string statusFileName;
-        private Status status { get; set; }
+        public static Status currentStatus { get; set; } = new Status();
+        public static Status lastStatus { get; set; } = new Status();
 
         // Keep track of status
         private bool running;
@@ -151,7 +152,7 @@ namespace EddiStatusMonitor
             return null;
         }
 
-        public static List<Event> ParseStatusEntry(string line)
+        public List<Event> ParseStatusEntry(string line)
         {
             List<Event> events = new List<Event>();
             try
@@ -194,7 +195,7 @@ namespace EddiStatusMonitor
                     {
                         case "Status":
                             {
-                                Status status = new Status();
+                                Status status = currentStatus;
 
                                 status.flags = JsonParsing.getLong(data, "Flags");
                                 if (status.flags > 0)
@@ -260,8 +261,7 @@ namespace EddiStatusMonitor
                                 status.altitude = JsonParsing.getOptionalDecimal(data, "Altitude");
                                 status.heading = JsonParsing.getOptionalDecimal(data, "Heading");
 
-                                // Update the global current status variable
-                                EDDI.Instance.eventHandler(new StatusEvent(timestamp, status));
+                                handleStatus(timestamp, status);
                             }
                             handled = true;
                             break;
@@ -279,6 +279,47 @@ namespace EddiStatusMonitor
                 Logging.Error("Exception whilst parsing Status.json line", line);
             }
             return events;
+        }
+
+        private void handleStatus(DateTime timestamp, Status thisStatus)
+        {
+            // Save our last status for reference and update our current status
+            lastStatus = currentStatus;
+            currentStatus = thisStatus;
+
+            if (currentStatus != thisStatus)
+            {
+                // Post a status event to share the new status with other monitors and responders 
+                EDDI.Instance.eventHandler(new StatusEvent(timestamp, thisStatus));
+
+                // Trigger events for changed status, as applicable
+                if (lastStatus.near_surface != thisStatus.near_surface)
+                {
+                    EDDI.Instance.eventHandler(new NearSurfaceEvent(timestamp, thisStatus.near_surface));
+                }
+                if (lastStatus.srv_turret_deployed != thisStatus.srv_turret_deployed)
+                {
+                    EDDI.Instance.eventHandler(new SRVTurretEvent(timestamp, thisStatus.srv_turret_deployed));
+                }
+                if (lastStatus.srv_under_ship != thisStatus.srv_under_ship)
+                {
+                    EDDI.Instance.eventHandler(new SRVUnderShipEvent(timestamp));
+                }
+                if (lastStatus.fsd_status != thisStatus.fsd_status)
+                {
+                    if (thisStatus.fsd_status != "ready") // Don't trigger events for "ready" status
+                    {
+                        EDDI.Instance.eventHandler(new ShipFsdEvent(timestamp, thisStatus.fsd_status));
+                    }
+                }
+                if (lastStatus.low_fuel != thisStatus.low_fuel)
+                {
+                    if (thisStatus.low_fuel) // Don't trigger 'low fuel' event when fuel exceeds 25%
+                    {
+                        EDDI.Instance.eventHandler(new ShipLowFuelEvent(timestamp));
+                    }
+                }
+            }
         }
 
         private static string GetSavedGamesDir()
@@ -345,7 +386,7 @@ namespace EddiStatusMonitor
             return null;
         }
 
-        private static Status ParseFlags(DateTime timestamp, long flags, string line, Status status)
+        private Status ParseFlags(DateTime timestamp, long flags, string line, Status status)
         {
             int value;
 
@@ -411,7 +452,7 @@ namespace EddiStatusMonitor
                 status.fsd_status = "cooldown";
                 flags = flags - value;
             }
-            if (EDDI.Instance.LastStatus.fsd_status == "cooldown" && EDDI.Instance.CurrentStatus.fsd_status != "cooldown")
+            if (lastStatus.fsd_status == "cooldown" && currentStatus.fsd_status != "cooldown")
             {
                 status.fsd_status = "cooldown complete";
             }
@@ -422,7 +463,7 @@ namespace EddiStatusMonitor
                 status.fsd_status = "charging";
                 flags = flags - value;
             }
-            if (EDDI.Instance.LastStatus.fsd_status == "charging" && EDDI.Instance.CurrentStatus.fsd_status != "charging")
+            if (lastStatus.fsd_status == "charging" && currentStatus.fsd_status != "charging")
             {
                 status.fsd_status = "charging complete";
             }
@@ -433,7 +474,7 @@ namespace EddiStatusMonitor
                 status.fsd_status = "masslock";
                 flags = flags - value;
             }
-            if (EDDI.Instance.LastStatus.fsd_status == "masslock" && EDDI.Instance.CurrentStatus.fsd_status != "masslock")
+            if (lastStatus.fsd_status == "masslock" && currentStatus.fsd_status != "masslock")
             {
                 status.fsd_status = "masslock cleared";
             }

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -307,7 +307,7 @@ namespace EddiStatusMonitor
                 EDDI.Instance.eventHandler(new StatusEvent(timestamp, thisStatus));
 
                 // Trigger events for changed status, as applicable
-                if (lastStatus.near_surface != thisStatus.near_surface)
+                if (lastStatus.near_surface != thisStatus.near_surface && thisStatus.vehicle == Constants.VEHICLE_SHIP)
                 {
                     EDDI.Instance.eventHandler(new NearSurfaceEvent(timestamp, thisStatus.near_surface));
                 }
@@ -319,7 +319,7 @@ namespace EddiStatusMonitor
                 {
                     EDDI.Instance.eventHandler(new SRVUnderShipEvent(timestamp));
                 }
-                if (lastStatus.fsd_status != thisStatus.fsd_status)
+                if (lastStatus.fsd_status != thisStatus.fsd_status && thisStatus.vehicle == Constants.VEHICLE_SHIP)
                 {
                     if (thisStatus.fsd_status != "ready") // Don't trigger events for "ready" status
                     {

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -195,7 +195,7 @@ namespace EddiStatusMonitor
                     {
                         case "Status":
                             {
-                                Status status = currentStatus;
+                                Status status = new Status();
 
                                 status.flags = JsonParsing.getLong(data, "Flags");
                                 if (status.flags > 0)
@@ -283,12 +283,12 @@ namespace EddiStatusMonitor
 
         private void handleStatus(DateTime timestamp, Status thisStatus)
         {
-            // Save our last status for reference and update our current status
-            lastStatus = currentStatus;
-            currentStatus = thisStatus;
-
             if (currentStatus != thisStatus)
             {
+                // Save our last status for reference and update our current status
+                lastStatus = currentStatus;
+                currentStatus = thisStatus;
+
                 // Post a status event to share the new status with other monitors and responders 
                 EDDI.Instance.eventHandler(new StatusEvent(timestamp, thisStatus));
 

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -111,7 +111,7 @@ namespace EddiStatusMonitor
                                     Logging.Info("Error locating Elite Dangerous Status.json. Status monitor is not active. Have you installed and run Elite Dangerous previously? ");
                                     while (fileInfo == null)
                                     {
-                                        Thread.Sleep(500);
+                                        Thread.Sleep(1000);
                                         fileInfo = FindStatusFile(Directory, Filter);
                                     }
                                     Logging.Info("Elite Dangerous Status.json found. Status monitor activated.");
@@ -138,7 +138,7 @@ namespace EddiStatusMonitor
                                 }
                                 lastStatus = thisStatus;
                             }
-                            Thread.Sleep(250);
+                            Thread.Sleep(500);
                         }
                     }
                 }

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -328,7 +328,8 @@ namespace EddiStatusMonitor
                 }
                 if (lastStatus.low_fuel != thisStatus.low_fuel)
                 {
-                    if (thisStatus.low_fuel) // Don't trigger 'low fuel' event when fuel exceeds 25%
+                    // Don't trigger 'low fuel' event when fuel exceeds 25% or when we're not in our ship
+                    if (thisStatus.low_fuel && thisStatus.vehicle == Constants.VEHICLE_SHIP) 
                     {
                         EDDI.Instance.eventHandler(new ShipLowFuelEvent(timestamp));
                     }

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -134,7 +134,7 @@ namespace EddiStatusMonitor
                         // file open elsewhere or being written, just wait for the next pass
                     }
                 }
-                Thread.Sleep(100);
+                Thread.Sleep(250);
             }
         }
 

--- a/VoiceAttackResponder/EddiVoiceAttackResponder.csproj
+++ b/VoiceAttackResponder/EddiVoiceAttackResponder.csproj
@@ -109,6 +109,10 @@
       <Project>{6614E6AD-65AE-49FC-850B-9DF79D1CC998}</Project>
       <Name>EddiStarMapService</Name>
     </ProjectReference>
+    <ProjectReference Include="..\StatusMonitor\EddiStatusMonitor.csproj">
+      <Project>{fec7ba2b-23c3-4f4f-96ef-bf1f1909eb03}</Project>
+      <Name>EddiStatusMonitor</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Utilities\Utilities.csproj">
       <Project>{cd71dd2a-86ac-44a8-959b-e1c3069966bd}</Project>
       <Name>Utilities</Name>

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -1,5 +1,13 @@
-﻿using EddiDataProviderService;
+﻿using Eddi;
+using EddiEvents;
+using EddiDataProviderService;
 using EddiDataDefinitions;
+using EddiShipMonitor;
+using EddiSpeechResponder;
+using EddiSpeechService;
+using EddiStatusMonitor;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,17 +15,10 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Diagnostics;
 using System.Windows;
-using EddiSpeechService;
-using Utilities;
-using Eddi;
-using EddiEvents;
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using EddiSpeechResponder;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using EddiShipMonitor;
+using Utilities;
 
 namespace EddiVoiceAttackResponder
 {
@@ -1070,7 +1071,7 @@ namespace EddiVoiceAttackResponder
 
             try
             {
-                setStatusValues(EDDI.Instance.CurrentStatus, "Status", ref vaProxy);
+                setStatusValues(StatusMonitor.currentStatus, "Status", ref vaProxy);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix for #395. VoiceAttack receives events again. The status monitor is more contained than it was before.