### PR TITLE
Fix system state info after internationalization

### DIFF
--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -22,6 +22,9 @@ namespace EddiDataDefinitions
         public string power { get; set; }
         public string powerstate { get; set; }
 
+        [Obsolete("Please use systemState instead")]
+        public string state => systemState?.localizedName ?? SystemState.None.localizedName;
+
         /// <summary>X co-ordinate for this system</summary>
         public decimal? x { get; set; }
         /// <summary>Y co-ordinate for this system</summary>
@@ -34,16 +37,10 @@ namespace EddiDataDefinitions
 
         /// <summary>Summary info for stations</summary>
         [JsonIgnore]
-        public List<Station> planetarystations
-        {
-            get { return stations.FindAll(s => s.IsPlanetary()); }
-        }
+        public List<Station> planetarystations => stations.FindAll(s => s.IsPlanetary());
 
         [JsonIgnore]
-        public List<Station> orbitalstations
-        {
-            get { return stations.FindAll(s => !s.IsPlanetary()); }
-        }
+        public List<Station> orbitalstations => stations.FindAll(s => !s.IsPlanetary());
 
         /// <summary>Details of bodies (stars/planets)</summary>
         public List<Body> bodies { get; set; }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -10,7 +10,7 @@ namespace EddiDataDefinitions
     public class StarSystem
     {
         // The ID in EDDB
-        public long EDDBID { get; set; }
+        public long? EDDBID { get; set; }
         public string name { get; set; }
         public long? population { get; set; }
         public string allegiance { get; set; }
@@ -21,6 +21,9 @@ namespace EddiDataDefinitions
         public string security { get; set; }
         public string power { get; set; }
         public string powerstate { get; set; }
+
+        [Obsolete("Please be explicit and use the systemState object instead")]
+        public string state { get { return systemState == null ? SystemState.FromEDName("None").localizedName : systemState.localizedName; } }
 
         /// <summary>X co-ordinate for this system</summary>
         public decimal? x { get; set; }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -23,7 +23,7 @@ namespace EddiDataDefinitions
         public string powerstate { get; set; }
 
         [Obsolete("Please use systemState instead")]
-        public string state => systemState?.localizedName ?? SystemState.None.localizedName;
+        public string state => (systemState ?? SystemState.None).localizedName;
 
         /// <summary>X co-ordinate for this system</summary>
         public decimal? x { get; set; }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -10,7 +10,7 @@ namespace EddiDataDefinitions
     public class StarSystem
     {
         // The ID in EDDB
-        public long? EDDBID { get; set; }
+        public long EDDBID { get; set; }
         public string name { get; set; }
         public long? population { get; set; }
         public string allegiance { get; set; }
@@ -21,9 +21,6 @@ namespace EddiDataDefinitions
         public string security { get; set; }
         public string power { get; set; }
         public string powerstate { get; set; }
-
-        [Obsolete("Please be explicit and use the systemState object instead")]
-        public string state { get { return systemState == null ? SystemState.FromEDName("None").localizedName : systemState.localizedName; } }
 
         /// <summary>X co-ordinate for this system</summary>
         public decimal? x { get; set; }

--- a/DataDefinitions/SystemState.cs
+++ b/DataDefinitions/SystemState.cs
@@ -13,14 +13,13 @@ namespace EddiDataDefinitions
         {
             resourceManager = Properties.SystemStates.ResourceManager;
             resourceManager.IgnoreCase = false;
-            missingEDNameHandler = (edname) => new SystemState(edname);
-
-            var None = new SystemState("None");
+            
+            None = new SystemState("None");
             var Retreat = new SystemState("Retreat");
             var War = new SystemState("War");
             var Lockdown = new SystemState("Lockdown");
-            var CivilUnrest = new SystemState("CivilUnrest");
-            var CivilWar = new SystemState("CivilWar");
+            CivilUnrest = new SystemState("CivilUnrest");
+            CivilWar = new SystemState("CivilWar");
             var Boom = new SystemState("Boom");
             var Expansion = new SystemState("Expansion");
             var Bust = new SystemState("Bust");
@@ -29,6 +28,10 @@ namespace EddiDataDefinitions
             var Election = new SystemState("Election");
             var Investment = new SystemState("Investment");
         }
+
+        public static readonly SystemState None;
+        public static readonly SystemState CivilUnrest;
+        public static readonly SystemState CivilWar;
 
         // dummy used to ensure that the static constructor has run
         public SystemState() : this("")

--- a/DataDefinitions/SystemState.cs
+++ b/DataDefinitions/SystemState.cs
@@ -13,13 +13,14 @@ namespace EddiDataDefinitions
         {
             resourceManager = Properties.SystemStates.ResourceManager;
             resourceManager.IgnoreCase = false;
-            
-            None = new SystemState("None");
+            missingEDNameHandler = (edname) => new SystemState(edname);
+
+            var None = new SystemState("None");
             var Retreat = new SystemState("Retreat");
             var War = new SystemState("War");
             var Lockdown = new SystemState("Lockdown");
-            CivilUnrest = new SystemState("CivilUnrest");
-            CivilWar = new SystemState("CivilWar");
+            var CivilUnrest = new SystemState("CivilUnrest");
+            var CivilWar = new SystemState("CivilWar");
             var Boom = new SystemState("Boom");
             var Expansion = new SystemState("Expansion");
             var Bust = new SystemState("Bust");
@@ -28,10 +29,6 @@ namespace EddiDataDefinitions
             var Election = new SystemState("Election");
             var Investment = new SystemState("Investment");
         }
-
-        public static readonly SystemState None;
-        public static readonly SystemState CivilUnrest;
-        public static readonly SystemState CivilWar;
 
         // dummy used to ensure that the static constructor has run
         public SystemState() : this("")

--- a/EDDPMonitor/SystemStateChangedEvent.cs
+++ b/EDDPMonitor/SystemStateChangedEvent.cs
@@ -10,7 +10,7 @@ namespace EddiEddpMonitor
         public const string NAME = "System state changed";
         public const string DESCRIPTION = "Triggered when there is a change in the state of a watched system";
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
-        public static SystemStateChangedEvent SAMPLE = new SystemStateChangedEvent(DateTime.Now, "home", "Shinrarta Dezhra", SystemState.CivilUnrest, SystemState.CivilWar);
+        public static SystemStateChangedEvent SAMPLE = new SystemStateChangedEvent(DateTime.Now, "home", "Shinrarta Dezhra", SystemState.FromEDName("CivilUnrest"), SystemState.FromEDName("CivilWar"));
 
         static SystemStateChangedEvent()
         {
@@ -24,16 +24,16 @@ namespace EddiEddpMonitor
 
         public string system { get; private set; }
 
-        public SystemState oldstate { get; private set; }
+        public string oldstate { get; private set; }
 
-        public SystemState newstate { get; private set; }
+        public string newstate { get; private set; }
 
         public SystemStateChangedEvent(DateTime timestamp, string match, string system, SystemState oldstate, SystemState newstate) : base(timestamp, NAME)
         {
             this.match = match;
             this.system = system;
-            this.oldstate = oldstate;
-            this.newstate = newstate;
+            this.oldstate = (oldstate == null ? SystemState.FromEDName("None").localizedName : oldstate.localizedName);
+            this.newstate = (newstate == null ? SystemState.FromEDName("None").localizedName : newstate.localizedName);
         }
     }
 }

--- a/EDDPMonitor/SystemStateChangedEvent.cs
+++ b/EDDPMonitor/SystemStateChangedEvent.cs
@@ -24,16 +24,20 @@ namespace EddiEddpMonitor
 
         public string system { get; private set; }
 
-        public SystemState oldstate { get; private set; }
+        public SystemState oldSystemState { get; private set; }
+        public SystemState newSystemState { get; private set; }
 
-        public SystemState newstate { get; private set; }
+        [Obsolete("Please use oldSystemState instead")]
+        public string oldstate => (oldSystemState ?? SystemState.None).localizedName;
+        [Obsolete("Please use newSystemState instead")]
+        public string newstate => (newSystemState ?? SystemState.None).localizedName;
 
-        public SystemStateChangedEvent(DateTime timestamp, string match, string system, SystemState oldstate, SystemState newstate) : base(timestamp, NAME)
+        public SystemStateChangedEvent(DateTime timestamp, string match, string system, SystemState oldSystemState, SystemState newSystemState) : base(timestamp, NAME)
         {
             this.match = match;
             this.system = system;
-            this.oldstate = oldstate;
-            this.newstate = newstate;
+            this.oldSystemState = oldSystemState;
+            this.newSystemState = newSystemState;
         }
     }
 }

