### PR TITLE
Fix for #407. EDDI will no longer try to sync your full flight log every time it loads

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,6 +4,7 @@
   * Core
     * Squashed a bug with the status monitor that was preventing events from being detected in VoiceAttack and was messing up some other variables.
 	* EDDI will no longer try to sync data from EDSM while the EDSM responder is disabled, and when syncing EDSM data EDDI will now writes to the local SQL database in batches.
+	* Squashed a bug that was causing EDDI to request and re-process complete EDSM flight logs on every load. Now it'll only request the new stuff since it's last update.
   * Update Server
     * Fixed the outdated TLS protocol usage on EDDI's side whereby the update server began refusing to talk to existing releases of EDDI.
 	  * In future, EDDI will let you know if it cannot reach its update server for any reason.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,6 +3,7 @@
 ### 3.0.0-b2
   * Core
     * Squashed a bug with the status monitor that was preventing events from being detected in VoiceAttack and was messing up some other variables.
+	* EDDI will no longer try to sync data from EDSM while the EDSM responder is disabled, and when syncing EDSM data EDDI will now writes to the local SQL database in batches.
   * Update Server
     * Fixed the outdated TLS protocol usage on EDDI's side whereby the update server began refusing to talk to existing releases of EDDI.
 	  * In future, EDDI will let you know if it cannot reach its update server for any reason.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,8 +3,8 @@
 ### 3.0.0-b2
   * Core
     * Squashed a bug with the status monitor that was preventing events from being detected in VoiceAttack and was messing up some other variables.
-	* EDDI will no longer try to sync data from EDSM while the EDSM responder is disabled, and when syncing EDSM data EDDI will now writes to the local SQL database in batches.
-	* Squashed a bug that was causing EDDI to request and re-process complete EDSM flight logs on every load. Now it'll only request the new stuff since it's last update.
+	* EDDI will no longer try to sync data from EDSM while the EDSM responder is disabled, and when syncing EDSM data EDDI will now write to the local SQL database in batches.
+	* Squashed a bug that was causing EDDI to request and re-process complete EDSM flight logs on every load. Now it'll only request the new stuff since its last update.
   * Update Server
     * Fixed the outdated TLS protocol usage on EDDI's side whereby the update server began refusing to talk to existing releases of EDDI.
 	  * In future, EDDI will let you know if it cannot reach its update server for any reason.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -202,10 +202,7 @@ namespace Eddi
                         starMapService = new StarMapService(starMapCredentials.apiKey, commanderName);
                         Logging.Info("EDDI access to EDSM is enabled");
                     }
-                    // Spin off a thread to download & sync EDSM flight logs & system comments in the background
-                    Thread updateThread = new Thread(() => starMapService.Sync(starMapCredentials.lastSync));
-                    updateThread.IsBackground = true;
-                    updateThread.Start();
+
                 }
                 if (starMapService == null)
                 {

--- a/EDSMResponder/ConfigurationWindow.xaml.cs
+++ b/EDSMResponder/ConfigurationWindow.xaml.cs
@@ -109,6 +109,8 @@ namespace EddiEdsmResponder
                 Dictionary<string, string> comments = starMapService.getStarMapComments();
                 int total = systems.Count;
                 int i = 0;
+                List<StarSystem> syncSystems = new List<StarSystem>();
+
                 foreach (string system in systems.Keys)
                 {
                     progress.Report("Obtaining log " + i++ + "/" + total);
@@ -119,8 +121,19 @@ namespace EddiEdsmResponder
                     {
                         CurrentStarSystem.comment = comments[system];
                     }
-                    StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                    syncSystems.Add(CurrentStarSystem);
+
+                    if (syncSystems.Count == StarMapService.syncBatchSize)
+                    {
+                        StarMapService.saveStarSystems(syncSystems);
+                        syncSystems.Clear();
+                    }
                 }
+                if (syncSystems.Count > 0)
+                {
+                    StarMapService.saveStarSystems(syncSystems);
+                }
+
                 progress.Report("Obtained log");
             }
             catch (EDSMException edsme)

--- a/EDSMResponder/ConfigurationWindow.xaml.cs
+++ b/EDSMResponder/ConfigurationWindow.xaml.cs
@@ -113,7 +113,8 @@ namespace EddiEdsmResponder
 
                 foreach (string system in systems.Keys)
                 {
-                    progress.Report("Obtaining log " + i++ + "/" + total);
+                    ++i;
+                    progress.Report($"Obtaining log {i}/{total}");
                     StarSystem CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(system, false);
                     CurrentStarSystem.visits = systems[system].visits;
                     CurrentStarSystem.lastvisit = systems[system].lastVisit;

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -4,6 +4,7 @@ using EddiEvents;
 using EddiShipMonitor;
 using EddiStarMapService;
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Controls;
 using Utilities;
 
@@ -37,6 +38,13 @@ namespace EddiEdsmResponder
         public bool Start()
         {
             Reload();
+
+            // Spin off a thread to download & sync EDSM flight logs & system comments in the background
+            StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
+            Thread updateThread = new Thread(() => starMapService.Sync(starMapCredentials.lastSync));
+            updateThread.IsBackground = true;
+            updateThread.Start();
+
             return starMapService != null;
         }
 

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -498,10 +498,13 @@ namespace EddiStarMapService
             var request = new RestRequest("api-logs-v1/get-logs", Method.POST);
             request.AddParameter("apiKey", apiKey);
             request.AddParameter("commanderName", commanderName);
-            request.AddParameter("fullSync", 1);
             if (since.HasValue)
             {
                 request.AddParameter("startdatetime", since.Value.ToString("yyyy-MM-dd HH:mm:ss"));
+            }
+            else
+            {
+                request.AddParameter("fullSync", 1);
             }
             var starMapLogResponse = client.Execute<StarMapLogResponse>(request);
             StarMapLogResponse response = starMapLogResponse.Data;


### PR DESCRIPTION
and now batch processes / writes sync data to its database as suggested in #407.