### PR TITLE
#429 make installer respect any custom VoiceAttack location

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,6 +1,9 @@
 ﻿# CHANGE LOG
 
 ### 3.0.0-b4
+  * Installer
+    * First installations will now take any custom VoiceAttack installation location into account when proposing a location for EDDI.
+    * Upgrade installations will continue to use whatever location was selected in the first installation.
 
 ### 3.0.0-b3
   * Core

--- a/Installer.iss
+++ b/Installer.iss
@@ -19,7 +19,7 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName=C:\Program Files (x86)\VoiceAttack\Apps\{#MyAppName}
+DefaultDirName={reg:HKCU\Software\VoiceAttack.com\VoiceAttack,InstallPath|{pf32}\VoiceAttack}\Apps\{#MyAppName}
 DefaultGroupName={#MyAppName}
 SourceDir="{#SourcePath}\bin\Release"
 OutputDir="{#SourcePath}\bin\Installer"
@@ -96,4 +96,4 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 UseRelativePaths=True
 
 [Messages]
-SelectDirBrowseLabel=To continue, click Next.  If you have a custom VoiceAttack installation location, or would like to put the EDDI files in a different location, click Browse.
+SelectDirBrowseLabel=To continue, click Next. If this is not your VoiceAttack installation location, or would like to put the EDDI files in a different location, click Browse.

--- a/Installer.iss
+++ b/Installer.iss
@@ -96,4 +96,4 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 UseRelativePaths=True
 
 [Messages]
-SelectDirBrowseLabel=To continue, click Next. If this is not your VoiceAttack installation location, or would like to put the EDDI files in a different location, click Browse.
+SelectDirBrowseLabel=To continue, click Next. If this is not your VoiceAttack installation location, or you would like to put the EDDI files in a different location, click Browse.


### PR DESCRIPTION
Fix #429 by enhancing the InnoSetup script.

Note to testers: upgrade installations will continue to use whatever location the user set in the first installation. So to test this you will need to uninstall EDDI from the Apps control panel (back up your %APPDATA%\EDDI dir first!).
