### PR TITLE
#70 use namespaces to distinguish the various types of test

### DIFF
--- a/Tests/BodyScanTests.cs
+++ b/Tests/BodyScanTests.cs
@@ -2,7 +2,7 @@
 using EddiEvents;
 using System.Collections.Generic;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class BodyScanTests

--- a/Tests/BuildTests.cs
+++ b/Tests/BuildTests.cs
@@ -2,7 +2,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class BuildTests

--- a/Tests/CommanderDataTests.cs
+++ b/Tests/CommanderDataTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using EddiShipMonitor;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class CommanderDataTests

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -2,7 +2,7 @@
 using System;
 using EddiDataDefinitions;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class CommodityTests

--- a/Tests/CoriolisTests.cs
+++ b/Tests/CoriolisTests.cs
@@ -2,7 +2,7 @@
 using System;
 using Eddi;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class CoriolisTests

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiDataDefinitions;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class DataDefinitionTests

--- a/Tests/DataProviderTests.cs
+++ b/Tests/DataProviderTests.cs
@@ -2,7 +2,7 @@
 using EddiDataDefinitions;
 using EddiDataProviderService;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class DataProviderTests

--- a/Tests/DiffTests.cs
+++ b/Tests/DiffTests.cs
@@ -3,7 +3,7 @@ using Utilities;
 using static Utilities.Diff;
 using System.Collections.Generic;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class DiffTests

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class EddnTests

--- a/Tests/GeneratorTests.cs
+++ b/Tests/GeneratorTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 
-namespace Tests
+namespace GeneratorTests
 {
     [TestClass]
     public class GeneratorTests

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -4,7 +4,7 @@ using EddiEvents;
 using EddiJournalMonitor;
 using System.Collections.Generic;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class JournalMonitorTests

--- a/Tests/PromotionTests.cs
+++ b/Tests/PromotionTests.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiEvents;
 using EddiJournalMonitor;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class PromotionTests

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class ScriptResolverTest

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -8,7 +8,7 @@ using EddiShipMonitor;
 using Utilities;
 using Eddi;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class ShipTests

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -12,7 +12,7 @@ using CSCore.Streams.Effects;
 using EddiDataDefinitions;
 using Utilities;
 
-namespace Tests
+namespace SpeechTests
 {
     [TestClass]
     public class SpeechTests

--- a/Tests/StarSystemDataTests.cs
+++ b/Tests/StarSystemDataTests.cs
@@ -2,7 +2,7 @@
 using EddiDataDefinitions;
 using EddiDataProviderService;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class StarSystemDataTests

--- a/Tests/StatusMonitorTests.cs
+++ b/Tests/StatusMonitorTests.cs
@@ -3,7 +3,7 @@ using EddiStatusMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class StatusMonitorTests

--- a/Tests/TranslationTests.cs
+++ b/Tests/TranslationTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiSpeechService;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class TranslationTests

--- a/Tests/VersioningTests.cs
+++ b/Tests/VersioningTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utilities;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     public class VersioningTests

--- a/Tests/VoiceAttackPluginTests.cs
+++ b/Tests/VoiceAttackPluginTests.cs
@@ -6,7 +6,7 @@ using EddiDataDefinitions;
 using EddiDataProviderService;
 using Newtonsoft.Json;
 
-namespace Tests
+namespace UnitTests
 {
     [TestClass]
     [DeploymentItem(@"x86\SQLite.Interop.dll", "x86")]


### PR DESCRIPTION
Separated the tests by namespace into "UnitTests", "SpeechTests" and "GeneratorTests".
This makes it easy to select a group to run when the Test Explorer is in hierarchy view.