### PR TITLE
Fix for #305. Run actions to update the shipmonitor in the dispatcher thread.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ### 3.0.0-b2
   * Core
+    * Squashed a bug that was preventing EDDI from correctly registering changes to the shipyard.
     * Squashed a bug with the status monitor that was preventing events from being detected in VoiceAttack and was messing up some other variables.
 	* EDDI will no longer try to sync data from EDSM while the EDSM responder is disabled, and when syncing EDSM data EDDI will now write to the local SQL database in batches.
 	* Squashed a bug that was causing EDDI to request and re-process complete EDSM flight logs on every load. Now it'll only request the new stuff since its last update.

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -14,6 +14,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using Utilities;
+using System.Windows.Data;
 
 namespace EddiShipMonitor
 {
@@ -22,12 +23,13 @@ namespace EddiShipMonitor
         private static List<string> HARDPOINT_SIZES = new List<string>() { "Huge", "Large", "Medium", "Small", "Tiny" };
 
         // Observable collection for us to handle changes
-        public ObservableCollection<Ship> shipyard = new ObservableCollection<Ship>();
+        public ObservableCollection<Ship> shipyard { get; private set; }
+
         // The ID of the current ship; can be null
         private int? currentShipId;
         private int? currentProfileId;
         private static readonly object shipyardLock = new object();
-        SynchronizationContext uiSyncContext;
+        public event EventHandler ShipyardUpdatedEvent;
 
         public string MonitorName()
         {
@@ -51,9 +53,25 @@ namespace EddiShipMonitor
 
         public ShipMonitor()
         {
-            uiSyncContext = SynchronizationContext.Current ?? new SynchronizationContext();
+            shipyard = new ObservableCollection<Ship>();
+            BindingOperations.CollectionRegistering += Shipyard_CollectionRegistering;
+
             readShips();
             Logging.Info("Initialised " + MonitorName() + " " + MonitorVersion());
+        }
+
+        private void Shipyard_CollectionRegistering(object sender, CollectionRegisteringEventArgs e)
+        {
+            if (Application.Current != null)
+            {
+                // Synchronize this collection between threads
+                BindingOperations.EnableCollectionSynchronization(shipyard, shipyardLock);
+            }
+            else
+            {
+                // If started from VoiceAttack, the dispatcher is on a different thread. Invoke synchronization there.
+                Dispatcher.CurrentDispatcher.Invoke(() => { BindingOperations.EnableCollectionSynchronization(shipyard, shipyardLock); });
+            }
         }
 
         public bool NeedsStart()
@@ -83,7 +101,7 @@ namespace EddiShipMonitor
 
         public void Save()
         {
-            uiSyncContext.Send(_ => writeShips(), null);
+            writeShips();
         }
 
         /// <summary>
@@ -259,7 +277,7 @@ namespace EddiShipMonitor
                 Ship storedShip = GetShip(@event.storedshipid);
                 if (storedShip != null)
                 {
-                    // Set location of stored ship to the current sstem
+                    // Set location of stored ship to the current system
                     storedShip.starsystem = EDDI.Instance?.CurrentStarSystem?.name;
                     storedShip.station = EDDI.Instance?.CurrentStation?.name;
                 }
@@ -316,14 +334,12 @@ namespace EddiShipMonitor
         private void handleShipSoldEvent(ShipSoldEvent @event)
         {
             RemoveShip(@event.shipid);
-
             writeShips();
         }
 
         private void handleShipSoldOnRebuyEvent(ShipSoldOnRebuyEvent @event)
         {
             RemoveShip(@event.shipid);
-
             writeShips();
         }
 
@@ -677,7 +693,7 @@ namespace EddiShipMonitor
         private void posthandleShipLoadoutEvent(ShipLoadoutEvent @event)
         {
             /// The ship may have engineering data, request a profile refresh from the Frontier API a minute after switching
-            refreshProfileDelayed(@event.shipid, currentProfileId);
+            refreshProfileDelayed(@event.shipid, currentProfileId).GetAwaiter().GetResult();
         }
 
         private void handleCargoInventoryEvent(CargoInventoryEvent @event)
@@ -817,6 +833,8 @@ namespace EddiShipMonitor
                 };
                 configuration.ToFile();
             }
