### PR TITLE
Scrub data directory file paths from Rollbar reporting.

### DIFF
--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -23,35 +23,35 @@ namespace Utilities
                 }
                 catch (ArgumentException ex)
                 {
-                    Logging.Debug("Failed to read from " + name, ex);
+                    Logging.Error("Failed to read from " + name, ex);
                 }
                 catch (PathTooLongException ex)
                 {
-                    Logging.Debug("Path " + name + " too long", ex);
+                    Logging.Error("Path " + name + " too long", ex);
                 }
                 catch (DirectoryNotFoundException ex)
                 {
-                    Logging.Debug("Directory for " + name + " not found", ex);
+                    Logging.Error("Directory for " + name + " not found", ex);
                 }
                 catch (FileNotFoundException ex)
                 {
-                    Logging.Debug("File " + name + " not found", ex);
+                    Logging.Error("File " + name + " not found", ex);
                 }
                 catch (IOException ex)
                 {
-                    Logging.Debug("IO exception for " + name, ex);
+                    Logging.Error("IO exception for " + name, ex);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
-                    Logging.Debug("Not allowed to read from " + name, ex);
+                    Logging.Error("Not allowed to read from " + name, ex);
                 }
                 catch (NotSupportedException ex)
                 {
-                    Logging.Debug("Not supported reading from " + name, ex);
+                    Logging.Error("Not supported reading from " + name, ex);
                 }
                 catch (SecurityException ex)
                 {
-                    Logging.Debug("Security exception reading from " + name, ex);
+                    Logging.Error("Security exception reading from " + name, ex);
                 }
 
             }

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -23,35 +23,35 @@ namespace Utilities
                 }
                 catch (ArgumentException ex)
                 {
-                    Logging.Error("Failed to read from " + name, ex);
+                    Logging.Debug("Failed to read from " + name, ex);
                 }
                 catch (PathTooLongException ex)
                 {
-                    Logging.Error("Path " + name + " too long", ex);
+                    Logging.Debug("Path " + name + " too long", ex);
                 }
                 catch (DirectoryNotFoundException ex)
                 {
-                    Logging.Error("Directory for " + name + " not found", ex);
+                    Logging.Debug("Directory for " + name + " not found", ex);
                 }
                 catch (FileNotFoundException ex)
                 {
-                    Logging.Error("File" + name + " not found", ex);
+                    Logging.Debug("File " + name + " not found", ex);
                 }
                 catch (IOException ex)
                 {
-                    Logging.Error("IO exception for " + name, ex);
+                    Logging.Debug("IO exception for " + name, ex);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
-                    Logging.Error("Not allowed to read from " + name, ex);
+                    Logging.Debug("Not allowed to read from " + name, ex);
                 }
                 catch (NotSupportedException ex)
                 {
-                    Logging.Error("Not supported reading from " + name, ex);
+                    Logging.Debug("Not supported reading from " + name, ex);
                 }
                 catch (SecurityException ex)
                 {
-                    Logging.Error("Security exception reading from " + name, ex);
+                    Logging.Debug("Security exception reading from " + name, ex);
                 }
 
             }

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -176,7 +176,7 @@ namespace Utilities
                 Environment = beta ? "development" : "production",
                 ScrubFields = new string[] // Scrub these fields from the reported data
                 {
-                    "Commander", "apiKey", "commanderName"
+                    "Commander", "apiKey", "commanderName", Constants.DATA_DIR
                 },
                 // Identify each EDDI configuration by a unique ID, or by "Commander" if a unique ID isn't available.
                 Person = new Rollbar.DTOs.Person(uniqueId),
@@ -198,7 +198,7 @@ namespace Utilities
 
                 if (isUniqueMessage(exception.GetType() + ": " + exception.Message, trace))
                 {
-                    Logging.Error("Reporting unhandled exception, anonymous ID " + RollbarLocator.RollbarInstance.Config.Person.Id);
+                    Logging.Info("Reporting unhandled exception, anonymous ID " + RollbarLocator.RollbarInstance.Config.Person.Id);
                     RollbarLocator.RollbarInstance.Error(exception, trace);
                 }
             };


### PR DESCRIPTION
And demote Files.Read() errors to Debug level reporting.