--- a/EDDPMonitor/SystemStateChangedEvent.cs
+++ b/EDDPMonitor/SystemStateChangedEvent.cs
@@ -10,7 +10,7 @@ namespace EddiEddpMonitor
         public const string NAME = "System state changed";
         public const string DESCRIPTION = "Triggered when there is a change in the state of a watched system";
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
-        public static SystemStateChangedEvent SAMPLE = new SystemStateChangedEvent(DateTime.Now, "home", "Shinrarta Dezhra", SystemState.FromEDName("CivilUnrest"), SystemState.FromEDName("CivilWar"));
+        public static SystemStateChangedEvent SAMPLE = new SystemStateChangedEvent(DateTime.Now, "home", "Shinrarta Dezhra", SystemState.CivilUnrest, SystemState.CivilWar);
 
         static SystemStateChangedEvent()
         {
@@ -24,16 +24,16 @@ namespace EddiEddpMonitor
 
         public string system { get; private set; }
 
-        public string oldstate { get; private set; }
+        public SystemState oldstate { get; private set; }
 
-        public string newstate { get; private set; }
+        public SystemState newstate { get; private set; }
 
         public SystemStateChangedEvent(DateTime timestamp, string match, string system, SystemState oldstate, SystemState newstate) : base(timestamp, NAME)
         {
             this.match = match;
             this.system = system;
-            this.oldstate = (oldstate == null ? SystemState.FromEDName("None").localizedName : oldstate.localizedName);
-            this.newstate = (newstate == null ? SystemState.FromEDName("None").localizedName : newstate.localizedName);
+            this.oldstate = oldstate;
+            this.newstate = newstate;
         }
     }
 }

