### PR TITLE
Update `Near surface` event with additional info & create a top level `Body` object

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,8 +1,47 @@
 ﻿# CHANGE LOG
 
-### 3.0.0-rc2
-  * Speech Responder
-    * Added 'Fighter rebuilt' event
+### 3.0.1-XX
+  * Core 
+    * EDDI will now track the nearest stellar body and make that data available to EDDI's Speech responder via the `body` variable (planet, moon, etc.).  
+  * Speech Responder 
+    * Updated the 'Near surface' event to include the name of the body that you are approaching or exiting. 
+    * Add a new top level `body` object, which contains details of the nearest stellar body. Any values might be missing, depending on EDDI's configuration and the information available about the body. 
+  * VoiceAttack 
+    * Added the following new variables describing details of the nearest stellar body, with values as described by the 'Body' object 
+      * `{DEC:Body EDDB id}`
+      * `{TXT:Body type}`
+      * `{TXT:Body name}` 
+      * `{TXT:Body system name}`
+      * `{DEC:Body age}`
+      * `{DEC:Body distance}`
+      * `{BOOL:Body landable}` 
+      * `{BOOL:Body tidally locked}` 
+      * `{DEC:Body temperature}` 
+      * `{BOOL:Body main star}` 
+      * `{TXT:Body stellar class}` 
+      * `{TXT:Body luminosity class}` 
+      * `{DEC:Body solar mass}` 
+      * `{DEC:Body solar radius}` 
+      * `{TXT:Body chromaticity}` 
+      * `{DEC:Body radius probability}` 
+      * `{DEC:Body mass probability}` 
+      * `{DEC:Body temp probability}` 
+      * `{DEC:Body age probability}` 
+      * `{DEC:Body periapsis}` 
+      * `{TXT:Body atmosphere}` 
+      * `{DEC:Body tilt}` 
+      * `{DEC:Body earth mass}` 
+      * `{DEC:Body gravity}` 
+      * `{DEC:Body eccentricity}` 
+      * `{DEC:Body inclination}` 
+      * `{DEC:Body orbital period}` 
+      * `{DEC:Body radius}` 
+      * `{DEC:Body rotational period}` 
+      * `{DEC:Body semi major axis}` 
+      * `{DEC:Body pressure}` 
+      * `{TXT:Body terraform state}` 
+      * `{TXT:Body planet type}` 
+      * `{TXT:Body reserves}` 
 
 ### 3.0.0-rc1
   * Core

--- a/Events/NearSurfaceEvent.cs
+++ b/Events/NearSurfaceEvent.cs
@@ -15,14 +15,19 @@ namespace EddiEvents
         static NearSurfaceEvent()
         {
             VARIABLES.Add("approaching_surface", "A boolean value. True if you are entering the gravity well and and false if you are leaving");
+            VARIABLES.Add("system", "The name of the starsystem");
+            VARIABLES.Add("body", "The name of the body");
         }
 
-        [JsonProperty("near_surface")]
         public bool approaching_surface { get; private set; }
+        public string system { get; private set; }
+        public string body { get; private set; }
 
-        public NearSurfaceEvent(DateTime timestamp, bool nearSurface) : base(timestamp, NAME)
+        public NearSurfaceEvent(DateTime timestamp, bool approachingSurface, string system, string body) : base(timestamp, NAME)
         {
-            this.approaching_surface = nearSurface;
+            this.approaching_surface = approachingSurface;
+            this.system = system;
+            this.body = body;
         }
     }
 }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -540,6 +540,24 @@ namespace EddiJournalMonitor
                             events.Add(new CockpitBreachedEvent(timestamp) { raw = line });
                             handled = true;
                             break;
+                        case "ApproachBody":
+                            {
+                                bool approachingSurface = true;
+                                string system = JsonParsing.getString(data, "StarSystem");
+                                string body = JsonParsing.getString(data, "Body");
+                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                            }
+                            handled = true;
+                            break;
+                        case "LeaveBody":
+                            {
+                                bool approachingSurface = false;
+                                string system = JsonParsing.getString(data, "StarSystem");
+                                string body = JsonParsing.getString(data, "Body");
+                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                            }
+                            handled = true;
+                            break;
                         case "ApproachSettlement":
                             {
                                 object val;

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -228,6 +228,11 @@ namespace EddiSpeechResponder
                 dict["station"] = new ReflectionValue(EDDI.Instance.CurrentStation);
             }
 
