### PR TITLE
Add Body approached event

### DIFF
--- a/Events/BodyApproachedEvent.cs
+++ b/Events/BodyApproachedEvent.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class BodyApproachedEvent : Event
+    {
+        public const string NAME = "Body approached";
+        public const string DESCRIPTION = "Triggered when you approach a landable planet and enter orbital cruise";
+        public const string SAMPLE = @"{ ""timestamp"":""2016-09-22T15:24:14Z"", ""event"":""ApproachBody"", ""StarSystem"":""Eranin"", ""Body"":""Eranin 2""}";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static BodyApproachedEvent()
+        {
+            VARIABLES.Add("system", "The name of the starsystem");
+            VARIABLES.Add("body", "The name of the body");
+        }
+
+        public string system { get; private set; }
+        public string body { get; private set; }
+
+        public BodyApproachedEvent(DateTime timestamp, string system, string body) : base(timestamp, NAME)
+        {
+            this.system = system;
+            this.body = body;
+        }
+    }
+}

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BeltScannedEvent.cs" />
+    <Compile Include="BodyApproachedEvent.cs" />
     <Compile Include="ShutdownEvent.cs" />
     <Compile Include="StatusEvent.cs" />
     <Compile Include="VAInitialized.cs" />

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -540,6 +540,20 @@ namespace EddiJournalMonitor
                             events.Add(new CockpitBreachedEvent(timestamp) { raw = line });
                             handled = true;
                             break;
+                        case "ApproachBody":
+                            {
+                                string system = JsonParsing.getString(data, "StarSystem");
+                                string body = JsonParsing.getString(data, "Body");
+                                events.Add(new BodyApproachedEvent(timestamp, system, body) { raw = line });
+                            }
+                            handled = true;
+                            break;
+                        case "LeaveBody":
+                            {
+                                events.Add(new BodyApproachedEvent(timestamp, null, null) { raw = line });
+                            }
+                            handled = true;
+                            break;
                         case "ApproachSettlement":
                             {
                                 object val;


### PR DESCRIPTION
Didn't see in the TODO list, I find it to be useful info for planetary navigation (GPS).

Triggered when you cross the orbital cruise threshold at a planetary body. The variables are set when transitioning to orbital cruise on the way down and are cleared when exiting from orbital cruise on the way up.

When using this event in the Speech responder the information about this event is available under the event object. 
The available variables are as follows:
system - The name of the system that the planet is in.
body -    The name of the planet.

To use this event in VoiceAttack, create a command entitled ((EDDI body approached)). 
The event information can be accessed using the following VoiceAttack variables
{TXT:EDDI body approached system} - the system that the planet is in.
{TXT:EDDI body approached body} - the name of the planet.