+            // Make sure the UI is up to date
+            RaiseOnUIThread(ShipyardUpdatedEvent, shipyard);
         }
 
         private void readShips()
@@ -847,9 +865,10 @@ namespace EddiShipMonitor
             {
                 ship.role = Role.MultiPurpose;
             }
-
-            // Run this on the UI syncContext to ensure that we can update it whilst reflecting changes in the UI
-            uiSyncContext.Send(_ => _AddShip(ship), null);
+            // Remove the ship first (just in case we are trying to add a ship that already exists)
+            _RemoveShip(ship.LocalId);
+            _AddShip(ship);
+            writeShips();
         }
 
         private void _AddShip(Ship ship)
@@ -860,10 +879,7 @@ namespace EddiShipMonitor
             }
             lock (shipyardLock)
             {
-                // Remove the ship first (just in case we are trying to add a ship that already exists)
-                RemoveShip(ship.LocalId);
                 shipyard.Add(ship);
-                writeShips();
             }
         }
 
@@ -872,12 +888,12 @@ namespace EddiShipMonitor
         /// </summary>
         private void RemoveShip(int? localid)
         {
-            if(localid == null)
+            if (localid == null)
             {
                 return;
             }
-            // Run this on the UI syncContext to ensure that we can update it whilst reflecting changes in the UI
-            uiSyncContext.Send(_ => _RemoveShip(localid), null);
+            _RemoveShip(localid);
+            writeShips();
         }
 
         /// <summary>
@@ -896,7 +912,6 @@ namespace EddiShipMonitor
                     if (shipyard[i].LocalId == localid)
                     {
                         shipyard.RemoveAt(i);
-                        writeShips();
                         break;
                     }
                 }
@@ -1174,7 +1189,7 @@ namespace EddiShipMonitor
             return (model == "Empire_Fighter" || model == "Federation_Fighter" || model == "Independent_Fighter" || model == "TestBuggy");
         }
 
-        static async void refreshProfileDelayed(int? shipId, int? profileId)
+        static async Task refreshProfileDelayed(int? shipId, int? profileId)
         {
             do
             {
@@ -1182,6 +1197,22 @@ namespace EddiShipMonitor
                 EDDI.Instance.refreshProfile();
             } while (shipId != profileId);
             Logging.Debug("Current Ship Id is: " + shipId + ", Profile Ship Id is " + profileId);
+        }
+
+        static void RaiseOnUIThread(EventHandler handler, object sender)
+        {
+            if (handler != null)
+            {
+                SynchronizationContext uiSyncContext = SynchronizationContext.Current ?? new SynchronizationContext();
+                if (uiSyncContext == null)
+                {
+                    handler(sender, EventArgs.Empty);
+                }
+                else
+                {
+                    uiSyncContext.Send(delegate { handler(sender, EventArgs.Empty); }, null);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Verified that shipmonitor.json is being updated, EDDI's UI is being updated, and that no exceptions are thrown. Please test and confirm! :-)

- The shipyard now uses BindingOperations.EnableCollectionSynchronization to synchronize the collection between threads (note that the shipmonitor is not run on the same thread when used as a plugin from VoiceAttack and requires the use of the dispatcher to initiate the sync.
- Removed `uiSyncContext`. No longer required.
- Added `ShipyardUpdatedEvent`. This can be used to "force" a UI refresh (though it typically is not needed)
- Revised sequencing to prevent a lock from being called while already inside a lock. 
- Unrelated improvement: The `refreshProfileDelayed` method is now an async Task method, rather than an async void method.