--- a/Events/DockedEvent.cs
+++ b/Events/DockedEvent.cs
@@ -58,7 +58,7 @@ namespace EddiEvents
             this.model = model;
             this.allegiance = allegiance;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate == null ? SystemState.FromEDName("None").localizedName : factionstate.localizedName);
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.distancefromstar = distancefromstar;

--- a/Events/DockedEvent.cs
+++ b/Events/DockedEvent.cs
@@ -58,7 +58,7 @@ namespace EddiEvents
             this.model = model;
             this.allegiance = allegiance;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.FromEDName("None").localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.distancefromstar = distancefromstar;

--- a/Events/DockedEvent.cs
+++ b/Events/DockedEvent.cs
@@ -58,7 +58,7 @@ namespace EddiEvents
             this.model = model;
             this.allegiance = allegiance;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate ?? SystemState.None).localizedName;
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.distancefromstar = distancefromstar;

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -68,7 +68,7 @@ namespace EddiEvents
             this.fuelremaining = fuelremaining;
             this.allegiance = (allegiance ?? Superpower.None).localizedName;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate == null ? SystemState.FromEDName("None").localizedName : factionstate.localizedName);
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.security = (security ?? SecurityLevel.None).localizedName;

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -68,7 +68,7 @@ namespace EddiEvents
             this.fuelremaining = fuelremaining;
             this.allegiance = (allegiance ?? Superpower.None).localizedName;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.FromEDName("None").localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.security = (security ?? SecurityLevel.None).localizedName;

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -68,7 +68,7 @@ namespace EddiEvents
             this.fuelremaining = fuelremaining;
             this.allegiance = (allegiance ?? Superpower.None).localizedName;
             this.faction = faction;
-            this.factionstate = (factionstate == null ? SystemState.None.localizedName : factionstate.localizedName);
+            this.factionstate = (factionstate ?? SystemState.None).localizedName;
             this.economy = (economy ?? Economy.None).localizedName;
             this.government = (government ?? Government.None).localizedName;
             this.security = (security ?? SecurityLevel.None).localizedName;


### PR DESCRIPTION
With internationalization, the `state` string in the `StarSystem` class was converted to reference the `SystemState` object and was renamed to `systemState`.
This PR removes inconsistencies in handling different system states, resolves incompatibilities with existing Cottle scripts, and presents the system state to the end user as a localized string rather than as an object.

(converting the `EDDBID` in `StarSystem.cs` from `long` to `long?` is unrelated, though it did prevent some exceptions I was seeing while testing... possibly related to prior tests I've done with acquiring system data from EDSM, which doesn't provide an EDDBID)