### PR TITLE
Set a variable in VoiceAttack whenever EDDI speaks

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,9 @@
 ﻿# CHANGE LOG
 
 ### 3.0.0-b4
+  * VoiceAttack
+    * Added the following new variables
+      * `{BOOL:EDDI speaking}` True if EDDI is speaking, false otherwise. Useful for synchronizing speech between EDDI and other sources in VoiceAttack.
 
 ### 3.0.0-b3
   * Core

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -27,8 +27,8 @@ namespace EddiSpeechService
         private ISoundOut activeSpeech;
         private int activeSpeechPriority;
 
-        private static bool? _eddiSpeaking;
-        public static bool? eddiSpeaking
+        private static bool _eddiSpeaking;
+        public static bool eddiSpeaking
         {
             get
             {

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -57,7 +57,6 @@ namespace EddiVoiceAttackResponder
                 EDDI.Instance.State.CollectionChanged += (s, e) => setDictionaryValues(EDDI.Instance.State, "state", ref vaProxy);
 
                 SpeechService.Instance.PropertyChanged += (s, e) => setSpeaking(SpeechService.eddiSpeaking, "EDDI speaking", ref vaProxy);
-                if (!SpeechService.eddiSpeaking.HasValue) { SpeechService.eddiSpeaking = new bool(); } // Initialize this variable when the plugin loads
 
                 // Display instance information if available
                 if (EDDI.Instance.UpgradeRequired)

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -53,8 +53,11 @@ namespace EddiVoiceAttackResponder
                 GetEddiInstance(ref vaProxy);
                 EDDI.Instance.Start();
 
-                // Add a notifier for state changes
+                // Add notifiers for state and property changes 
                 EDDI.Instance.State.CollectionChanged += (s, e) => setDictionaryValues(EDDI.Instance.State, "state", ref vaProxy);
+
+                SpeechService.Instance.PropertyChanged += (s, e) => setSpeaking(SpeechService.eddiSpeaking, "EDDI speaking", ref vaProxy);
+                if (!SpeechService.eddiSpeaking.HasValue) { SpeechService.eddiSpeaking = new bool(); } // Initialize this variable when the plugin loads
 
                 // Display instance information if available
                 if (EDDI.Instance.UpgradeRequired)
@@ -1510,6 +1513,11 @@ namespace EddiVoiceAttackResponder
                 vaProxy.SetDecimal(prefix + " age", (decimal)(long)body.age);
             }
             Logging.Debug("Set body information (" + prefix + ")");
+        }
+
+        private static void setSpeaking(bool? eddiSpeaking, string key, ref dynamic vaProxy)
+        {
+            vaProxy.SetBoolean(key, eddiSpeaking);
         }
 
         private static void setStatus(ref dynamic vaProxy, string status, Exception exception = null)


### PR DESCRIPTION
Sets a variable in VoiceAttack to indicate whether EDDI is speaking at the moment. For synchronizing text to speech between EDDI and other sources.
Fix for #34.