### PR TITLE
Rollbar enhancements

### DIFF
--- a/EDDI/App.config
+++ b/EDDI/App.config
@@ -41,6 +41,9 @@
       <setting name="OverrideCulture" serializeAs="String">
         <value />
       </setting>
+      <setting name="uniqueID" serializeAs="String">
+        <value />
+      </setting>
     </Eddi.Properties.Settings>
   </userSettings>
   <system.data>

--- a/EDDI/App.xaml.cs
+++ b/EDDI/App.xaml.cs
@@ -30,18 +30,21 @@ namespace Eddi
             {
                 Exception exception = args.Exception as Exception;
                 _Rollbar.ExceptionHandler(exception);
+                ReloadAndRecover(exception);
             };
             // Catch and send unhandled exceptions from non-UI threads
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
                 Exception exception = args.ExceptionObject as Exception;
                 _Rollbar.ExceptionHandler(exception);
+                ReloadAndRecover(exception);
             };
             // Catch and send unhandled exceptions from the task scheduler
             TaskScheduler.UnobservedTaskException += (sender, args) =>
             {
                 Exception exception = args.Exception as Exception;
                 _Rollbar.ExceptionHandler(exception);
+                ReloadAndRecover(exception);
             };
 
             ApplyAnyOverrideCulture(); // this must be done before any UI is generated
@@ -91,6 +94,13 @@ namespace Eddi
                 Thread.CurrentThread.CurrentCulture = ci;
                 Thread.CurrentThread.CurrentUICulture = ci;
             }
+        }
+
+        private static void ReloadAndRecover(Exception exception)
+        {
+            Logging.Debug("Reloading after unhandled exception: " + exception.ToString());
+            EDDI.Instance.Stop();
+            EDDI.Instance.Start();
         }
     }
 }

--- a/EDDI/App.xaml.cs
+++ b/EDDI/App.xaml.cs
@@ -106,9 +106,12 @@ namespace Eddi
 
         private static void ReloadAndRecover(Exception exception)
         {
+#if DEBUG
+#else
             Logging.Debug("Reloading after unhandled exception: " + exception.ToString());
             EDDI.Instance.Stop();
             EDDI.Instance.Start();
+#endif
         }
     }
 }

--- a/EDDI/App.xaml.cs
+++ b/EDDI/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,14 +16,14 @@ namespace Eddi
         [STAThread]
         static void Main()
         {
+            // Configure Rollbar error reporting
+
             // Generate or retrieve an id unique to this configuration for bug tracking
             string uniqueId = Eddi.Properties.Settings.Default.uniqueID ?? Guid.NewGuid().ToString();
             if (Eddi.Properties.Settings.Default.uniqueID == null)
             {
                 Eddi.Properties.Settings.Default.uniqueID = uniqueId;
             }
-
-            // Configure Rollbar error reporting
             _Rollbar.configureRollbar(uniqueId);
 
             // Catch and send unhandled exceptions from Windows forms
@@ -46,6 +47,13 @@ namespace Eddi
                 _Rollbar.ExceptionHandler(exception);
                 ReloadAndRecover(exception);
             };
+            // Catch and write managed exceptions to the local debug console (but do not send)
+            AppDomain.CurrentDomain.FirstChanceException += (sender, eventArgs) =>
+            {
+                Debug.WriteLine(eventArgs.Exception.ToString());
+            };
+
+            // Start the application
 
             ApplyAnyOverrideCulture(); // this must be done before any UI is generated
 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -143,7 +143,6 @@ namespace Eddi
                 // Set up the EDDI configuration
                 EDDIConfiguration configuration = EDDIConfiguration.FromFile();
                 updateHomeSystemStation(configuration);
-                _Rollbar.configureRollbarExceptionHandling(configuration.Beta, configuration.uniqueId);
 
                 // Set up monitors and responders
                 monitors = findMonitors();

--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -37,9 +37,6 @@ namespace Eddi
         [JsonProperty("exporttarget")]
         public string exporttarget { get; set; } = "Coriolis";
 
-        [JsonProperty("uniqueId")]
-        public string uniqueId { get; set; }
-
         /// <summary> Administrative values </summary>
         public bool validSystem { get; set; }
         public bool validStation { get; set; }
