### PR TITLE
Update crime definitions per Rollbar data.

### DIFF
--- a/DataDefinitions/Crime.cs
+++ b/DataDefinitions/Crime.cs
@@ -25,16 +25,17 @@ namespace EddiDataDefinitions
             var FireInStation = new Crime("fireInStation");
             var DumpingDangerous = new Crime("dumpingDangerous");
             var DumpingNearStation = new Crime("dumpingNearStation");
-            var BlockingAirlockMinor = new Crime("dockingMinonBlockingAirlock");
+            var BlockingAirlockMinor = new Crime("dockingMinorBlockingAirlock");
             var BlockingAirlockMajor = new Crime("dockingMajorBlockingAirlock");
             var BlockingLandingPadMinor = new Crime("dockingMinorBlockingLandingPad");
             var BlockingLandingPadMajor = new Crime("dockingMajorBlockingLandingPad");
-            var TrespassMinor = new Crime("dockingMinorTrespass");
-            var TrespassMajor = new Crime("dockingMajorTrespass");
+            var TrespassMinor = new Crime("dockingMinorTresspass");
+            var TrespassMajor = new Crime("dockingMajorTresspass");
             var Collided = new Crime("collidedAtSpeedInNoFireZone");
             var CollidedWithDamage = new Crime("collidedAtSpeedInNoFireZone_hulldamage");
             var RecklessWeaponsDischarge = new Crime("recklessWeaponsDischarge");
-        }
+            var PassengerWanted = new Crime("passengerWanted");
+    }
 
         // dummy used to ensure that the static constructor has run
         public Crime() : this("")

--- a/DataDefinitions/Properties/Crimes.es.resx
+++ b/DataDefinitions/Properties/Crimes.es.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
+  <!-- 
 		Microsoft ResX Schema
 
 		Version 1.3
@@ -58,46 +58,45 @@
 			: using a System.ComponentModel.TypeConverter
 			: and then encoded with base64 encoding.
 	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="assault" xml:space="preserve">
     <value>Asalto</value>
     <comment>Crime assault</comment>
@@ -138,9 +137,9 @@
     <value>Tirar carga cerca de la estación</value>
     <comment>Crime dumpingNearStation</comment>
   </data>
-  <data name="dockingMinonBlockingAirlock" xml:space="preserve">
+  <data name="dockingMinorBlockingAirlock" xml:space="preserve">
     <value>Bloqueo esclusa de aire</value>
-    <comment>Crime dockingMinonBlockingAirlock</comment>
+    <comment>Crime dockingMinorBlockingAirlock</comment>
   </data>
   <data name="dockingMajorBlockingAirlock" xml:space="preserve">
     <value>Bloqueo esclusa de aire</value>
@@ -154,7 +153,7 @@
     <value>Bloqueo de plataforma de aterrizaje</value>
     <comment>Crime dockingMajorBlockingLandingPad</comment>
   </data>
-  <data name="dockingMinorTrespass" xml:space="preserve">
+  <data name="dockingMinorTresspass" xml:space="preserve">
     <value>Traspasar</value>
     <comment>Crime dockingMinorTrespass</comment>
   </data>

--- a/DataDefinitions/Properties/Crimes.fr.resx
+++ b/DataDefinitions/Properties/Crimes.fr.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
+  <!-- 
 		Microsoft ResX Schema
 
 		Version 1.3
@@ -58,46 +58,45 @@
 			: using a System.ComponentModel.TypeConverter
 			: and then encoded with base64 encoding.
 	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="assault" xml:space="preserve">
     <value>Assault</value>
     <comment>Crime assault</comment>
@@ -138,9 +137,9 @@
     <value>Cargaison larguée à proximité d'une station</value>
     <comment>Crime dumpingNearStation</comment>
   </data>
-  <data name="dockingMinonBlockingAirlock" xml:space="preserve">
+  <data name="dockingMinorBlockingAirlock" xml:space="preserve">
     <value>Bloquer un sas</value>
-    <comment>Crime dockingMinonBlockingAirlock</comment>
+    <comment>Crime dockingMinorBlockingAirlock</comment>
   </data>
   <data name="dockingMajorBlockingAirlock" xml:space="preserve">
     <value>Bloquer un sas</value>
@@ -154,7 +153,7 @@
     <value>Bloquer une aire d'atterrissage</value>
     <comment>Crime dockingMajorBlockingLandingPad</comment>
   </data>
-  <data name="dockingMinorTrespass" xml:space="preserve">
+  <data name="dockingMinorTresspass" xml:space="preserve">
     <value>intrusion</value>
     <comment>Crime dockingMinorTrespass</comment>
   </data>

--- a/DataDefinitions/Properties/Crimes.resx
+++ b/DataDefinitions/Properties/Crimes.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
+  <!-- 
 		Microsoft ResX Schema
 
 		Version 1.3
@@ -58,46 +58,45 @@
 			: using a System.ComponentModel.TypeConverter
 			: and then encoded with base64 encoding.
 	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="assault" xml:space="preserve">
     <value>Assault</value>
     <comment>Crime assault</comment>
@@ -138,9 +137,9 @@
     <value>Dumping cargo near a station</value>
     <comment>Crime dumpingNearStation</comment>
   </data>
-  <data name="dockingMinonBlockingAirlock" xml:space="preserve">
+  <data name="dockingMinorBlockingAirlock" xml:space="preserve">
     <value>Blocking an airlock</value>
-    <comment>Crime dockingMinonBlockingAirlock</comment>
+    <comment>Crime dockingMinorBlockingAirlock</comment>
   </data>
   <data name="dockingMajorBlockingAirlock" xml:space="preserve">
     <value>Blocking an airlock</value>
@@ -154,13 +153,13 @@
     <value>Blocking a landing pad</value>
     <comment>Crime dockingMajorBlockingLandingPad</comment>
   </data>
-  <data name="dockingMinorTrespass" xml:space="preserve">
+  <data name="dockingMinorTresspass" xml:space="preserve">
     <value>Trespass</value>
-    <comment>Crime dockingMinorTrespass</comment>
+    <comment>Crime dockingMinorTresspass</comment>
   </data>
-  <data name="dockingMajorTrespass" xml:space="preserve">
+  <data name="dockingMajorTresspass" xml:space="preserve">
     <value>Major trespass</value>
-    <comment>Crime dockingMajorTrespass</comment>
+    <comment>Crime dockingMajorTresspass</comment>
   </data>
   <data name="collidedAtSpeedInNoFireZone" xml:space="preserve">
     <value>Collision</value>
@@ -173,5 +172,9 @@
   <data name="recklessWeaponsDischarge" xml:space="preserve">
     <value>reckless weapons discharge</value>
     <comment>Crime recklessWeaponsDischarge</comment>
+  </data>
+  <data name="passengerWanted" xml:space="preserve">
+    <value>carrying a wanted person</value>
+    <comment>Crime passengerWanted</comment>
   </data>
 </root>


### PR DESCRIPTION
Notes:
- dockingMinorBlockingAirlock had a typo
- dockingMinorTresspass doesn't match the journal manual (has an extra `s`)
- dockingMajorTresspass doesn't match the journal manual (has an extra `s`)
- passengerWanted is a new crime that doesn't appear in the journal manual but is present in-game