### PR TITLE
Remove dead code from the Material Monitor

### DIFF
--- a/DataDefinitions/Material.cs
+++ b/DataDefinitions/Material.cs
@@ -234,23 +234,5 @@ namespace EddiDataDefinitions
             }
             return result;
         }
-
-        public static bool DeprecatedMaterials(string name)
-        {
-            // These material names have been replaced / are no longer in use. Listed for reference so that they won't be retained by the material monitor.
-            if (name == null)
-            {
-                return false;
-            }
-            List<string> deprecatedMaterialsList = new List<string>
-            {
-                "Thargoid Residue Data Analysis",
-                "Unknown Ship Signature",
-                "Unknown Wake Data",
-                "Unknown Fragment",
-            };
-
-            return deprecatedMaterialsList.Contains(name.Trim());
-        }
     }
 }

--- a/DataDefinitions/MaterialAmount.cs
+++ b/DataDefinitions/MaterialAmount.cs
@@ -11,6 +11,7 @@ namespace EddiDataDefinitions
 
         [JsonIgnore]
         private string _material;
+        [JsonIgnore]
         public string material
         {
             get
@@ -97,7 +98,9 @@ namespace EddiDataDefinitions
             }
         }
 
+        [JsonIgnore]
         private string _Category;
+        [JsonIgnore]
         public string Category
         {
             get
@@ -136,7 +139,7 @@ namespace EddiDataDefinitions
         }
 
         [JsonConstructor]
-        public MaterialAmount(string edname, string material, int amount, int? minimum, int? desired, int? maximum)
+        public MaterialAmount(string edname, int amount, int? minimum, int? desired, int? maximum)
         {
             Material My_material = Material.FromEDName(edname);
             this.material = My_material.localizedName;

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -346,45 +346,20 @@ namespace EddiMaterialMonitor
                 // Start with the materials we have in the log
                 foreach (MaterialAmount ma in configuration.materials)
                 {
-                    // Fix up & add any materials that are not deprecated material names 
-                    if (Material.DeprecatedMaterials(ma.material) == false)
+                    MaterialAmount ma2 = new MaterialAmount(ma.edname, ma.amount, ma.minimum, ma.desired, ma.maximum);
+                    // Make sure the edname is unique before adding the material to the new inventory 
+                    if (newInventory.Where(inv => inv.edname == ma2.edname).Count() == 0)
                     {
-                        bool addToInv = false;
-                        // if the edname is not set, or
-                        if (ma.edname == null)
+                        // Set material maximums if they aren't already defined
+                        if (ma2.maximum == null || ma2.maximum == 0)
                         {
-                            addToInv = true;
-                        }
-                        // if the edname is UNIQUE to the collection, or
-                        else if (configuration.materials.Any(item => item.edname == ma.edname) == false)
-                        {
-                            addToInv = true;
-                        }
-                        /// if the EDNAME IS NOT UNIQUE to the collection, the MATERIAL NAME IS UNIQUE, & THE EDNAME DOESN'T MATCH THE MATERIAL NAME 
-                        /// (once an EDName is established, this will identify & "heal" any duplicate entries having the same EDName in the materialmonitor)
-                        else if ((configuration.materials.Any(item => item.edname == ma.edname) == true) &&
-                            (configuration.materials.Any(item => item.material == ma.material) == true) &&
-                            (ma.edname != ma.material))
-                        {
-                            addToInv = true;
-                        }
-                        // then add the material to the new inventory list, preserving user preferences for that material
-                        if (addToInv == true)
-                        {
-                            MaterialAmount ma2 = new MaterialAmount(ma.edname, ma.material, ma.amount, ma.minimum, ma.desired, ma.maximum);
-
-                            // Set material maximums if they aren't already defined
-                            if (ma2.maximum == null || ma2.maximum == 0)
+                            int rarityLevel = Material.FromEDName(ma2.edname).rarity.level;
+                            if (rarityLevel > 0)
                             {
-                                int rarityLevel = Material.FromEDName(ma2.edname).rarity.level;
-                                if (rarityLevel > 0)
-                                {
-                                    ma2.maximum = -50 * (rarityLevel) + 350;
-                                }
+                                ma2.maximum = -50 * (rarityLevel) + 350;
                             }
-
-                            newInventory.Add(ma2);
                         }
+                        newInventory.Add(ma2);
                     }
                 }
 
@@ -395,12 +370,9 @@ namespace EddiMaterialMonitor
                     if (ma == null)
                     {
                         // We don't have this one - add it and set it to zero
-                        if ((Material.DeprecatedMaterials(material.invariantName) == false))
-                        {
-                            Logging.Debug("Adding new material " + material.invariantName + " to the materials list");
-                            ma = new MaterialAmount(material, 0);
-                            newInventory.Add(ma);
-                        }
+                        Logging.Debug("Adding new material " + material.invariantName + " to the materials list");
+                        ma = new MaterialAmount(material, 0);
+                        newInventory.Add(ma);
                     }
                 }
 

