### PR TITLE
Fix doubling in commodity refine and eject events

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -277,7 +277,11 @@ namespace EddiCargoMonitor
                     cargo.other -= @event.amount;
                 }
 
-                cargo.total -= @event.amount;
+                if (cargo.total < 1)
+                {
+                    // All of the commodity was ejected
+                    RemoveCargo(cargo.name);
+                }
             }
             writeInventory();
         }
@@ -307,7 +311,6 @@ namespace EddiCargoMonitor
             if (cargo != null)
             {
                 cargo.other++;
-                cargo.total++;
             }
             else
             {

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -344,8 +344,6 @@ namespace EddiCargoMonitor
                     // Cargo is owned by the commander
                     cargo.other -= @event.amount;
                 }
-
-                cargo.total -= @event.amount;
                 if (cargo.total < 1)
                 {
                     // All of the commodity was sold


### PR DESCRIPTION
Commodity values were doubled for Commodity Refined and Commodity Ejected events in Cargo Monitor.
See Issue #454 for details.
   