### PR TITLE
Implement "safe mode" for mandatory upgrades.

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -36,7 +36,7 @@ namespace Eddi
 
         private static bool started;
 
-        private static bool running = true;
+        internal static bool running = true;
 
         public bool inCQC { get; private set; } = false;
 
@@ -127,9 +127,8 @@ namespace Eddi
                 CheckUpgrade();
                 if (UpgradeRequired)
                 {
-                    // We are too old to continue; don't
+                    // We are too old to continue; initialize in a "safe mode". 
                     running = false;
-                    return;
                 }
 
                 // Ensure that our primary data structures have something in them.  This allows them to be updated from any source
@@ -145,60 +144,68 @@ namespace Eddi
                 updateHomeSystemStation(configuration);
                 _Rollbar.configureRollbarExceptionHandling(configuration.Beta, configuration.uniqueId);
 
-                // Set up monitors and responders
-                monitors = findMonitors();
-                responders = findResponders();
-
-                // Set up the app service
-                if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.READY)
+                if (running)
                 {
-                    // Carry out initial population of profile
-                    try
-                    {
-                        refreshProfile();
-                    }
-                    catch (Exception ex)
-                    {
-                        Logging.Debug("Failed to obtain profile: " + ex);
-                    }
-                }
+                    // Set up monitors and responders
+                    monitors = findMonitors();
+                    responders = findResponders();
 
-                Cmdr.insurance = configuration.Insurance;
-                Cmdr.gender = configuration.Gender;
-                if (Cmdr.name != null)
-                {
-                    Logging.Info("EDDI access to the companion app is enabled");
+                    // Set up the app service
+                    if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.READY)
+                    {
+                        // Carry out initial population of profile
+                        try
+                        {
+                            refreshProfile();
+                        }
+                        catch (Exception ex)
+                        {
+                            Logging.Debug("Failed to obtain profile: " + ex);
+                        }
+                    }
+
+
+                    Cmdr.insurance = configuration.Insurance;
+                    Cmdr.gender = configuration.Gender;
+                    if (Cmdr.name != null)
+                    {
+                        Logging.Info("EDDI access to the companion app is enabled");
+                    }
+                    else
+                    {
+                        // If InvokeUpdatePlugin failed then it will have have left an error message, but this once we ignore it
+                        Logging.Info("EDDI access to the companion app is disabled");
+                    }
+
+                    // Set up the star map service
+                    StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
+                    if (starMapCredentials != null && starMapCredentials.apiKey != null)
+                    {
+                        // Commander name might come from star map credentials or the companion app's profile
+                        string commanderName = null;
+                        if (starMapCredentials.commanderName != null)
+                        {
+                            commanderName = starMapCredentials.commanderName;
+                        }
+                        else if (Cmdr != null && Cmdr.name != null)
+                        {
+                            commanderName = Cmdr.name;
+                        }
+                        if (commanderName != null)
+                        {
+                            starMapService = new StarMapService(starMapCredentials.apiKey, commanderName);
+                            Logging.Info("EDDI access to EDSM is enabled");
+                        }
+
+                    }
+                    if (starMapService == null)
+                    {
+                        Logging.Info("EDDI access to EDSM is disabled");
+                    }
                 }
                 else
                 {
-                    // If InvokeUpdatePlugin failed then it will have have left an error message, but this once we ignore it
-                    Logging.Info("EDDI access to the companion app is disabled");
-                }
-
-                // Set up the star map service
-                StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
-                if (starMapCredentials != null && starMapCredentials.apiKey != null)
-                {
-                    // Commander name might come from star map credentials or the companion app's profile
-                    string commanderName = null;
-                    if (starMapCredentials.commanderName != null)
-                    {
-                        commanderName = starMapCredentials.commanderName;
-                    }
-                    else if (Cmdr != null && Cmdr.name != null)
-                    {
-                        commanderName = Cmdr.name;
-                    }
-                    if (commanderName != null)
-                    {
-                        starMapService = new StarMapService(starMapCredentials.apiKey, commanderName);
-                        Logging.Info("EDDI access to EDSM is enabled");
-                    }
-
-                }
-                if (starMapService == null)
-                {
-                    Logging.Info("EDDI access to EDSM is disabled");
+                    Logging.Info("Mandatory upgrade required! EDDI initializing in safe mode until upgrade is completed.");
                 }
 
                 // We always start in normal space

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -543,6 +543,10 @@ namespace Eddi
                 {
                     statusText.Text = Properties.EddiResources.frontier_api_nok;
                 }
+                else if (!EDDI.running)
+                {
+                    statusText.Text = Properties.EddiResources.safe_mode;
+                }
                 else
                 {
                     statusText.Text = Properties.EddiResources.operational;

--- a/EDDI/Properties/EddiResources.Designer.cs
+++ b/EDDI/Properties/EddiResources.Designer.cs
@@ -315,6 +315,15 @@ namespace Eddi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Safe mode - upgrade required..
+        /// </summary>
+        public static string safe_mode {
+            get {
+                return ResourceManager.GetString("safe_mode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Starting upgrade..
         /// </summary>
         public static string starting_upgrade {

--- a/EDDI/Properties/EddiResources.resx
+++ b/EDDI/Properties/EddiResources.resx
@@ -233,4 +233,7 @@ Please close the other instance and try again.</value>
     <value>Automatic</value>
     <comment>The user's system language</comment>
   </data>
+  <data name="safe_mode" xml:space="preserve">
+    <value>Safe mode - upgrade required.</value>
+  </data>
 </root>


### PR DESCRIPTION
Ref. #493. Allows an instance of EDDI to be initialized without starting start responders or monitors (including the journal parser).
This implementation is not quite the full extreme we discussed, as the visible config data can still be edited (I don't see a need to limit editing further at this time)
Resubmitting after rebasing.