### PR TITLE
Use ship definitions to convert from FDev ship names (e.g. `Empire_Eagle`) to human readable names players will readily recognize (e.g. `Imperial Eagle`).

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.0-XX
+  * Ship monitor
+    * Made sure we are using human readable ship names in all scripts (e.g. "Imperial Eagle" rather than "Empire_Eagle")
+
 ### 3.0.0-rc2
   * Core
     * The EDSM responder has been updated to send data to EDSM per their revised API. 

--- a/Events/CommanderContinuedEvent.cs
+++ b/Events/CommanderContinuedEvent.cs
@@ -62,7 +62,7 @@ namespace EddiEvents
         {
             this.commander = commander;
             this.shipid = shipId;
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipname = shipName;
             this.shipident = shipIdent;
             this.mode = (mode == null ? null : mode.name);

--- a/Events/DiedEvent.cs
+++ b/Events/DiedEvent.cs
@@ -32,8 +32,18 @@ namespace EddiEvents
         public DiedEvent(DateTime timestamp, List<string> commanders, List<string> ships, List<CombatRating> ratings) : base(timestamp, NAME)
         {
             this.commanders = commanders;
-            this.ships = ships;
+            this.ships = killerShipModels(ships);
             this.ratings = ratings.ConvertAll(x => x.name);
+        }
+
+        public static List<string> killerShipModels(List<string> ships)
+        {
+            List<string> shipModels = new List<string>();
+            foreach (string shipName in ships)
+            {
+                shipModels.Add(ShipDefinitions.FromEDModel(shipName).model);
+            }
+            return shipModels;
         }
     }
 }

--- a/ShipMonitor/ModuleArrivedEvent.cs
+++ b/ShipMonitor/ModuleArrivedEvent.cs
@@ -40,7 +40,7 @@ namespace EddiShipMonitor
 
         public ModuleArrivedEvent(DateTime timestamp, string ship, int? shipid, int storageslot, long serverid, Module module, long transfercost, long? transfertime, string system, string station) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.storageslot = storageslot;
             this.serverid = serverid;

--- a/ShipMonitor/ModulePurchasedEvent.cs
+++ b/ShipMonitor/ModulePurchasedEvent.cs
@@ -51,7 +51,7 @@ namespace EddiShipMonitor
 
         public ModulePurchasedEvent(DateTime timestamp, string ship, int? shipid, string slot, Module buymodule, long buyprice, Module sellmodule, long? sellprice, Module storedmodule) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.slot = slot;
             this.buymodule = buymodule;

--- a/ShipMonitor/ModuleRetrievedEvent.cs
+++ b/ShipMonitor/ModuleRetrievedEvent.cs
@@ -47,7 +47,7 @@ namespace EddiShipMonitor
 
         public ModuleRetrievedEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long? cost, string engineermodifications, Module swapoutmodule) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModuleSoldEvent.cs
+++ b/ShipMonitor/ModuleSoldEvent.cs
@@ -39,7 +39,7 @@ namespace EddiShipMonitor
 
         public ModuleSoldEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long price) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModuleSoldFromStorageEvent.cs
+++ b/ShipMonitor/ModuleSoldFromStorageEvent.cs
@@ -31,7 +31,7 @@ namespace EddiShipMonitor
 
         public ModuleSoldFromStorageEvent(DateTime timestamp, string ship, int? shipid, int storageslot, long serverid, Module module, long price) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.storageslot = storageslot;
             this.serverid = serverid;

--- a/ShipMonitor/ModuleStoredEvent.cs
+++ b/ShipMonitor/ModuleStoredEvent.cs
@@ -34,7 +34,7 @@ namespace EddiShipMonitor
 
         public ModuleStoredEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long? cost, string engineermodifications, Module replacementmodule) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModuleSwappedEvent.cs
+++ b/ShipMonitor/ModuleSwappedEvent.cs
@@ -43,7 +43,7 @@ namespace EddiShipMonitor
 
         public ModuleSwappedEvent(DateTime timestamp, string ship, int? shipid, string fromslot, Module frommodule, string toslot, Module tomodule) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.fromslot = fromslot;
             this.frommodule = frommodule;

--- a/ShipMonitor/ModuleTransferEvent.cs
+++ b/ShipMonitor/ModuleTransferEvent.cs
@@ -35,7 +35,7 @@ namespace EddiShipMonitor
 
         public ModuleTransferEvent(DateTime timestamp, string ship, int? shipid, int storageslot, long serverid, Module module, long transfercost, long? transfertime) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.storageslot = storageslot;
             this.serverid = serverid;

