### PR TITLE
Material event updates (resubmitted)

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -140,6 +140,10 @@ namespace EddiCargoMonitor
             {
                 // If we fail a mission with cargo it becomes stolen
             }
+            else if (@event is TechnologyBrokerEvent)
+            {
+                // TODO
+            }
             // TODO Powerplay events
         }
 
@@ -168,6 +172,17 @@ namespace EddiCargoMonitor
             //{
             //    inventory.Add(cargo);
             //}
+        }
+
+        private void handleTechnologyBrokerEvent(TechnologyBrokerEvent @event)
+        {
+            for (int i = 0; i < @event.commodities.Count; i++)
+            {
+                Cargo cargo = new Cargo();
+                string commodityName = @event.commodities[i].commodity;
+                cargo.amount = @event.commodities[i].amount;
+                removeCargo(cargo);
+            }
         }
 
         public IDictionary<string, object> GetVariables()

--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -297,6 +297,7 @@ namespace EddiDataDefinitions
 
         public static string TidiedCategory(string edCategory)
         {
+            // FDev categorizes materials as one of: `$MICRORESOURCE_CATEGORY_Manufactured;`, `$MICRORESOURCE_CATEGORY_Encoded;`, or `$MICRORESOURCE_CATEGORY_Elements;`
             return edCategory.Replace("$MICRORESOURCE_CATEGORY_", "").Replace(";", "");
         }
     }

--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -48,104 +48,104 @@ namespace EddiDataDefinitions
         ///<summary>Raw Materials</summary>
 
         // Grade 1, Very Common
-        public static readonly Material Carbon = new Material("carbon", "Element", "Carbon", Rarity.VeryCommon, "C", 20.4M, 24.6M);
-        public static readonly Material Iron = new Material("iron", "Element", "Iron", Rarity.VeryCommon, "Fe", 36.3M, 48.4M);
-        public static readonly Material Lead = new Material("lead", "Element", "Lead", Rarity.VeryCommon, "Pb", null, null);
-        public static readonly Material Nickel = new Material("nickel", "Element", "Nickel", Rarity.VeryCommon, "Ni", 26.6M, 31.9M);
-        public static readonly Material Phosphorus = new Material("phosphorus", "Element", "Phosphorus", Rarity.VeryCommon, "P", 15.1M, 18.1M);
-        public static readonly Material Rhenium = new Material("rhenium", "Element", "Rhenium", Rarity.VeryCommon, "Re", null, null);
-        public static readonly Material Sulphur = new Material("sulphur", "Element", "Sulphur", Rarity.VeryCommon, "S", 27.9M, 33.5M);
+        public static readonly Material Carbon = new Material("carbon", "Elements", "Carbon", Rarity.VeryCommon, "C", 20.4M, 24.6M);
+        public static readonly Material Iron = new Material("iron", "Elements", "Iron", Rarity.VeryCommon, "Fe", 36.3M, 48.4M);
+        public static readonly Material Lead = new Material("lead", "Elements", "Lead", Rarity.VeryCommon, "Pb", null, null);
+        public static readonly Material Nickel = new Material("nickel", "Elements", "Nickel", Rarity.VeryCommon, "Ni", 26.6M, 31.9M);
+        public static readonly Material Phosphorus = new Material("phosphorus", "Elements", "Phosphorus", Rarity.VeryCommon, "P", 15.1M, 18.1M);
+        public static readonly Material Rhenium = new Material("rhenium", "Elements", "Rhenium", Rarity.VeryCommon, "Re", null, null);
+        public static readonly Material Sulphur = new Material("sulphur", "Elements", "Sulphur", Rarity.VeryCommon, "S", 27.9M, 33.5M);
 
         // Grade 2, Common
-        public static readonly Material Arsenic = new Material("arsenic", "Element", "Arsenic", Rarity.Common, "As", 2.3M, 2.7M);
-        public static readonly Material Chromium = new Material("chromium", "Element", "Chromium", Rarity.Common, "Cr", 13.8M, 16.6M);
-        public static readonly Material Germanium = new Material("germanium", "Element", "Germanium", Rarity.Common, "Ge", 5.6M, 6.8M);
-        public static readonly Material Manganese = new Material("manganese", "Element", "Manganese", Rarity.Common, "Mn", 12.9M, 15.5M);
-        public static readonly Material Vanadium = new Material("vanadium", "Element", "Vanadium", Rarity.Common, "V", 8.3M, 9.9M);
-        public static readonly Material Zinc = new Material("zinc", "Element", "Zinc", Rarity.Common, "Zn", 9.1M, 10.9M);
+        public static readonly Material Arsenic = new Material("arsenic", "Elements", "Arsenic", Rarity.Common, "As", 2.3M, 2.7M);
+        public static readonly Material Chromium = new Material("chromium", "Elements", "Chromium", Rarity.Common, "Cr", 13.8M, 16.6M);
+        public static readonly Material Germanium = new Material("germanium", "Elements", "Germanium", Rarity.Common, "Ge", 5.6M, 6.8M);
+        public static readonly Material Manganese = new Material("manganese", "Elements", "Manganese", Rarity.Common, "Mn", 12.9M, 15.5M);
+        public static readonly Material Vanadium = new Material("vanadium", "Elements", "Vanadium", Rarity.Common, "V", 8.3M, 9.9M);
+        public static readonly Material Zinc = new Material("zinc", "Elements", "Zinc", Rarity.Common, "Zn", 9.1M, 10.9M);
 
         // Grade 3, Standard
