### PR TITLE
Fix unparseable null values passed from journal reader

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -24,13 +24,15 @@ namespace EddiJournalMonitor
 
         public static void ForwardJournalEntry(string line, Action<Event> callback)
         {
-            if (line != null)
+            if (line == null)
             {
-                List<Event> events = ParseJournalEntry(line);
-                foreach (Event @event in events)
-                {
-                    callback(@event);
-                }
+                return;
+            }
+
+            List<Event> events = ParseJournalEntry(line);
+            foreach (Event @event in events)
+            {
+                callback(@event);
             }
         }
 

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -24,10 +24,13 @@ namespace EddiJournalMonitor
 
         public static void ForwardJournalEntry(string line, Action<Event> callback)
         {
-            List<Event> events = ParseJournalEntry(line);
-            foreach (Event @event in events)
+            if (line != null)
             {
-                callback(@event);
+                List<Event> events = ParseJournalEntry(line);
+                foreach (Event @event in events)
+                {
+                    callback(@event);
+                }
             }
         }
 


### PR DESCRIPTION
Fix for rollbar#99.
```
 System.NullReferenceException: Object reference not set to an instance of an object.
at EddiJournalMonitor.JournalMonitor.ParseJournalEntry(String line)
```