### PR TITLE
Prevent synthetic events sent to EDSM

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -814,16 +814,11 @@ namespace EddiJournalMonitor
                                     ShipArrived();
                                     async void ShipArrived()
                                     {
-                                        // Add a bit of context
+                                        // Include the station and system at which the transfer will arrive
                                         string arrivalStation = EDDI.Instance.CurrentStation?.name ?? string.Empty;
                                         string arrivalSystem = EDDI.Instance.CurrentStarSystem?.name ?? string.Empty;
-
-                                        line = line.Replace("ShipyardTransfer", "ShipyardArrived");
-                                        line = line.Replace(timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture), timestamp.AddSeconds((double)time).ToUniversalTime().ToString());
-                                        line = line.Replace(",\"System\":\"" + system + "\"", ",\"System\":\"" + arrivalSystem + "\""); // Include the system at which the transfer will arrive
-                                        line = line.Replace("}", ",\"Station\":\"" + arrivalStation + "\"}"); // Include the station at which the transferred ship will arrive
                                         await Task.Delay((int)time * 1000);
-                                        ForwardJournalEntry(line, EDDI.Instance.eventHandler);
+                                        EDDI.Instance.eventHandler(new ShipArrivedEvent(DateTime.UtcNow, ship, shipId, arrivalSystem, distance, price, time, arrivalStation));
                                     }
                                 }
                             }
@@ -857,16 +852,11 @@ namespace EddiJournalMonitor
                                     ModuleArrived();
                                     async void ModuleArrived()
                                     {
-                                        // Add a bit of context
+                                        // Include the station and system at which the transfer will arrive
                                         string arrivalStation = EDDI.Instance.CurrentStation?.name ?? string.Empty;
                                         string arrivalSystem = EDDI.Instance.CurrentStarSystem?.name ?? string.Empty;
-
-                                        line = line.Replace("FetchRemoteModule", "ModuleArrived");
-                                        line = line.Replace(timestamp.ToString("s", System.Globalization.CultureInfo.InvariantCulture), timestamp.AddSeconds((double)transferTime).ToUniversalTime().ToString());
-                                        line = line.Replace("}", ",\"System\":\"" + arrivalSystem + "\"}"); // Include the system at which the transfer will arrive
-                                        line = line.Replace("}", ",\"Station\":\"" + arrivalStation + "\"}"); // Include the station at which the transferred module will arrive
                                         await Task.Delay((int)transferTime * 1000);
-                                        ForwardJournalEntry(line, EDDI.Instance.eventHandler);
+                                        EDDI.Instance.eventHandler(new ModuleArrivedEvent(DateTime.UtcNow, ship, shipId, storageSlot, serverId, module, transferCost, transferTime, arrivalSystem, arrivalStation));
                                     }
                                 }
                             }


### PR DESCRIPTION
Anthor alerted me that the `Module arrived` and `Ship arrived` events were being passed to EDSM.
This occured because the old method of generating the events created a "raw" event, and events with a "raw" are sent to EDSM. Fixed by generating the events as synthetic events, without a "raw" property.