-        public static readonly Material Boron = new Material("boron", "Element", "Boron", Rarity.Standard, "B", null, null);
-        public static readonly Material Cadmium = new Material("cadmium", "Element", "Cadmium", Rarity.Standard, "Cd", 2.8M, 3.3M);
-        public static readonly Material Mercury = new Material("mercury", "Element", "Mercury", Rarity.Standard, "Hg", 1.6M, 1.9M);
-        public static readonly Material Molybdenum = new Material("molybdenum", "Element", "Molybdenum", Rarity.Standard, "Mo", 2.3M, 2.8M);
-        public static readonly Material Niobium = new Material("niobium", "Element", "Niobium", Rarity.Standard, "Nb", 2.4M, 2.9M);
-        public static readonly Material Tin = new Material("tin", "Element", "Tin", Rarity.Standard, "Sn", 2.4M, 2.9M);
-        public static readonly Material Tungsten = new Material("tungsten", "Element", "Tungsten", Rarity.Standard, "W", 2.0M, 2.3M);
+        public static readonly Material Boron = new Material("boron", "Elements", "Boron", Rarity.Standard, "B", null, null);
+        public static readonly Material Cadmium = new Material("cadmium", "Elements", "Cadmium", Rarity.Standard, "Cd", 2.8M, 3.3M);
+        public static readonly Material Mercury = new Material("mercury", "Elements", "Mercury", Rarity.Standard, "Hg", 1.6M, 1.9M);
+        public static readonly Material Molybdenum = new Material("molybdenum", "Elements", "Molybdenum", Rarity.Standard, "Mo", 2.3M, 2.8M);
+        public static readonly Material Niobium = new Material("niobium", "Elements", "Niobium", Rarity.Standard, "Nb", 2.4M, 2.9M);
+        public static readonly Material Tin = new Material("tin", "Elements", "Tin", Rarity.Standard, "Sn", 2.4M, 2.9M);
+        public static readonly Material Tungsten = new Material("tungsten", "Elements", "Tungsten", Rarity.Standard, "W", 2.0M, 2.3M);
 
         // Grade 4, Rare
-        public static readonly Material Ruthenium = new Material("ruthenium", "Element", "Ruthenium", Rarity.Rare, "Ru", 2.2M, 2.6M);
-        public static readonly Material Selenium = new Material("selenium", "Element", "Selenium", Rarity.Rare, "Se", 3.7M, 4.4M);
-        public static readonly Material Technetium = new Material("technetium", "Element", "Technetium", Rarity.Rare, "Tc", 1.3M, 1.5M);
-        public static readonly Material Tellurium = new Material("tellurium", "Element", "Tellurium", Rarity.Rare, "Te", 1.3M, 1.5M);
-        public static readonly Material Yttrium = new Material("yttrium", "Element", "Yttrium", Rarity.Rare, "Y", 2.1M, 2.5M);
-        public static readonly Material Zirconium = new Material("zirconium", "Element", "Zirconium", Rarity.Rare, "Zr", 4.1M, 5.0M);
+        public static readonly Material Ruthenium = new Material("ruthenium", "Elements", "Ruthenium", Rarity.Rare, "Ru", 2.2M, 2.6M);
+        public static readonly Material Selenium = new Material("selenium", "Elements", "Selenium", Rarity.Rare, "Se", 3.7M, 4.4M);
+        public static readonly Material Technetium = new Material("technetium", "Elements", "Technetium", Rarity.Rare, "Tc", 1.3M, 1.5M);
+        public static readonly Material Tellurium = new Material("tellurium", "Elements", "Tellurium", Rarity.Rare, "Te", 1.3M, 1.5M);
+        public static readonly Material Yttrium = new Material("yttrium", "Elements", "Yttrium", Rarity.Rare, "Y", 2.1M, 2.5M);
+        public static readonly Material Zirconium = new Material("zirconium", "Elements", "Zirconium", Rarity.Rare, "Zr", 4.1M, 5.0M);
 
         // Grade 5, Very Rare
-        public static readonly Material Antimony = new Material("antimony", "Element", "Antimony", Rarity.VeryRare, "Sb", 1.4M, 1.6M);
-        public static readonly Material Polonium = new Material("polonium", "Element", "Polonium", Rarity.VeryRare, "Po", 1.1M, 1.3M);
+        public static readonly Material Antimony = new Material("antimony", "Elements", "Antimony", Rarity.VeryRare, "Sb", 1.4M, 1.6M);
+        public static readonly Material Polonium = new Material("polonium", "Elements", "Polonium", Rarity.VeryRare, "Po", 1.1M, 1.3M);
 
         ///<summary>Data</summary>
         
         // Grade 1, Very Common
-        public static readonly Material AnomalousBulkScanData = new Material("bulkscandata", "Data", "Anomalous Bulk Scan Data", Rarity.VeryCommon);
-        public static readonly Material AtypicalDisruptedWakeEchoes = new Material("disruptedwakeechoes", "Data", "Atypical Disrupted Wake Echoes", Rarity.VeryCommon);
-        public static readonly Material DistortedShieldCycleRecordings = new Material("shieldcyclerecordings", "Data", "Distorted Shield Cycle Recordings", Rarity.VeryCommon);
-        public static readonly Material ExceptionalScrambledEmissionData = new Material("scrambledemissiondata", "Data", "Exceptional Scrambled Emission Data", Rarity.VeryCommon);
-        public static readonly Material SpecialisedLegacyFirmware = new Material("legacyfirmware", "Data", "Specialised Legacy Firmware", Rarity.VeryCommon);
-        public static readonly Material UnusualEncryptedFiles = new Material("encryptedfiles", "Data", "Unusual Encrypted Files", Rarity.VeryCommon);
+        public static readonly Material AnomalousBulkScanData = new Material("bulkscandata", "Encoded", "Anomalous Bulk Scan Data", Rarity.VeryCommon);
+        public static readonly Material AtypicalDisruptedWakeEchoes = new Material("disruptedwakeechoes", "Encoded", "Atypical Disrupted Wake Echoes", Rarity.VeryCommon);
+        public static readonly Material DistortedShieldCycleRecordings = new Material("shieldcyclerecordings", "Encoded", "Distorted Shield Cycle Recordings", Rarity.VeryCommon);
+        public static readonly Material ExceptionalScrambledEmissionData = new Material("scrambledemissiondata", "Encoded", "Exceptional Scrambled Emission Data", Rarity.VeryCommon);
+        public static readonly Material SpecialisedLegacyFirmware = new Material("legacyfirmware", "Encoded", "Specialised Legacy Firmware", Rarity.VeryCommon);
+        public static readonly Material UnusualEncryptedFiles = new Material("encryptedfiles", "Encoded", "Unusual Encrypted Files", Rarity.VeryCommon);
         // Grade 1 Xeno
