### PR TITLE
Remove `Ship low fuel` event.

### DIFF
--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -236,6 +236,10 @@ namespace EddiSpeechResponder
                     {
                         scriptHolder.Add(kv.Key);
                     }
+                    else if (kv.Value.Name == "Ship low fuel") // Accidental duplicate. The real event is called 'Low fuel'
+                    {
+                        scriptHolder.Add(kv.Key);
+                    }
                 }
                 foreach (string script in scriptHolder)
                 {

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1442,15 +1442,6 @@
       "name": "Ship loadout",
       "description": "Triggered when you obtain the loadout of your ship"
     },
-    "Ship low fuel": {
-      "enabled": true,
-      "priority": 3,
-      "responder": true,
-      "script": null,
-      "default": true,
-      "name": "Ship low fuel",
-      "description": "Triggered when your fuel level falls below 25%"
-    },
     "Ship purchased": {
       "enabled": true,
       "priority": 3,


### PR DESCRIPTION
This was an accidential duplication... the actual script triggered by the `ShipLowFuelEvent` is the similarly named `Low fuel` event.