### PR TITLE
Fix FireGroup typo

### DIFF
--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -222,7 +222,7 @@ namespace EddiStatusMonitor
                                 status.pips_eng = pips != null ? ((decimal?)pips[1] / 2) : null; // Set engine pips (converting from half pips)
                                 status.pips_wea = pips != null ? ((decimal?)pips[2] / 2) : null; // Set weapon pips (converting from half pips)
 
-                                status.firegroup = JsonParsing.getOptionalInt(data, "Firegroup");
+                                status.firegroup = JsonParsing.getOptionalInt(data, "FireGroup");
                                 int? gui_focus = JsonParsing.getOptionalInt(data, "GuiFocus");
                                 switch (gui_focus)
                                 {


### PR DESCRIPTION
FD's _Status.json_ text is "FireGroup", typo'ed in StatusMonitor.cs as "Firegroup" 
Causes variable {INT:Status firegroup} to be returned as unset.

_Example data from Status.json_
{ "timestamp":"2018-03-10T19:14:50Z", "event":"Status", "Flags":16777224, "Pips":[4,4,4], "FireGroup":1, "GuiFocus":0 }