### PR TITLE
EDDN `Docked` Event - sanity check

### DIFF
--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -18,10 +18,10 @@ namespace EDDNResponder
     public class EDDNResponder : EDDIResponder
     {
         // We keep track of the starsystem information locally
-        public string systemName = null;
-        public decimal? systemX = null;
-        public decimal? systemY = null;
-        public decimal? systemZ = null;
+        public string systemName { get; private set; } = null;
+        public decimal? systemX { get; private set; } = null;
+        public decimal? systemY { get; private set; } = null;
+        public decimal? systemZ { get; private set; } = null;
 
         public string ResponderName()
         {

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -383,7 +383,7 @@ namespace EDDNResponder
                 return true;
             }
 
-            StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(eventSystem);
+            StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetStarSystem(eventSystem);
             if (system != null)
             {
                 // Provide a fallback data source for system coordinate metadata if the eventSystem does not match the systemName we expected

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -165,10 +165,13 @@ namespace EDDNResponder
 
         private void handleDockedEvent(DockedEvent theEvent)
         {
-            // When we dock we have access to commodity and outfitting information
-            sendCommodityInformation();
-            sendOutfittingInformation();
-            sendShipyardInformation();
+            if (eventSystemNameMatches(theEvent.system))
+            {
+                // When we dock we have access to commodity and outfitting information
+                sendCommodityInformation();
+                sendOutfittingInformation();
+                sendShipyardInformation();
+            }
         }
 
         private void handleMarketInformationUpdatedEvent(MarketInformationUpdatedEvent theEvent)
@@ -370,6 +373,33 @@ namespace EDDNResponder
         public UserControl ConfigurationTabItem()
         {
             return null;
+        }
+
+        private bool eventSystemNameMatches(string eventSystem)
+        {
+            // Check to make sure the eventSystem given matches the systemName we expected to see.
+            if (systemName != eventSystem)
+            {
+                StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(eventSystem);
+                if (system != null)
+                {
+                    // Provide a fallback data source for system coordinate metadata if the eventSystem does not match the systemName we expected
+                    systemName = system.name;
+                    systemX = system.x;
+                    systemY = system.y;
+                    systemZ = system.z;
+                }
+                else
+                {
+                    // Set values to null if data isn't available. If any data is null, data shall not be sent to EDDN.
+                    systemName = eventSystem;
+                    systemX = null;
+                    systemY = null;
+                    systemZ = null;
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -378,28 +378,30 @@ namespace EDDNResponder
         public bool eventSystemNameMatches(string eventSystem)
         {
             // Check to make sure the eventSystem given matches the systemName we expected to see.
-            if (systemName != eventSystem)
+            if (systemName == eventSystem)
             {
-                StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(eventSystem);
-                if (system != null)
-                {
-                    // Provide a fallback data source for system coordinate metadata if the eventSystem does not match the systemName we expected
-                    systemName = system.name;
-                    systemX = system.x;
-                    systemY = system.y;
-                    systemZ = system.z;
-                }
-                else
-                {
-                    // Set values to null if data isn't available. If any data is null, data shall not be sent to EDDN.
-                    systemName = eventSystem;
-                    systemX = null;
-                    systemY = null;
-                    systemZ = null;
-                    return false;
-                }
+                return true;
             }
-            return true;
+
+            StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(eventSystem);
+            if (system != null)
+            {
+                // Provide a fallback data source for system coordinate metadata if the eventSystem does not match the systemName we expected
+                systemName = system.name;
+                systemX = system.x;
+                systemY = system.y;
+                systemZ = system.z;
+                return true;
+            }
+            else
+            {
+                // Set values to null if data isn't available. If any data is null, data shall not be sent to EDDN.
+                systemName = eventSystem;
+                systemX = null;
+                systemY = null;
+                systemZ = null;
+                return false;
+            }
         }
     }
 }

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -17,11 +17,11 @@ namespace EDDNResponder
     /// </summary>
     public class EDDNResponder : EDDIResponder
     {
-        // We keep a local track of the starsystem information
-        private string systemName = null;
-        private decimal? systemX = null;
-        private decimal? systemY = null;
-        private decimal? systemZ = null;
+        // We keep track of the starsystem information locally
+        public string systemName = null;
+        public decimal? systemX = null;
+        public decimal? systemY = null;
+        public decimal? systemZ = null;
 
         public string ResponderName()
         {
@@ -375,12 +375,12 @@ namespace EDDNResponder
             return null;
         }
 
-        private bool eventSystemNameMatches(string eventSystem)
+        public bool eventSystemNameMatches(string eventSystem)
         {
             // Check to make sure the eventSystem given matches the systemName we expected to see.
             if (systemName != eventSystem)
             {
-                StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(eventSystem);
+                StarSystem system = EddiDataProviderService.StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(eventSystem);
                 if (system != null)
                 {
                     // Provide a fallback data source for system coordinate metadata if the eventSystem does not match the systemName we expected

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -76,5 +76,29 @@ namespace Tests
             Assert.AreEqual(-63.1875M, (decimal)responder.systemY);
             Assert.AreEqual(-24.875M, (decimal)responder.systemZ);
         }
+
+        [TestMethod()]
+        public void TestEDDNResponderGoodInitialBadFinal()
+        {
+            EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
+            var privateObject = new PrivateObject(responder);
+
+            // The EDDN responder tracks system names and coordinates independently. 
+            // Intentionally place our EDDN responder in a state with no coordinates available.
+            privateObject.SetFieldOrProperty("systemName", "Sol");
+            privateObject.SetFieldOrProperty("systemX", 0.0M);
+            privateObject.SetFieldOrProperty("systemY", 0.0M);
+            privateObject.SetFieldOrProperty("systemZ", 0.0M);
+
+            // Force a call to the method
+            bool matched = responder.eventSystemNameMatches("Not in this galaxy");
+            Assert.IsFalse(matched);
+
+            // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
+            Assert.IsNull(responder.systemX);
+            Assert.IsNull(responder.systemY);
+            Assert.IsNull(responder.systemZ);
+        }
     }
 }
+

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -34,5 +34,30 @@ namespace Tests
                 }
             }
         }
+
+        [TestMethod()]
+        public void eventSystemNameMatchesTest()
+        {
+            EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
+            responder.Start();
+
+            /// The EDDN responder tracks system names and coordinates independently. 
+            /// Intentionally place our EDDN responder in a state with no coordinates available.
+            responder.systemName = "Not in this galaxy";
+            responder.systemX = null;
+            responder.systemY = null;
+            responder.systemZ = null;
+
+            // Force a call to the method
+            responder.eventSystemNameMatches("Artemis");
+
+            // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
+            Assert.AreEqual("Artemis", responder.systemName);
+            Assert.AreEqual(14.28125, (double)responder.systemX);
+            Assert.AreEqual(-63.1875, (double)responder.systemY);
+            Assert.AreEqual(-24.875, (double)responder.systemZ);
+
+            responder.Stop();
+        }
     }
 }

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -53,9 +53,9 @@ namespace Tests
 
             // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
             Assert.AreEqual("Artemis", responder.systemName);