-        public static readonly Material AncientHistoricalData = new Material("ancienthistoricaldata", "Data", "Ancient Historical Data (Pattern Gamma)", Rarity.VeryCommon);
+        public static readonly Material AncientHistoricalData = new Material("ancienthistoricaldata", "Encoded", "Ancient Historical Data (Pattern Gamma)", Rarity.VeryCommon);
 
         // Grade 2, Common
-        public static readonly Material AnomalousFSDTelemetry = new Material("fsdtelemetry", "Data", "Anomalous FSD Telemetry", Rarity.Common);
-        public static readonly Material InconsistentShieldSoakAnalysis = new Material("shieldsoakanalysis", "Data", "Inconsistent Shield Soak Analysis", Rarity.Common);
-        public static readonly Material IrregularEmissionData = new Material("archivedemissiondata", "Data", "Irregular Emission Data", Rarity.Common);
-        public static readonly Material ModifiedConsumerFirmware = new Material("consumerfirmware", "Data", "Modified Consumer Firmware", Rarity.Common);
-        public static readonly Material TaggedEncryptionCodes = new Material("encryptioncodes", "Data", "Tagged Encryption Codes", Rarity.Common);
-        public static readonly Material UnidentifiedScanArchives = new Material("scanarchives", "Data", "Unidentified Scan Archives", Rarity.Common);
+        public static readonly Material AnomalousFSDTelemetry = new Material("fsdtelemetry", "Encoded", "Anomalous FSD Telemetry", Rarity.Common);
+        public static readonly Material InconsistentShieldSoakAnalysis = new Material("shieldsoakanalysis", "Encoded", "Inconsistent Shield Soak Analysis", Rarity.Common);
+        public static readonly Material IrregularEmissionData = new Material("archivedemissiondata", "Encoded", "Irregular Emission Data", Rarity.Common);
+        public static readonly Material ModifiedConsumerFirmware = new Material("consumerfirmware", "Encoded", "Modified Consumer Firmware", Rarity.Common);
+        public static readonly Material TaggedEncryptionCodes = new Material("encryptioncodes", "Encoded", "Tagged Encryption Codes", Rarity.Common);
+        public static readonly Material UnidentifiedScanArchives = new Material("scanarchives", "Encoded", "Unidentified Scan Archives", Rarity.Common);
         // Grade 2 Xeno
-        public static readonly Material AncientCulturalData = new Material("ancientculturaldata", "Data", "Ancient Cultural Data (Pattern Beta)", Rarity.Common);
-        public static readonly Material Tg_StructuralData = new Material("tg_structuraldata", "Data", "Thargoid Structural Data", Rarity.Common);
+        public static readonly Material AncientCulturalData = new Material("ancientculturaldata", "Encoded", "Ancient Cultural Data (Pattern Beta)", Rarity.Common);
+        public static readonly Material Tg_StructuralData = new Material("tg_structuraldata", "Encoded", "Thargoid Structural Data", Rarity.Common);
 
         // Grade 3, Standard
-        public static readonly Material ClassifiedScanDatabanks = new Material("scandatabanks", "Data", "Classified Scan Databanks", Rarity.Standard);
-        public static readonly Material CrackedIndustrialFirmware = new Material("industrialfirmware", "Data", "Cracked Industrial Firmware", Rarity.Standard);
-        public static readonly Material OpenSymmetricKeys = new Material("symmetrickeys", "Data", "Open Symmetric Keys", Rarity.Standard);
-        public static readonly Material StrangeWakeSolutions = new Material("wakesolutions", "Data", "Strange Wake Solutions", Rarity.Standard);
-        public static readonly Material UnexpectedEmissionData = new Material("emissiondata", "Data", "Unexpected Emission Data", Rarity.Standard);
-        public static readonly Material UntypicalShieldScans = new Material("shielddensityreports", "Data", "Untypical Shield Scans", Rarity.Standard);
+        public static readonly Material ClassifiedScanDatabanks = new Material("scandatabanks", "Encoded", "Classified Scan Databanks", Rarity.Standard);
+        public static readonly Material CrackedIndustrialFirmware = new Material("industrialfirmware", "Encoded", "Cracked Industrial Firmware", Rarity.Standard);
+        public static readonly Material OpenSymmetricKeys = new Material("symmetrickeys", "Encoded", "Open Symmetric Keys", Rarity.Standard);
+        public static readonly Material StrangeWakeSolutions = new Material("wakesolutions", "Encoded", "Strange Wake Solutions", Rarity.Standard);
+        public static readonly Material UnexpectedEmissionData = new Material("emissiondata", "Encoded", "Unexpected Emission Data", Rarity.Standard);
+        public static readonly Material UntypicalShieldScans = new Material("shielddensityreports", "Encoded", "Untypical Shield Scans", Rarity.Standard);
         // Grade 3 Xeno