+            if (EDDI.Instance.CurrentStellarBody != null)
+            {
+                dict["body"] = new ReflectionValue(EDDI.Instance.CurrentStellarBody);
+            }
+
             if (StatusMonitor.currentStatus != null)
             {
                 dict["status"] = new ReflectionValue(StatusMonitor.currentStatus);

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -276,11 +276,6 @@ namespace EddiStatusMonitor
                 EDDI.Instance.eventHandler(new StatusEvent(thisStatus.timestamp, thisStatus));
 
                 // Trigger events for changed status, as applicable
-                if (thisStatus.near_surface != lastStatus.near_surface 
-                    && thisStatus.vehicle == Constants.VEHICLE_SHIP)
-                {
-                    EDDI.Instance.eventHandler(new NearSurfaceEvent(thisStatus.timestamp, thisStatus.near_surface));
-                }
                 if (thisStatus.srv_turret_deployed != lastStatus.srv_turret_deployed)
                 {
                     EDDI.Instance.eventHandler(new SRVTurretEvent(thisStatus.timestamp, thisStatus.srv_turret_deployed));

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -1136,6 +1136,15 @@ namespace EddiVoiceAttackResponder
 
             try
             {
+                setDetailedBodyValues(EDDI.Instance.CurrentStellarBody, "Body", ref vaProxy);
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set stellar body", ex);
+            }
+
+            try
+            {
                 setStationValues(EDDI.Instance.CurrentStation, "Last station", ref vaProxy);
             }
             catch (Exception ex)
@@ -1518,6 +1527,56 @@ namespace EddiVoiceAttackResponder
             {
                 vaProxy.SetDecimal(prefix + " age", (decimal)(long)body.age);
             }
+            Logging.Debug("Set body information (" + prefix + ")");
+        }
+
+        private static void setDetailedBodyValues(Body body, string prefix, ref dynamic vaProxy)
+        {
+            Logging.Debug("Setting current stellar body information");
+            vaProxy.SetDecimal(prefix + " EDDB id", body?.EDDBID);
+            vaProxy.SetText(prefix + " type", body?.type);
+            vaProxy.SetText(prefix + " name", body?.name);
+            vaProxy.SetText(prefix + " system name", body?.systemname);
+            if (body?.age == null)
+            {
+                vaProxy.SetDecimal(prefix + " age", null);
+            }
+            else
+            {
+                vaProxy.SetDecimal(prefix + " age", (decimal)(long)body.age);
+            }
+            vaProxy.SetDecimal(prefix + " distance", body?.distance);
+            vaProxy.SetBoolean(prefix + " landable", body?.landable);
+            vaProxy.SetBoolean(prefix + " tidally locked", body?.tidallylocked);
+            vaProxy.SetDecimal(prefix + " temperature", body?.temperature);
+            // Star specific items 
+            vaProxy.SetBoolean(prefix + " main star", body?.mainstar);
+            vaProxy.SetText(prefix + " stellar class", body?.stellarclass);
+            vaProxy.SetText(prefix + " luminosity class", body?.luminosityclass);
+            vaProxy.SetDecimal(prefix + " solar mass", body?.solarmass);
+            vaProxy.SetDecimal(prefix + " solar radius", body?.solarradius);
+            vaProxy.SetText(prefix + " chromaticity", body?.chromaticity);
+            vaProxy.SetDecimal(prefix + " radius probability", body?.radiusprobability);
+            vaProxy.SetDecimal(prefix + " mass probability", body?.massprobability);
+            vaProxy.SetDecimal(prefix + " temp probability", body?.tempprobability);
+            vaProxy.SetDecimal(prefix + " age probability", body?.ageprobability);
+            // Body specific items 
+            vaProxy.SetDecimal(prefix + " periapsis", body?.periapsis);
+            vaProxy.SetText(prefix + " atmosphere", body?.atmosphere);
+            vaProxy.SetDecimal(prefix + " tilt", body?.tilt);
+            vaProxy.SetDecimal(prefix + " earth mass", body?.earthmass);
+            vaProxy.SetDecimal(prefix + " gravity", body?.gravity);
+            vaProxy.SetDecimal(prefix + " eccentricity", body?.eccentricity);
+            vaProxy.SetDecimal(prefix + " inclination", body?.inclination);
+            vaProxy.SetDecimal(prefix + " orbital period", body?.orbitalperiod);
+            vaProxy.SetDecimal(prefix + " radius", body?.radius);
+            vaProxy.SetDecimal(prefix + " rotational period", body?.rotationalperiod);
+            vaProxy.SetDecimal(prefix + " semi major axis", body?.semimajoraxis);
+            vaProxy.SetDecimal(prefix + " pressure", body?.pressure);
+            vaProxy.SetText(prefix + " terraform state", body?.terraformstate);
+            vaProxy.SetText(prefix + " planet type", body?.planettype);
+            vaProxy.SetText(prefix + " reserves", body?.reserves);
+
             Logging.Debug("Set body information (" + prefix + ")");
         }
 


### PR DESCRIPTION
Replaces PR #417
In my testing I found that latitude and longitude were already present before either `ApproachBody` or `LeaveBody` were written, making the status event redundant / not value added.
I'm proposing that we create a new top level object describing the nearest orbital body (this will only be available when we have enough info to support it, and when you leave a body this top level object would become null). 