-            Assert.AreEqual(14.28125, (double)responder.systemX);
-            Assert.AreEqual(-63.1875, (double)responder.systemY);
-            Assert.AreEqual(-24.875, (double)responder.systemZ);
+            Assert.AreEqual(14.28125, (double)responder.systemX, 0.00001);
+            Assert.AreEqual(-63.1875, (double)responder.systemY, 0.00001);
+            Assert.AreEqual(-24.875, (double)responder.systemZ, 0.00001);
 
             responder.Stop();
         }

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -43,19 +43,19 @@ namespace Tests
 
             // The EDDN responder tracks system names and coordinates independently. 
             // Intentionally place our EDDN responder in a state with no coordinates available.
-            privateObject.SetProperty("systemName", "Not in this galaxy");
-            privateObject.SetProperty("systemX", null);
-            privateObject.SetProperty("systemY", null);
-            privateObject.SetProperty("systemZ", null);
+            privateObject.SetFieldOrProperty("systemName", "Not in this galaxy");
+            privateObject.SetFieldOrProperty("systemX", null);
+            privateObject.SetFieldOrProperty("systemY", null);
+            privateObject.SetFieldOrProperty("systemZ", null);
 
             // Force a call to the method
             responder.eventSystemNameMatches("Artemis");
 
             // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
             Assert.AreEqual("Artemis", responder.systemName);
-            Assert.AreEqual(14.28125, (double)responder.systemX, 0.00001);
-            Assert.AreEqual(-63.1875, (double)responder.systemY, 0.00001);
-            Assert.AreEqual(-24.875, (double)responder.systemZ, 0.00001);
+            Assert.AreEqual(14.28125M, (decimal)responder.systemX);
+            Assert.AreEqual(-63.1875M, (decimal)responder.systemY);
+            Assert.AreEqual(-24.875M, (decimal)responder.systemZ);
         }
     }
 }

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -39,13 +39,14 @@ namespace Tests
         public void TestEventSystemNameMatches()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
+            var privateObject = new PrivateObject(responder);
 
-            /// The EDDN responder tracks system names and coordinates independently. 
-            /// Intentionally place our EDDN responder in a state with no coordinates available.
-            responder.systemName = "Not in this galaxy";
-            responder.systemX = null;
-            responder.systemY = null;
-            responder.systemZ = null;
+            // The EDDN responder tracks system names and coordinates independently. 
+            // Intentionally place our EDDN responder in a state with no coordinates available.
+            privateObject.SetProperty("systemName", "Not in this galaxy");
+            privateObject.SetProperty("systemX", null);
+            privateObject.SetProperty("systemY", null);
+            privateObject.SetProperty("systemZ", null);
 
             // Force a call to the method
             responder.eventSystemNameMatches("Artemis");

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -54,7 +54,7 @@ namespace Tests
         }
 
         [TestMethod()]
-        public void TestEDDNResponderBadInitialSystem()
+        public void TestEDDNResponderBadInitialGoodFinal()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             var privateObject = new PrivateObject(responder);
@@ -67,7 +67,8 @@ namespace Tests
             privateObject.SetFieldOrProperty("systemZ", null);
 
             // Force a call to the method