@@ -61,9 +58,6 @@ namespace Eddi
 
             // Default the galnet monitor to 'off'
             Plugins.Add("Galnet monitor", false);
-
-            // Generate an id unique to this configuration for bug tracking
-            uniqueId = Guid.NewGuid().ToString();
         }
 
         /// <summary>

--- a/EDDI/Properties/Settings.Designer.cs
+++ b/EDDI/Properties/Settings.Designer.cs
@@ -82,5 +82,17 @@ namespace Eddi.Properties {
                 this["OverrideCulture"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string uniqueID {
+            get {
+                return ((string)(this["uniqueID"]));
+            }
+            set {
+                this["uniqueID"] = value;
+            }
+        }
     }
 }

--- a/EDDI/Properties/Settings.settings
+++ b/EDDI/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="OverrideCulture" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="uniqueID" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -174,7 +174,7 @@ namespace Utilities
         {
             var config = new RollbarConfig(rollbarWriteToken)
             {
-                Environment = beta ? "development" : "production",
+                Environment = Constants.EDDI_VERSION,
                 ScrubFields = new string[] // Scrub these fields from the reported data
                 {
                     "Commander", "apiKey", "commanderName", Constants.DATA_DIR
@@ -184,7 +184,7 @@ namespace Utilities
                 // Set server info
                 Server = new Rollbar.DTOs.Server
                 {
-                    CodeVersion = Constants.EDDI_VERSION,
+                    CodeVersion = ThisAssembly.Git.Commit,
                     Root = "/"
                 },
             };

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -128,7 +128,7 @@ namespace Utilities
             try
             {
                 message.Replace(Constants.DATA_DIR, ""); // Scrub out data directories, if present in the Rollbar message.
-                if (!(data is Dictionary<string, object>))
+                if (!(data is Dictionary<string, object> || data is Exception))
                 {
                     var wrapppedData = new Dictionary<string, object>()
                     {

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -127,6 +127,7 @@ namespace Utilities
 #else
             try
             {
+                message.Replace(Constants.DATA_DIR, ""); // Scrub out data directories, if present in the Rollbar message.
                 if (!(data is Dictionary<string, object>))
                 {
                     var wrapppedData = new Dictionary<string, object>()

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -21,7 +21,7 @@ namespace Utilities
 
         public static void Error(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
-            Error(ex.ToString(), memberName, filePath);
+            Error(ex.Message, ex.ToString(), memberName, filePath);
         }
 
         public static void Error(string message, string data = null, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
@@ -42,7 +42,7 @@ namespace Utilities
 
         public static void Warn(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
-            Warn(ex.ToString(), memberName, filePath);
+            Warn(ex.Message, ex.ToString(), memberName, filePath);
         }
 
         public static void Warn(string message, string data, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
@@ -62,7 +62,7 @@ namespace Utilities
 
         public static void Info(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
-            Info(ex.ToString(), memberName, filePath);
+            Info(ex.Message, ex.ToString(), memberName, filePath);
         }
 
         public static void Info(string message, string data, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -128,6 +130,13 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\GitInfo.2.0.10\build\GitInfo.targets" Condition="Exists('..\packages\GitInfo.2.0.10\build\GitInfo.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\GitInfo.2.0.10\build\GitInfo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitInfo.2.0.10\build\GitInfo.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Utilities/packages.config
+++ b/Utilities/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="GitInfo" version="2.0.10" targetFramework="net471" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net471" />
   <package id="RestSharp" version="106.2.1" targetFramework="net471" />
   <package id="Rollbar" version="1.1.1" targetFramework="net471" />


### PR DESCRIPTION
- 2nd attempt to remove user directory information from Rollbar reports.
- Allow exceptions to pass through to Rollbar without a wrapper
- Standardize messages to report exceptions within the data payload (rather than sometimes within the message body)
- Revise Rollbar "Environment" variable to match EDDI version and "CodeVersion" variable match Git SHA. Per https://docs.rollbar.com/docs/source-control/ this will allow better linking between Rollbar and correct code versions for better stack traces.
- Move Rollbar initialization from EDDI.cs to App.xaml.cs and add hooks to improve EDDI's capture of unhandled exceptions.
- Catch and write managed exceptions (contained within try-catch statements) to the Visual Studios Output window while debugging.