-        public static readonly Material AncientBiologicalData = new Material("ancientbiologicaldata", "Data", "Ancient Biological Data (Pattern Alpha)", Rarity.Standard);
-        public static readonly Material Tg_CompositionData = new Material("tg_compositiondata", "Data", "Thargoid Material Composition Data", Rarity.Standard);
-        public static readonly Material UnknownShipSignature = new Material("unknownshipsignature", "Data", "Thargoid Ship Signature", Rarity.Standard);
+        public static readonly Material AncientBiologicalData = new Material("ancientbiologicaldata", "Encoded", "Ancient Biological Data (Pattern Alpha)", Rarity.Standard);
+        public static readonly Material Tg_CompositionData = new Material("tg_compositiondata", "Encoded", "Thargoid Material Composition Data", Rarity.Standard);
+        public static readonly Material UnknownShipSignature = new Material("unknownshipsignature", "Encoded", "Thargoid Ship Signature", Rarity.Standard);
 
         // Grade 4, Rare
-        public static readonly Material AberrantShieldPatternAnalysis = new Material("shieldpatternanalysis", "Data", "Aberrant Shield Pattern Analysis", Rarity.Rare);
-        public static readonly Material AtypicalEncryptionArchives = new Material("encryptionarchives", "Data", "Atypical Encryption Archives", Rarity.Rare);
-        public static readonly Material DecodedEmissionData = new Material("decodedemissiondata", "Data", "Decoded Emission Data", Rarity.Rare);
-        public static readonly Material DivergentScanData = new Material("encodedscandata", "Data", "Divergent Scan Data", Rarity.Rare);
-        public static readonly Material EccentricHyperspaceTrajectories = new Material("hyperspacetrajectories", "Data", "Eccentric Hyperspace Trajectories", Rarity.Rare);
-        public static readonly Material SecurityFirmwarePatch = new Material("securityfirmware", "Data", "Security Firmware Patch", Rarity.Rare);
+        public static readonly Material AberrantShieldPatternAnalysis = new Material("shieldpatternanalysis", "Encoded", "Aberrant Shield Pattern Analysis", Rarity.Rare);
+        public static readonly Material AtypicalEncryptionArchives = new Material("encryptionarchives", "Encoded", "Atypical Encryption Archives", Rarity.Rare);
+        public static readonly Material DecodedEmissionData = new Material("decodedemissiondata", "Encoded", "Decoded Emission Data", Rarity.Rare);
+        public static readonly Material DivergentScanData = new Material("encodedscandata", "Encoded", "Divergent Scan Data", Rarity.Rare);
+        public static readonly Material EccentricHyperspaceTrajectories = new Material("hyperspacetrajectories", "Encoded", "Eccentric Hyperspace Trajectories", Rarity.Rare);
+        public static readonly Material SecurityFirmwarePatch = new Material("securityfirmware", "Encoded", "Security Firmware Patch", Rarity.Rare);
         // Grade 4 Xeno
-        public static readonly Material AncientLanguageData = new Material("ancientlanguagedata", "Data", "Ancient Language Data (Pattern Delta)", Rarity.Rare);
-        public static readonly Material AncientTechnologicalData = new Material("ancienttechnologicaldata", "Data", "Ancient Technological Data (Pattern Epsilon)", Rarity.Rare);
-        public static readonly Material Tg_ShipFlightData = new Material("tg_shipflightdata", "Data", "Ship Flight Data", Rarity.Rare);
-        public static readonly Material Tg_ShipSystemData = new Material("tg_shipsystemdata", "Data", "Ship System Data", Rarity.Rare);
-        public static readonly Material Tg_ResidueData = new Material("tg_residuedata", "Data", "Thargoid Residue Data", Rarity.Rare);
-        public static readonly Material UnknownWakeScan = new Material("unknownwakedata", "Data", "Thargoid Wake Data", Rarity.Rare);
+        public static readonly Material AncientLanguageData = new Material("ancientlanguagedata", "Encoded", "Ancient Language Data (Pattern Delta)", Rarity.Rare);
+        public static readonly Material AncientTechnologicalData = new Material("ancienttechnologicaldata", "Encoded", "Ancient Technological Data (Pattern Epsilon)", Rarity.Rare);
+        public static readonly Material Tg_ShipFlightData = new Material("tg_shipflightdata", "Encoded", "Ship Flight Data", Rarity.Rare);
+        public static readonly Material Tg_ShipSystemData = new Material("tg_shipsystemdata", "Encoded", "Ship System Data", Rarity.Rare);
+        public static readonly Material Tg_ResidueData = new Material("tg_residuedata", "Encoded", "Thargoid Residue Data", Rarity.Rare);
+        public static readonly Material UnknownWakeScan = new Material("unknownwakedata", "Encoded", "Thargoid Wake Data", Rarity.Rare);
 
         // Grade 5, Very Rare
-        public static readonly Material AbnormalCompactEmissionData = new Material("compactemissionsdata", "Data", "Abnormal Compact Emission Data", Rarity.VeryRare);
-        public static readonly Material AdaptiveEncryptorsCapture = new Material("adaptiveencryptors", "Data", "Adaptive Encryptors Capture", Rarity.VeryRare);
-        public static readonly Material ClassifiedScanFragment = new Material("classifiedscandata", "Data", "Classified Scan Fragment", Rarity.VeryRare);
-        public static readonly Material DataminedWakeExceptions = new Material("dataminedwake", "Data", "Datamined Wake Exceptions", Rarity.VeryRare);
-        public static readonly Material ModifiedEmbeddedFirmware = new Material("embeddedfirmware", "Data", "Modified Embedded Firmware", Rarity.VeryRare);
-        public static readonly Material PeculiarShieldFrequencyData = new Material("shieldfrequencydata", "Data", "Peculiar Shield Frequency Data", Rarity.VeryRare);
+        public static readonly Material AbnormalCompactEmissionData = new Material("compactemissionsdata", "Encoded", "Abnormal Compact Emission Data", Rarity.VeryRare);
+        public static readonly Material AdaptiveEncryptorsCapture = new Material("adaptiveencryptors", "Encoded", "Adaptive Encryptors Capture", Rarity.VeryRare);
+        public static readonly Material ClassifiedScanFragment = new Material("classifiedscandata", "Encoded", "Classified Scan Fragment", Rarity.VeryRare);
+        public static readonly Material DataminedWakeExceptions = new Material("dataminedwake", "Encoded", "Datamined Wake Exceptions", Rarity.VeryRare);
+        public static readonly Material ModifiedEmbeddedFirmware = new Material("embeddedfirmware", "Encoded", "Modified Embedded Firmware", Rarity.VeryRare);
+        public static readonly Material PeculiarShieldFrequencyData = new Material("shieldfrequencydata", "Encoded", "Peculiar Shield Frequency Data", Rarity.VeryRare);
         // Grade 5 Xeno