-            responder.eventSystemNameMatches("Artemis");
+            bool matched = responder.eventSystemNameMatches("Artemis");
+            Assert.IsTrue(matched);
 
             // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
             Assert.AreEqual("Artemis", responder.systemName);

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -36,7 +36,7 @@ namespace Tests
         }
 
         [TestMethod()]
-        public void eventSystemNameMatchesTest()
+        public void TestEventSystemNameMatches()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             responder.Start();

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -36,7 +36,7 @@ namespace Tests
         }
 
         [TestMethod()]
-        public void TestEventSystemNameMatches()
+        public void TestEDDNResponderBadInitialSystem()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             var privateObject = new PrivateObject(responder);

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -39,7 +39,6 @@ namespace Tests
         public void TestEventSystemNameMatches()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
-            responder.Start();
 
             /// The EDDN responder tracks system names and coordinates independently. 
             /// Intentionally place our EDDN responder in a state with no coordinates available.
@@ -56,8 +55,6 @@ namespace Tests
             Assert.AreEqual(14.28125, (double)responder.systemX, 0.00001);
             Assert.AreEqual(-63.1875, (double)responder.systemY, 0.00001);
             Assert.AreEqual(-24.875, (double)responder.systemZ, 0.00001);
-
-            responder.Stop();
         }
     }
 }

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -40,16 +40,13 @@ namespace Tests
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             var privateObject = new PrivateObject(responder);
-
-            // The EDDN responder tracks system names and coordinates independently. 
-            // Intentionally place our EDDN responder in a state with no coordinates available.
             privateObject.SetFieldOrProperty("systemName", "Sol");
             privateObject.SetFieldOrProperty("systemX", 0.0M);
             privateObject.SetFieldOrProperty("systemY", 0.0M);
             privateObject.SetFieldOrProperty("systemZ", 0.0M);
 
-            // Force a call to the method
             bool matched = responder.eventSystemNameMatches("Sol");
+
             Assert.IsTrue(matched);
         }
 
@@ -58,19 +55,15 @@ namespace Tests
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             var privateObject = new PrivateObject(responder);
-
-            // The EDDN responder tracks system names and coordinates independently. 
             // Intentionally place our EDDN responder in a state with no coordinates available.
             privateObject.SetFieldOrProperty("systemName", "Not in this galaxy");
             privateObject.SetFieldOrProperty("systemX", null);
             privateObject.SetFieldOrProperty("systemY", null);
             privateObject.SetFieldOrProperty("systemZ", null);
 
-            // Force a call to the method
             bool matched = responder.eventSystemNameMatches("Artemis");
-            Assert.IsTrue(matched);
 
-            // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
+            Assert.IsTrue(matched);
             Assert.AreEqual("Artemis", responder.systemName);
             Assert.AreEqual(14.28125M, (decimal)responder.systemX);
             Assert.AreEqual(-63.1875M, (decimal)responder.systemY);
@@ -82,19 +75,14 @@ namespace Tests
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
             var privateObject = new PrivateObject(responder);
-
-            // The EDDN responder tracks system names and coordinates independently. 
-            // Intentionally place our EDDN responder in a state with no coordinates available.
             privateObject.SetFieldOrProperty("systemName", "Sol");
             privateObject.SetFieldOrProperty("systemX", 0.0M);
             privateObject.SetFieldOrProperty("systemY", 0.0M);
             privateObject.SetFieldOrProperty("systemZ", 0.0M);
 
-            // Force a call to the method
             bool matched = responder.eventSystemNameMatches("Not in this galaxy");
-            Assert.IsFalse(matched);
 
-            // Test that the results, including coordinates, have been correctly retrieved by the EDDN responder
+            Assert.IsFalse(matched);
             Assert.IsNull(responder.systemX);
             Assert.IsNull(responder.systemY);
             Assert.IsNull(responder.systemZ);

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -36,6 +36,24 @@ namespace Tests
         }
 
         [TestMethod()]
+        public void TestEDDNResponderGoodMatch()
+        {
+            EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();
+            var privateObject = new PrivateObject(responder);
+
+            // The EDDN responder tracks system names and coordinates independently. 
+            // Intentionally place our EDDN responder in a state with no coordinates available.
+            privateObject.SetFieldOrProperty("systemName", "Sol");
+            privateObject.SetFieldOrProperty("systemX", 0.0M);
+            privateObject.SetFieldOrProperty("systemY", 0.0M);
+            privateObject.SetFieldOrProperty("systemZ", 0.0M);
+
+            // Force a call to the method
+            bool matched = responder.eventSystemNameMatches("Sol");
+            Assert.IsTrue(matched);
+        }
+
+        [TestMethod()]
         public void TestEDDNResponderBadInitialSystem()
         {
             EDDNResponder.EDDNResponder responder = new EDDNResponder.EDDNResponder();


### PR DESCRIPTION
Add a sanity check to make sure that the system name during the `Docked` matches the system name and coordinates that the EDDN Responder is referencing. If the two do not match, fall back to the StarSystemSqlLiteRepository or null the values and do not send.