### PR TITLE
Log missing speech scripts at info level, not report

### DIFF
--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -258,7 +258,7 @@ namespace EddiSpeechResponder
             missingScripts.RemoveAll(t => t == "Belt scanned" || t == "Jumping" || t == "Status");
             if (missingScripts.Count > 0)
             {
-                Logging.Report("Failed to find scripts", JsonConvert.SerializeObject(missingScripts));
+                Logging.Info("Failed to find scripts" + string.Join(";", missingScripts));
             }
 
             // Re-order the scripts by name


### PR DESCRIPTION
This was killing performance at startup for me due to being called very repeatedly (I have a handful of legacy personality scripts) to the point where a regular user would think the app had crashed. I'm talking over a minute to launch the app, hence the label I've assigned.

Reducing to `Logging.Info()` solved it completely.

I assess the risk as minimal.