-        public static readonly Material Guardian_ModuleBlueprint = new Material("guardian_moduleblueprint", "Manufactured", "Guardian Module Blueprint", Rarity.Rare);
-        public static readonly Material Guardian_VesselBlueprint = new Material("guardian_vesselblueprint", "Manufactured", "Guardian Vessel Blueprint", Rarity.VeryRare);
-        public static readonly Material Guardian_WeaponBlueprint = new Material("guardian_weaponblueprint", "Manufactured", "Guardian Weapon Blueprint", Rarity.VeryRare);
+        public static readonly Material Guardian_ModuleBlueprint = new Material("guardian_moduleblueprint", "Encoded", "Guardian Module Blueprint", Rarity.Rare);
+        public static readonly Material Guardian_VesselBlueprint = new Material("guardian_vesselblueprint", "Encoded", "Guardian Vessel Blueprint", Rarity.VeryRare);
+        public static readonly Material Guardian_WeaponBlueprint = new Material("guardian_weaponblueprint", "Encoded", "Guardian Weapon Blueprint", Rarity.VeryRare);
 
         ///<summary>Manufactured</summary>
 

--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -294,5 +294,10 @@ namespace EddiDataDefinitions
 
             return deprecatedMaterialsList.Contains(name.Trim());
         }
+
+        public static string TidiedCategory(string edCategory)
+        {
+            return edCategory.Replace("$MICRORESOURCE_CATEGORY_", "").Replace(";", "");
+        }
     }
 }

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ### 3.0.0-rc2
   * Incorporate new material transaction events
+  * EDDI's Material Monitor will now auto-calculate maximum material limits when they are not otherwise defined... provided the material rarity is known.
   * Speech Responder
     * Added `Fighter rebuilt` event
     * Added `Material trade` event

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,7 +1,7 @@
 ﻿# CHANGE LOG
 
 ### 3.0.0-rc2
-  * Incorporate new material transaction events
+  * Incorporated new material transaction events
   * EDDI's Material Monitor will now auto-calculate maximum material limits when they are not otherwise defined... provided the material rarity is known.
   * Speech Responder
     * Added `Fighter rebuilt` event

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,8 +1,11 @@
 ﻿# CHANGE LOG
 
 ### 3.0.0-rc2
+  * Incorporate new material transaction events
   * Speech Responder
-    * Added 'Fighter rebuilt' event
+    * Added `Fighter rebuilt` event
+    * Added `Material trade` event
+    * Added `Technology broker` event
 
 ### 3.0.0-rc1
   * Core
@@ -11,9 +14,9 @@
     * First installations will now take any custom VoiceAttack installation location into account when proposing a location for EDDI.
     * Upgrade installations will continue to use whatever location was selected in the first installation.
   * Speech Responder
-    * Added 'Jet cone damage' event
+    * Added `Jet cone damage` event
     * Script changes
-      * Added new script 'Jet cone damage'
+      * Added new script `Jet cone damage`
   * VoiceAttack
     * Added the following new variables
       * `{BOOL:EDDI speaking}` True if EDDI is speaking, false otherwise. Useful for synchronizing speech between EDDI and other sources in VoiceAttack.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -1,5 +1,7 @@
 ﻿# CHANGE LOG
 
+Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
+
 ### 3.0.0-rc2
   * Incorporated new material transaction events
   * EDDI's Material Monitor will now auto-calculate maximum material limits when they are not otherwise defined... provided the material rarity is known.

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeltScannedEvent.cs" />
     <Compile Include="FighterRebuiltEvent.cs" />
     <Compile Include="JetConeDamageEvent.cs" />
+    <Compile Include="MaterialTradedEvent.cs" />
     <Compile Include="ShutdownEvent.cs" />
     <Compile Include="StatusEvent.cs" />
     <Compile Include="VAInitialized.cs" />

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -68,6 +68,7 @@
     <Compile Include="MaterialTradedEvent.cs" />
     <Compile Include="ShutdownEvent.cs" />
     <Compile Include="StatusEvent.cs" />
+    <Compile Include="TechnologyBrokerEvent.cs" />
     <Compile Include="VAInitialized.cs" />
     <Compile Include="SRVTurretEvent.cs" />
     <Compile Include="NearSurfaceEvent.cs" />

--- a/Events/MaterialTradedEvent.cs
+++ b/Events/MaterialTradedEvent.cs
@@ -16,9 +16,9 @@ namespace EddiEvents
         {
             VARIABLES.Add("tradertype", "The type of material trader for the trade");
             VARIABLES.Add("paid", "The name of the material lost in the trade");
-            VARIABLES.Add("paidqty", "The amount of the material lost in the trade");
-            VARIABLES.Add("received", "The name of the material lost in the trade");
-            VARIABLES.Add("receivedqty", "The amount of the material lost in the trade");
+            VARIABLES.Add("paid_quantity", "The amount of the material lost in the trade");
+            VARIABLES.Add("received", "The name of the material gained in the trade");
+            VARIABLES.Add("received_quantity", "The amount of the material gained in the trade");
         }
 
         [JsonProperty("tradertype")]
@@ -27,14 +27,14 @@ namespace EddiEvents
         [JsonProperty("paid")]
         public string paid { get; private set; }
 
