### PR TITLE
Corrected 'Location' event handler to use 'station' name instead of '…

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -780,25 +780,23 @@ namespace Eddi
 
             if (theEvent.docked == true)
             {
-                // In this case body === station
-
                 // Force first location update even if it matches with 'firstLocation' bool
-                if (!firstLocation && (CurrentStation != null && CurrentStation.name == theEvent.body))
+                if (!firstLocation && (CurrentStation != null && CurrentStation.name == theEvent.station))
                 {
                     // We are already at this station; nothing to do
-                    Logging.Debug("Already at station " + theEvent.body);
+                    Logging.Debug("Already at station " + theEvent.station);
                     return false;
                 }
                 firstLocation = false;
 
                 // Update the station
-                Logging.Debug("Now at station " + theEvent.body);
-                Station station = CurrentStarSystem.stations.Find(s => s.name == theEvent.body);
+                Logging.Debug("Now at station " + theEvent.station);
+                Station station = CurrentStarSystem.stations.Find(s => s.name == theEvent.station);
                 if (station == null)
                 {
                     // This station is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder
                     station = new Station();
-                    station.name = theEvent.body;
+                    station.name = theEvent.station;
                     station.systemname = theEvent.system;
                 }
 


### PR DESCRIPTION
Fixed EDDI.cs 'Location' event handler to use 'station' name instead of 'body' when docked.

Previous iteration of Journal Monitor did not provide station data. Unimproved code now causing occasional bogus station data to be forwarded to EDDB, requiring manual deletion of bad data by EDDB maintainers.

This PR corrects the issue.
