### PR TITLE
Update crime definitions per Rollbar data.

### DIFF
--- a/DataDefinitions/Crime.cs
+++ b/DataDefinitions/Crime.cs
@@ -25,16 +25,17 @@ namespace EddiDataDefinitions
             var FireInStation = new Crime("fireInStation");
             var DumpingDangerous = new Crime("dumpingDangerous");
             var DumpingNearStation = new Crime("dumpingNearStation");
-            var BlockingAirlockMinor = new Crime("dockingMinonBlockingAirlock");
+            var BlockingAirlockMinor = new Crime("dockingMinorBlockingAirlock");
             var BlockingAirlockMajor = new Crime("dockingMajorBlockingAirlock");
             var BlockingLandingPadMinor = new Crime("dockingMinorBlockingLandingPad");
             var BlockingLandingPadMajor = new Crime("dockingMajorBlockingLandingPad");
-            var TrespassMinor = new Crime("dockingMinorTrespass");
-            var TrespassMajor = new Crime("dockingMajorTrespass");
+            var TrespassMinor = new Crime("dockingMinorTresspass");
+            var TrespassMajor = new Crime("dockingMajorTresspass");
             var Collided = new Crime("collidedAtSpeedInNoFireZone");
             var CollidedWithDamage = new Crime("collidedAtSpeedInNoFireZone_hulldamage");
             var RecklessWeaponsDischarge = new Crime("recklessWeaponsDischarge");
-        }
+            var PassengerWanted = new Crime("passengerWanted");
+    }
 
         // dummy used to ensure that the static constructor has run
         public Crime() : this("")


### PR DESCRIPTION
Notes:
- dockingMinorBlockingAirlock had a typo
- dockingMinorTresspass doesn't match the journal manual (has an extra `s`)
- dockingMajorTresspass doesn't match the journal manual (has an extra `s`)
- passengerWanted is a new crime that doesn't appear in the journal manual but is present in-game