### PR TITLE
Amend code where data is not a JSON dictionary

### DIFF
--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -122,6 +122,9 @@ namespace Utilities
 
         public static void Report(string message, object data = null, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
+#if DEBUG
+            Debug(message, data?.ToString(), memberName, filePath);
+#else
             try
             {
                 if (!(data is Dictionary<string, object>))
@@ -147,6 +150,7 @@ namespace Utilities
             {
                 // Nothing to do
             }
+#endif
         }
     }
 

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -126,7 +126,11 @@ namespace Utilities
             {
                 if (!(data is Dictionary<string, object>))
                 {
-                    data = JsonConvert.DeserializeObject<Dictionary<string, object>>(data.ToString());
+                    var wrapppedData = new Dictionary<string, object>()
+                    {
+                        {"data", data}
+                    };
+                    data = wrapppedData;
                 }
                 Dictionary<string, object> thisData = (Dictionary<string, object>)data;
                 if (isUniqueMessage(message, thisData))


### PR DESCRIPTION
If passed a List<>, this code generates an exception.
Wrapping the passed-in object in a one-element dictionary solves the problem.