-        [JsonProperty("paidqty")]
-        public int paidqty { get; private set; }
+        [JsonProperty("paid_quantity")]
+        public int paid_quantity { get; private set; }
 
         [JsonProperty("received")]
         public string received { get; private set; }
 
-        [JsonProperty("receivedqty")]
-        public int receivedqty { get; private set; }
+        [JsonProperty("received_quantity")]
+        public int received_quantity { get; private set; }
 
         // Admin
         public long marketid { get; private set; }
@@ -50,10 +50,10 @@ namespace EddiEvents
             this.marketid = marketId;
             this.tradertype = traderType;
             this.paid = materialPaid?.name;
-            this.paidqty = materialPaidQty;
+            this.paid_quantity = materialPaidQty;
             this.paid_edname = materialPaid?.EDName;
             this.received = materialReceived?.name;
-            this.receivedqty = materialReceivedQty;
+            this.received_quantity = materialReceivedQty;
             this.received_edname = materialReceived?.EDName;
         }
     }

--- a/Events/MaterialTradedEvent.cs
+++ b/Events/MaterialTradedEvent.cs
@@ -9,13 +9,12 @@ namespace EddiEvents
     {
         public const string NAME = "Material traded";
         public const string DESCRIPTION = "Triggered when you trade materials at a materials trader";
-        public const string SAMPLE = "{ \"timestamp\":\"2018-02-21T15:23:49Z\", \"event\":\"MaterialTrade\", \"MarketID\":3221397760, \"TraderType\":\"encoded\", \"Paid\":{ \"Material\":\"scandatabanks\", \"Material_Localised\":\"Classified Scan Databanks\", \"Category\":\"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\":\"Encoded\", \"Quantity\":6, \"Category\":\"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\":\"Encoded\" }, \"Received\":{ \"Material\":\"encodedscandata\", \"Material_Localised\":\"Divergent Scan Data\", \"Quantity\":1 }";
-
+        public const string SAMPLE = "{ \"timestamp\": \"2018-04-02T05:04:45Z\", \"event\": \"MaterialTrade\", \"MarketID\": 3223343616, \"TraderType\": \"encoded\", \"Paid\": { \"Material\": \"shielddensityreports\", \"Material_Localised\": \"Untypical Shield Scans \", \"Category\": \"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\": \"Encoded\", \"Quantity\": 72 }, \"Received\": { \"Material\": \"shieldfrequencydata\", \"Material_Localised\": \"Peculiar Shield Frequency Data\", \"Category\": \"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\": \"Encoded\", \"Quantity\": 2 } }";
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
         static MaterialTradedEvent()
         {
-            VARIABLES.Add("traderType", "The type of material trader for the trade");
+            VARIABLES.Add("tradertype", "The type of material trader for the trade");
             VARIABLES.Add("paid", "The name of the material lost in the trade");
             VARIABLES.Add("paidqty", "The amount of the material lost in the trade");
             VARIABLES.Add("received", "The name of the material lost in the trade");

--- a/Events/MaterialTradedEvent.cs
+++ b/Events/MaterialTradedEvent.cs
@@ -1,0 +1,61 @@
+﻿using EddiDataDefinitions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class MaterialTradedEvent : Event
+    {
+        public const string NAME = "Material traded";
+        public const string DESCRIPTION = "Triggered when you trade materials at a materials trader";
+        public const string SAMPLE = "{ \"timestamp\":\"2018-02-21T15:23:49Z\", \"event\":\"MaterialTrade\", \"MarketID\":3221397760, \"TraderType\":\"encoded\", \"Paid\":{ \"Material\":\"scandatabanks\", \"Material_Localised\":\"Classified Scan Databanks\", \"Category\":\"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\":\"Encoded\", \"Quantity\":6, \"Category\":\"$MICRORESOURCE_CATEGORY_Encoded;\", \"Category_Localised\":\"Encoded\" }, \"Received\":{ \"Material\":\"encodedscandata\", \"Material_Localised\":\"Divergent Scan Data\", \"Quantity\":1 }";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static MaterialTradedEvent()
+        {
+            VARIABLES.Add("traderType", "The type of material trader for the trade");
+            VARIABLES.Add("paid", "The name of the material lost in the trade");
+            VARIABLES.Add("paidqty", "The amount of the material lost in the trade");
+            VARIABLES.Add("received", "The name of the material lost in the trade");
+            VARIABLES.Add("receivedqty", "The amount of the material lost in the trade");
+        }
+
+        [JsonProperty("tradertype")]
+        public string tradertype { get; private set; }
+
+        [JsonProperty("paid")]
+        public string paid { get; private set; }
+
+        [JsonProperty("paidqty")]
+        public int paidqty { get; private set; }
+
+        [JsonProperty("received")]
+        public string received { get; private set; }
+
+        [JsonProperty("receivedqty")]
+        public int receivedqty { get; private set; }
+
+        // Admin
+        public long marketid { get; private set; }
+
+        [JsonProperty("paid_edname")]
+        public string paid_edname { get; private set; }
+
+        [JsonProperty("received_edname")]
+        public string received_edname { get; private set; }
+
+        public MaterialTradedEvent(DateTime timestamp, long marketId, string traderType, Material materialPaid, int materialPaidQty, Material materialReceived, int materialReceivedQty) : base(timestamp, NAME)
+        {
+            this.marketid = marketId;
+            this.tradertype = traderType;
+            this.paid = materialPaid?.name;
+            this.paidqty = materialPaidQty;
+            this.paid_edname = materialPaid?.EDName;
+            this.received = materialReceived?.name;
+            this.receivedqty = materialReceivedQty;
+            this.received_edname = materialReceived?.EDName;
+        }
+    }
+}

--- a/Events/TechnologyBrokerEvent.cs
+++ b/Events/TechnologyBrokerEvent.cs
@@ -1,0 +1,45 @@
+﻿using EddiDataDefinitions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class TechnologyBrokerEvent : Event
+    {
+        public const string NAME = "Technology broker";
+        public const string DESCRIPTION = "Triggered when using the Technology Broker to unlock new purchasable technology";
+        public const string SAMPLE = "{ \"timestamp\":\"2018-03-02T11:28:44Z\", \"event\":\"TechnologyBroker\", \"BrokerType\":\"Human\", \"MarketID\":128151032, \"ItemsUnlocked\":[{ \"Name\":\"Hpt_PlasmaShockCannon_Fixed_Medium\", \"Name_Localised\":\"Shock Cannon\" }], \"Commodities\":[{ \"Name\":\"iondistributor\", \"Name_Localised\":\"Ion Distributor\", \"Count\":6 }], \"Materials\":[ { \"Name\":\"vanadium\", \"Count\":30, \"Category\":\"Raw\" }, { \"Name\":\"tungsten\", \"Count\":30, \"Category\":\"Raw\" }, { \"Name\":\"rhenium\", \"Count\":36, \"Category\":\"Raw\" }, { \"Name\":\"technetium\", \"Count\":30, \"Category\":\"Raw\"}]}";
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static TechnologyBrokerEvent()
+        {
+            VARIABLES.Add("brokertype", "The technology broker's type (e.g. \"Human\")");
+            VARIABLES.Add("items", "The items unlocked in the transaction (this is a list of item names)");
+            VARIABLES.Add("materials", "The materials and quantities used in the crafting (MaterialAmount object)");
+            VARIABLES.Add("commodities", "The commodities and quantities used in the crafting (CommodityAmount object)");
+        }
+
+        [JsonProperty("brokertype")]
+        public string brokertype { get; private set; }
+
+        [JsonProperty("items")]
+        public List<string> items { get; private set; }
+
+        public List<CommodityAmount> commodities { get; private set; }
+
+        public List<MaterialAmount> materials { get; private set; }
+
+        // Admin
+        public long marketid { get; private set; }
+
+        public TechnologyBrokerEvent(DateTime timestamp, string brokerType, long marketId, List<string> items, List<CommodityAmount> commodities, List<MaterialAmount> materials) : base(timestamp, NAME)
+        {
+            this.brokertype = brokerType;
+            this.marketid = marketId;
+            this.items = items;
+            this.commodities = commodities;
+            this.materials = materials;
+        }
+    }
+}

