### PR TITLE
Fix Friends event

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2055,14 +2055,15 @@ namespace EddiJournalMonitor
                                 {
                                     if (friends[index].status != cmdr.status)
                                     {
-                                        /// This is a known friend: replace in situ (this is more efficient than removing and re-adding).
+                                        /// This is a known friend with a revised status: replace in situ (this is more efficient than removing and re-adding).
                                         friends[index] = cmdr;
-                                    }                                }
+                                        events.Add(new FriendsEvent(timestamp, name, status) { raw = line });
+                                    }
+                                }
                                 else
                                 {
                                     /// This is a new friend, add them to the list
                                     friends.Add(cmdr);
-                                    events.Add(new FriendsEvent(timestamp, name, status) { raw = line });
                                 }
 
                                 handled = true;

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -236,5 +236,29 @@ namespace UnitTests
 
             Assert.AreEqual("Wine", event1.commodity);
         }
+
+        [TestMethod]
+        public void TestFriends()
+        {
+            string line = "{ \"timestamp\":\"2017-08-24T17:22:03Z\", \"event\":\"Friends\", \"Status\":\"Online\", \"Name\":\"_Testy_McTest_\" }";
+            string line2 = "{ \"timestamp\":\"2017-08-24T17:22:03Z\", \"event\":\"Friends\", \"Status\":\"Offline\", \"Name\":\"_Testy_McTest_\" }";
+
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            events = JournalMonitor.ParseJournalEntry(line2);
+
+            /// Since this friend is unknown to us, the first time we see this friend no event should trigger. 
+            /// Only the second line, registering the status as offline, should be registered as an event.
+            Assert.IsTrue(events.Count == 1);
+
+            FriendsEvent @event = (FriendsEvent)events[0];
+            Friend testFriend = new Friend();
+            testFriend.name = @event.name;
+            testFriend.status = @event.status;
+
+            Assert.AreEqual("Offline", @event.status);
+
+            // Clean up
+            Eddi.EDDI.Instance.Cmdr.friends.Remove(testFriend);
+        }
     }
 }


### PR DESCRIPTION
The friends event should be triggering when
1. A friend is already being tracked on our list (the initial rush of events when you log in populates the list, index > 0) and
2. There is a change in the status of that friend (friends[index].status != cmdr.status).

Looks like we may have got this a bit backwards previously during an editorial review so that we were triggering the event under the wrong conditions. ;-)