--- a/Tests/MaterialMonitorTests.cs
+++ b/Tests/MaterialMonitorTests.cs
@@ -38,11 +38,11 @@ namespace UnitTests
             MaterialAmount zirconiumAmount = config.materials[1];
             Assert.AreEqual("zirconium", zirconiumAmount.edname);
             Assert.AreEqual(13, zirconiumAmount.amount);
-            Assert.AreEqual(EddiDataDefinitions.Properties.Materials.zirconium, ResourceBasedLocalizedEDName<Material>.FromEDName(config.materials[1].edname).localizedName);
+            Assert.AreEqual(EddiDataDefinitions.Properties.Materials.zirconium, Material.FromEDName(config.materials[1].edname).localizedName);
             Assert.AreEqual(100, config.materials[1].maximum);
             Assert.AreEqual(50, config.materials[1].desired);
             Assert.IsNull(config.materials[1].minimum);
-            Assert.AreEqual(EddiDataDefinitions.Properties.MaterialCategories.Element, ResourceBasedLocalizedEDName<Material>.FromEDName(config.materials[1].edname).category.localizedName);
+            Assert.AreEqual(EddiDataDefinitions.Properties.MaterialCategories.Element, Material.FromEDName(config.materials[1].edname).category.localizedName);
         }
     }
 }

--- a/Tests/MaterialMonitorTests.cs
+++ b/Tests/MaterialMonitorTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Resources;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiDataDefinitions;
 using EddiMaterialMonitor;
@@ -12,35 +13,36 @@ namespace UnitTests
             ""materials"": [
             {
                 ""edname"": ""shieldpatternanalysis"",
-                ""material"": ""Aberrant Shield Pattern Analysis"",
                 ""amount"": 7,
                 ""minimum"": null,
                 ""desired"": null,
                 ""maximum"": null,
-                ""Category"": ""Encoded""
             },
 
             {
                 ""edname"": ""zirconium"",
-                ""material"": ""Zirconium"",
                 ""amount"": 13,
                 ""minimum"": null,
-                ""desired"": null,
-                ""maximum"": null,
-                ""Category"": ""Elements""
+                ""desired"": 50,
+                ""maximum"": 100,
             }
             ]
             }";
 
         [TestMethod]
-        public void TestLoadCAPI()
+        public void TestMaterialMonitor()
         {
-            
             MaterialMonitorConfiguration config = MaterialMonitorConfiguration.FromJsonString(json);
             Assert.AreEqual(2, config.materials.Count);
+
             MaterialAmount zirconiumAmount = config.materials[1];
             Assert.AreEqual("zirconium", zirconiumAmount.edname);
             Assert.AreEqual(13, zirconiumAmount.amount);
+            Assert.AreEqual(EddiDataDefinitions.Properties.Materials.zirconium, ResourceBasedLocalizedEDName<Material>.FromEDName(config.materials[1].edname).localizedName);
+            Assert.AreEqual(100, config.materials[1].maximum);
+            Assert.AreEqual(50, config.materials[1].desired);
+            Assert.IsNull(config.materials[1].minimum);
+            Assert.AreEqual(EddiDataDefinitions.Properties.MaterialCategories.Element, ResourceBasedLocalizedEDName<Material>.FromEDName(config.materials[1].edname).category.localizedName);
         }
     }
 }


### PR DESCRIPTION
...and (now that everything is tracked by edname) simplify the material monitor. Remove all localized strings from materialmonitor.json. Also, update material monitor test.