--- a/Events/TechnologyBrokerEvent.cs
+++ b/Events/TechnologyBrokerEvent.cs
@@ -15,16 +15,16 @@ namespace EddiEvents
         static TechnologyBrokerEvent()
         {
             VARIABLES.Add("brokertype", "The technology broker's type (e.g. \"Human\")");
-            VARIABLES.Add("items", "The items unlocked in the transaction (this is a list of item names)");
-            VARIABLES.Add("materials", "The materials and quantities used in the crafting (MaterialAmount object)");
-            VARIABLES.Add("commodities", "The commodities and quantities used in the crafting (CommodityAmount object)");
+            VARIABLES.Add("items", "The items unlocked in the transaction (this is a list of Module objects)");
+            VARIABLES.Add("materials", "The materials and quantities used in the crafting (MaterialAmount object with keys \"material\" and \"amount\", consisting of a material object and an amount)");
+            VARIABLES.Add("commodities", "The commodities and quantities used in the crafting (CommodityAmount object with keys \"commodity\" and \"amount\", consisting of a commodity object and an amount)");
         }
 
         [JsonProperty("brokertype")]
         public string brokertype { get; private set; }
 
         [JsonProperty("items")]
-        public List<string> items { get; private set; }
+        public List<Module> items { get; private set; }
 
         public List<CommodityAmount> commodities { get; private set; }
 
@@ -33,7 +33,7 @@ namespace EddiEvents
         // Admin
         public long marketid { get; private set; }
 
-        public TechnologyBrokerEvent(DateTime timestamp, string brokerType, long marketId, List<string> items, List<CommodityAmount> commodities, List<MaterialAmount> materials) : base(timestamp, NAME)
+        public TechnologyBrokerEvent(DateTime timestamp, string brokerType, long marketId, List<Module> items, List<CommodityAmount> commodities, List<MaterialAmount> materials) : base(timestamp, NAME)
         {
             this.brokertype = brokerType;
             this.marketid = marketId;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -794,6 +794,46 @@ namespace EddiJournalMonitor
                             }
                             handled = true;
                             break;
+                        case "TechnologyBroker":
+                            {
+                                object val;
+
+                                string brokerType = JsonParsing.getString(data, "BrokerType");
+                                long marketId = JsonParsing.getLong(data, "MarketID");
+
+                                data.TryGetValue("ItemsUnlocked", out val);
+                                List<Dictionary<string, object>> itemsUnlocked = (List<Dictionary<string, object>>)val;
+                                List<string> items = new List<string>();
+                                foreach (Dictionary<string, object> item in itemsUnlocked)
+                                {
+                                    items.Add(JsonParsing.getString(item, "Name"));
+                                }
+
+                                data.TryGetValue("Commodities", out val);
+                                List<Dictionary<string, object>> commodities = (List<Dictionary<string, object>>)val;
+                                List<CommodityAmount> Commodities = new List<CommodityAmount>();
+                                foreach (Dictionary<string, object> _commodity in commodities)
+                                {
+                                    Commodity commodity = CommodityDefinitions.FromName(JsonParsing.getString(_commodity, "Name"));
+                                    int count = JsonParsing.getInt(_commodity, "Count");
+                                    Commodities.Add(new CommodityAmount(commodity, count));
+                                }
+
+                                data.TryGetValue("Materials", out val);
+                                List<Dictionary<string, object>> materials = (List<Dictionary<string, object>>)val;
+                                List<MaterialAmount> Materials = new List<MaterialAmount>();
+                                foreach (Dictionary<string, object> _material in materials)
+                                {
+                                    Material material = Material.FromEDName(JsonParsing.getString(_material, "Name"));
+                                    material.category = Material.TidiedCategory(JsonParsing.getString(_material, "Category"));
+                                    int count = JsonParsing.getInt(_material, "Count");
+                                    Materials.Add(new MaterialAmount(material, count));
+                                }
+
+                                events.Add(new TechnologyBrokerEvent(timestamp, brokerType, marketId, items, Commodities, Materials) { raw = line });
+                                handled = true;
+                            }
+                            break;
                         case "ShipyardTransfer":
                             {
                                 object val;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1231,6 +1231,32 @@ namespace EddiJournalMonitor
                                 handled = true;
                             }
                             break;