--- a/ShipMonitor/ModulesStored.cs
+++ b/ShipMonitor/ModulesStored.cs
@@ -35,7 +35,7 @@ namespace EddiShipMonitor
 
         public ModulesStoredEvent(DateTime timestamp, string ship, int? shipid, List<string> slots, List<Module> modules ) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.slots = slots;
             this.modules = modules;

--- a/ShipMonitor/ShipArrivedEvent.cs
+++ b/ShipMonitor/ShipArrivedEvent.cs
@@ -49,7 +49,7 @@ namespace EddiShipMonitor
 
         public ShipArrivedEvent(DateTime timestamp, string ship, int? shipid, string system, decimal distance, long? price, long? time, string station) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.station = station;
             this.system = system;

--- a/ShipMonitor/ShipDeliveredEvent.cs
+++ b/ShipMonitor/ShipDeliveredEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ namespace EddiShipMonitor
 
         public ShipDeliveredEvent(DateTime timestamp, string ship, int? shipId) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipId;
         }
     }

--- a/ShipMonitor/ShipLoadoutEvent.cs
+++ b/ShipMonitor/ShipLoadoutEvent.cs
@@ -33,7 +33,7 @@ namespace EddiShipMonitor
 
         public ShipLoadoutEvent(DateTime timestamp, string ship, int? shipId, string shipName, string shipIdent, List<Compartment> compartments, List<Hardpoint> hardpoints, string paintjob) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipId;
             this.shipname = shipName;
             this.shipident = shipIdent;

--- a/ShipMonitor/ShipPurchasedEvent.cs
+++ b/ShipMonitor/ShipPurchasedEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -46,7 +47,7 @@ namespace EddiShipMonitor
 
         public ShipPurchasedEvent(DateTime timestamp, string ship, long price, string soldShip, int? soldShipId, long? soldPrice, string storedShip, int? storedShipId) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.price = price;
             this.soldship = soldShip;
             this.soldshipid = soldShipId;

--- a/ShipMonitor/ShipRenamedEvent.cs
+++ b/ShipMonitor/ShipRenamedEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -34,7 +35,7 @@ namespace EddiShipMonitor
 
         public ShipRenamedEvent(DateTime timestamp, string ship, int shipid, string name, string ident) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.name = name;
             this.ident = ident;

--- a/ShipMonitor/ShipSoldEvent.cs
+++ b/ShipMonitor/ShipSoldEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -34,7 +35,7 @@ namespace EddiShipMonitor
 
         public ShipSoldEvent(DateTime timestamp, string ship, int shipId, long price, string system) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipId;
             this.price = price;
             this.system = system;

--- a/ShipMonitor/ShipSoldOnRebuyEvent.cs
+++ b/ShipMonitor/ShipSoldOnRebuyEvent.cs
@@ -1,3 +1,4 @@
+using EddiDataDefinitions;
 using EddiEvents;
 using Newtonsoft.Json;
 using System;
@@ -34,7 +35,7 @@ namespace EddiShipMonitor
 
         public ShipSoldOnRebuyEvent(DateTime timestamp, string ship, int shipId, long price, string system) : base(timestamp, NAME)
         {
-            this.ship = ship;      
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipId;
             this.price = price;
             this.system = system;

--- a/ShipMonitor/ShipSwappedEvent.cs
+++ b/ShipMonitor/ShipSwappedEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -42,7 +43,7 @@ namespace EddiShipMonitor
 
         public ShipSwappedEvent(DateTime timestamp, string ship, int shipId, string soldship, int? soldshipid, string storedship, int? storedshipid) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipId;
             this.soldship = soldship;
             this.soldshipid = soldshipid;

--- a/ShipMonitor/ShipTransferInitiatedEvent.cs
+++ b/ShipMonitor/ShipTransferInitiatedEvent.cs
@@ -43,7 +43,7 @@ namespace EddiShipMonitor
 
         public ShipTransferInitiatedEvent(DateTime timestamp, string ship, int? shipid, string system, decimal distance, long? price, long? time) : base(timestamp, NAME)
         {
-            this.ship = ship;
+            this.ship = ShipDefinitions.FromEDModel(ship).model;
             this.shipid = shipid;
             this.system = system;
             this.distance = distance;

--- a/ShipMonitor/ShipTransferInitiatedEvent.cs
+++ b/ShipMonitor/ShipTransferInitiatedEvent.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
The conversion takes place after all internal processing performed by EDDI is completed so the risk is low. 
Also reviewed scripts - existing user scripts should not break with this change (if anything, the use of the P() method will become less necessary).