+                        case "MaterialTrade":
+                            {
+                                object val;
+
+                                long marketId = JsonParsing.getLong(data, "MarketID");
+                                string traderType = JsonParsing.getString(data, "TraderType");
+
+                                data.TryGetValue("Paid", out val);
+                                Dictionary<string, object> paid = (Dictionary<string, object>)val;
+
+                                Material materialPaid = Material.FromEDName(JsonParsing.getString(paid, "Material"));
+                                materialPaid.category = Material.TidiedCategory(JsonParsing.getString(paid, "Category"));
+                                int materialPaidQty = JsonParsing.getInt(paid, "Quantity");
+
+                                data.TryGetValue("Received", out val);
+                                Dictionary<string, object> received = (Dictionary<string, object>)val;
+
+                                Material materialReceived = Material.FromEDName(JsonParsing.getString(received, "Material"));
+                                materialReceived.category = Material.TidiedCategory(JsonParsing.getString(received, "Category"));
+                                int materialReceivedQty = JsonParsing.getInt(received, "Quantity");
+
+                                events.Add(new MaterialTradedEvent(timestamp, marketId, traderType, materialPaid, materialPaidQty, materialReceived, materialReceivedQty) { raw = line });
+                                handled = true;
+
+                                break;
+                            }
                         case "ScientificResearch":
                             {
                                 object val;

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -101,6 +101,10 @@ namespace EddiMaterialMonitor
             {
                 handleMaterialDonatedEvent((MaterialDonatedEvent)@event);
             }
+            else if (@event is MaterialTradedEvent)
+            {
+                handleMaterialTradedEvent((MaterialTradedEvent)@event);
+            }
             else if (@event is SynthesisedEvent)
             {
                 handleSynthesisedEvent((SynthesisedEvent)@event);
@@ -161,6 +165,12 @@ namespace EddiMaterialMonitor
         private void handleMaterialDonatedEvent(MaterialDonatedEvent @event)
         {
             decMaterial(@event.edname, @event.amount);
+        }
+
+        private void handleMaterialTradedEvent(MaterialTradedEvent @event)
+        {
+            decMaterial(@event.paid_edname, @event.paidqty);
+            incMaterial(@event.received_edname, @event.receivedqty);
         }
 
         private void handleSynthesisedEvent(SynthesisedEvent @event)

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -173,8 +173,8 @@ namespace EddiMaterialMonitor
 
         private void handleMaterialTradedEvent(MaterialTradedEvent @event)
         {
-            decMaterial(@event.paid_edname, @event.paidqty);
-            incMaterial(@event.received_edname, @event.receivedqty);
+            decMaterial(@event.paid_edname, @event.paid_quantity);
+            incMaterial(@event.received_edname, @event.received_quantity);
         }
 
         private void handleSynthesisedEvent(SynthesisedEvent @event)

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -367,6 +367,17 @@ namespace EddiMaterialMonitor
                         if (addToInv == true)
                         {
                             MaterialAmount ma2 = new MaterialAmount(ma.material, ma.amount, ma.minimum, ma.desired, ma.maximum);
+
+                            // Set material maximums if they aren't already defined
+                            if (ma2.maximum == null || ma2.maximum == 0)
+                            {
+                                int rarityLevel = Material.FromEDName(ma2.edname).rarity.level;
+                                if (rarityLevel > 0)
+                                {
+                                    ma2.maximum = -50 * (rarityLevel) + 350;
+                                }
+                            }
+
                             newInventory.Add(ma2);
                         }
                     }

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -113,6 +113,10 @@ namespace EddiMaterialMonitor
             {
                 handleModificationCraftedEvent((ModificationCraftedEvent)@event);
             }
+            else if (@event is TechnologyBrokerEvent)
+            {
+                handleTechnologyBrokerEvent((TechnologyBrokerEvent)@event);
+            }
         }
 
         // Flush any pending events
@@ -186,6 +190,14 @@ namespace EddiMaterialMonitor
             foreach (MaterialAmount component in @event.materials)
             {
                 decMaterial(component.edname, component.amount);
+            }
+        }
+
+        private void handleTechnologyBrokerEvent(TechnologyBrokerEvent @event)
+        {
+            foreach (MaterialAmount material in @event.materials)
+            {
+                decMaterial(material.edname, material.amount);
             }
         }
 

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1703,6 +1703,15 @@
       "name": "System state report",
       "description": "Report on the current state of the contextual system"
     },
+    "Technology broker": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Technology broker",
+      "description": "Triggered when using the Technology Broker to unlock new purchasable technology"
+    },
     "Touchdown": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -947,6 +947,15 @@
       "name": "Material threshold",
       "description": "Triggered when a material reaches a threshold"
     },
+    "Material traded": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Material traded",
+      "description": "Triggered when materials are traded at a material trader"
+    },
     "Material use report": {
       "enabled": true,
       "priority": 3,


### PR DESCRIPTION
Fix for #453.
Adds new 'MaterialTrade` and `TechnologyBroker` events
Replaces #462 (resubmitted to slightly clean the commit history).