### PR TITLE
Fix/cottle null refs

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -673,8 +673,11 @@ namespace EddiCargoMonitor
 
         private void handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
-            _handleMissionCompletedEvent(@event);
-            writeInventory();
+            if (@event.commodityDefinition != null || @event.commodityrewards != null)
+            {
+                _handleMissionCompletedEvent(@event);
+                writeInventory();
+            }
         }
 
         public void _handleMissionCompletedEvent(MissionCompletedEvent @event)

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -626,7 +626,7 @@ namespace EddiCargoMonitor
 
         private void handleMissionAcceptedEvent(MissionAcceptedEvent @event)
         {
-            if (@event.commodityDefinition.edname != null)
+            if (@event.commodityDefinition != null)
             {
                 _handleMissionAcceptedEvent(@event);
                 writeInventory();
@@ -720,9 +720,16 @@ namespace EddiCargoMonitor
                             break;
                         case "salvage":
                             {
-                                if (subtype.Contains("illegal"))
+                                if (subtype != null)
                                 {
-                                    cargo.stolen -= @event.amount ?? 0;
+                                    if (subtype.Contains("illegal"))
+                                    {
+                                        cargo.stolen -= @event.amount ?? 0;
+                                    }
+                                    else
+                                    {
+                                        cargo.haulage -= @event.amount ?? 0;
+                                    }
                                 }
                                 else
                                 {
@@ -1030,9 +1037,16 @@ namespace EddiCargoMonitor
                             break;
                         case "salvage":
                             {
-                                if (subtype.Contains("illegal"))
+                                if (subtype != null)
                                 {
-                                    stolenNeeded += haulageAmount.amount;
+                                    if (subtype.Contains("illegal"))
+                                    {
+                                        stolenNeeded += haulageAmount.amount;
+                                    }
+                                    else
+                                    {
+                                        haulageNeeded += haulageAmount.amount;
+                                    }
                                 }
                                 else
                                 {

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -265,7 +265,7 @@ namespace EddiCargoMonitor
 
         public void _handleCommodityCollectedEvent(CommodityCollectedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 bool handled = false;
@@ -318,7 +318,7 @@ namespace EddiCargoMonitor
             }
             else
             {
-                Cargo newCargo = new Cargo(@event.commodityDefinition.edname, 1);
+                Cargo newCargo = new Cargo(@event.commodityDefinition?.edname, 1);
                 newCargo.haulage = 0;
                 if (@event.stolen)
                 {
@@ -340,7 +340,7 @@ namespace EddiCargoMonitor
 
         public void _handleCommodityEjectedEvent(CommodityEjectedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 bool handled = false;
@@ -412,7 +412,7 @@ namespace EddiCargoMonitor
 
         public void _handleCommodityPurchasedEvent(CommodityPurchasedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 cargo.owned += @event.amount;
@@ -420,7 +420,7 @@ namespace EddiCargoMonitor
             }
             else
             {
-                Cargo newCargo = new Cargo(@event.commodityDefinition.edname, @event.amount, @event.price);
+                Cargo newCargo = new Cargo(@event.commodityDefinition?.edname, @event.amount, @event.price);
                 newCargo.haulage = 0;
                 newCargo.stolen = 0;
                 newCargo.owned = @event.amount;
@@ -436,7 +436,7 @@ namespace EddiCargoMonitor
 
         public void _handleCommodityRefinedEvent(CommodityRefinedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 cargo.owned++;
@@ -444,7 +444,7 @@ namespace EddiCargoMonitor
             }
             else
             {
-                Cargo newCargo = new Cargo(@event.commodityDefinition.edname, 1);
+                Cargo newCargo = new Cargo(@event.commodityDefinition?.edname, 1);
                 newCargo.haulage = 0;
                 newCargo.stolen = 0;
                 newCargo.owned = 1;
@@ -460,7 +460,7 @@ namespace EddiCargoMonitor
 
         public void _handleCommoditySoldEvent(CommoditySoldEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 if (@event.stolen)
@@ -492,7 +492,7 @@ namespace EddiCargoMonitor
 
         public void _handlePowerCommodityObtainedEvent(PowerCommodityObtainedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 cargo.owned += @event.amount;
@@ -500,7 +500,7 @@ namespace EddiCargoMonitor
             }
             else
             {
-                Cargo newCargo = new Cargo(@event.commodityDefinition.edname, @event.amount);
+                Cargo newCargo = new Cargo(@event.commodityDefinition?.edname, @event.amount);
                 newCargo.haulage = 0;
                 newCargo.stolen = 0;
                 newCargo.owned = @event.amount;
@@ -516,7 +516,7 @@ namespace EddiCargoMonitor
 
         public void _handlePowerCommodityDeliveredEvent(PowerCommodityDeliveredEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 cargo.owned -= @event.amount;
@@ -649,7 +649,7 @@ namespace EddiCargoMonitor
                     {
                         int amount = (type == "delivery" || type == "smuggle") ? @event.amount ?? 0 : 0;
                         HaulageAmount haulageAmount = new HaulageAmount(@event.missionid ?? 0, @event.name, @event.amount ?? 0, (DateTime)@event.expiry);
-                        Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+                        Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
                         if (cargo != null)
                         {
                             cargo.haulage += amount;
@@ -658,7 +658,7 @@ namespace EddiCargoMonitor
                         }
                         else
                         {
-                            Cargo newCargo = new Cargo(@event.commodityDefinition.edname, amount);
+                            Cargo newCargo = new Cargo(@event.commodityDefinition?.edname, amount);
                             newCargo.haulage = amount;
                             newCargo.stolen = 0;
                             newCargo.owned = 0;
@@ -682,7 +682,7 @@ namespace EddiCargoMonitor
 
         public void _handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 HaulageAmount haulageAmount = cargo.haulageamounts.FirstOrDefault(ha => ha.id == @event.missionid);
@@ -829,7 +829,7 @@ namespace EddiCargoMonitor
 
         public void _handleSearchAndRescueEvent(SearchAndRescueEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
             {
                 cargo.owned -= Math.Min(cargo.owned, @event.amount ?? 0);

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -619,7 +619,7 @@ namespace EddiCompanionAppService
                         case "module":
                         case "utility":
                             {
-                                long id = (long)json["module"]["id"];
+                                long id = module["id"];
                                 Module Module = new Module(Module.FromEliteID(id));
                                 if (Module?.invariantName == null)
                                 {
@@ -633,7 +633,6 @@ namespace EddiCompanionAppService
                     }
                 }
             }
-
             return Modules;
         }
 

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -683,7 +683,7 @@ namespace EddiCompanionAppService
         // Obtain the list of commodities from the profile
         private static List<CommodityMarketQuote> CommodityQuotesFromProfile(dynamic json)
         {
-            var quotes = new List<CommodityMarketQuote>();
+            List<CommodityMarketQuote> quotes = new List<CommodityMarketQuote>();
 
             if (json["lastStarport"] != null && json["lastStarport"]["commodities"] != null)
             {
@@ -693,10 +693,10 @@ namespace EddiCompanionAppService
                     CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef);
                     quote.buyprice = (int)commodity["buyPrice"];
                     quote.stock = (int)commodity["stock"];
-                    quote.stockbracket = (dynamic)commodity["stockBracket"];
+                    quote.stockbracket = (int)commodity["stockBracket"];
                     quote.sellprice = (int)commodity["sellPrice"];
                     quote.demand = (int)commodity["demand"];
-                    quote.demandbracket = (dynamic)commodity["demandBracket"];
+                    quote.demandbracket = (int)commodity["demandBracket"];
 
                     List<string> StatusFlags = new List<string>();
                     foreach (dynamic statusFlag in commodity["statusFlags"])
@@ -706,7 +706,7 @@ namespace EddiCompanionAppService
                     quote.StatusFlags = StatusFlags;
                     quotes.Add(quote);
 
-                    if (commodityDef == null || (string)commodity["name"] != commodityDef.invariantName)
+                    if (commodityDef == null || (string)commodity["name"] != commodityDef.edname)
                     {
                         if (commodityDef.edname != "Drones")
                         {

--- a/DataDefinitions/Cargo.cs
+++ b/DataDefinitions/Cargo.cs
@@ -17,6 +17,8 @@ namespace EddiDataDefinitions
         public string invariantName => commodityDef?.invariantName ?? "";
         [JsonIgnore]
         public string localizedName => commodityDef?.localizedName ?? "";
+        [JsonIgnore, Obsolete("Please use localizedName or invariantName")]
+        public string name => localizedName;
 
         public string edname
         {
@@ -75,6 +77,8 @@ namespace EddiDataDefinitions
                 }
             }
         }
+        [Obsolete("please use owned instead")]
+        public int other => owned;
 
         // The number of items needed for missions
         [JsonIgnore]
@@ -106,7 +110,7 @@ namespace EddiDataDefinitions
         public string localizedCategory => commodityDef?.category?.localizedName ?? null;
 
         // deprecated commodity category (exposed to Cottle and VA)
-        [JsonIgnore, Obsolete("Please use localizedCategory instead")]
+        [Obsolete("Please use localizedCategory instead")]
         public string category => localizedCategory;
 
         [JsonIgnore]
@@ -123,6 +127,9 @@ namespace EddiDataDefinitions
                 NotifyPropertyChanged("localizedCategory");
             }
         }
+
+        [Obsolete]
+        public CommodityDefinition commodity => commodityDef;
 
         public List<HaulageAmount> haulageamounts { get; set; }
 

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace EddiDataDefinitions
 {
@@ -17,9 +18,10 @@ namespace EddiDataDefinitions
             get => definition.localizedName;
         }
 
-        // deprecated for UI usage but retained for JSON conversion from the cAPI
+        [Obsolete("deprecated for UI usage but retained for JSON conversion from the cAPI")]
         public string name
         {
+            get => definition.localizedName;
             set
             {
                 CommodityDefinition newDef = CommodityDefinition.FromName(value);
@@ -43,6 +45,13 @@ namespace EddiDataDefinitions
 
         // VB: same type as stockbracket above
         public List<string> StatusFlags { get; set; }
+
+        public long EliteID => definition.EliteID;
+        public long EDDBID => definition.EDDBID;
+        [Obsolete("Please use localizedName or InvariantName")]
+        public string category => definition.category.localizedName;
+        public int avgprice => definition.avgprice;
+        public bool rare => definition.rare;
 
         public CommodityMarketQuote(CommodityDefinition definition)
         {

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -299,6 +299,12 @@ namespace EddiDataDefinitions
             launchbays = new List<LaunchBay>();
         }
 
+        public override string ToString()
+        {
+            // This is mostly to help with debugging
+            return name ?? $"{Role.localizedName} {model}";
+        }
+
         public string SpokenName(string defaultname = null)
         {
             string model = (defaultname == null ? SpokenModel() : defaultname) ?? "ship";

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -18,7 +18,7 @@ namespace EddiJournalMonitor
 {
     public class JournalMonitor : LogMonitor, EDDIMonitor
     {
-        private static Regex JsonRegex = new Regex(@"^{.*}$");
+        private static Regex JsonRegex = new Regex(@"^{.*}$", RegexOptions.Singleline);
 
         public JournalMonitor() : base(GetSavedGamesDir(), @"^Journal.*\.[0-9\.]+\.log$", result =>
         ForwardJournalEntry(result, EDDI.Instance.eventHandler)) { }

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -13,44 +13,6 @@ namespace EddiShipMonitor
     {
         private static List<string> HARDPOINT_SIZES = new List<string>() { "Huge", "Large", "Medium", "Small", "Tiny" };
 
-        // Translations from the internal names used by Frontier to clean human-readable - Legacy code, not used.
-        private static Dictionary<string, string> shipTranslations = new Dictionary<string, string>()
-        {
-            { "Adder" , "Adder"},
-            { "Anaconda", "Anaconda" },
-            { "Asp", "Asp Explorer" },
-            { "Asp_Scout", "Asp Scout" },
-            { "BelugaLiner", "Beluga Liner" },
-            { "CobraMkIII", "Cobra Mk. III" },
-            { "CobraMkIV", "Cobra Mk. IV" },
-            { "Cutter", "Imperial Cutter" },
-            { "DiamondBack", "Diamondback Scout" },
-            { "DiamondBackXL", "Diamondback Explorer" },
-            { "Dolphin", "Dolphin" },
-            { "Eagle", "Eagle" },
-            { "Empire_Courier", "Imperial Courier" },
-            { "Empire_Eagle", "Imperial Eagle" },
-            { "Empire_Fighter", "Imperial Fighter" },
-            { "Empire_Trader", "Imperial Clipper" },
-            { "Federation_Corvette", "Federal Corvette" },
-            { "Federation_Dropship", "Federal Dropship" },
-            { "Federation_Dropship_MkII", "Federal Assault Ship" },
-            { "Federation_Gunship", "Federal Gunship" },
-            { "Federation_Fighter", "F63 Condor" },
-            { "FerDeLance", "Fer-de-Lance" },
-            { "Hauler", "Hauler" },
-            { "Independant_Trader", "Keelback" },
-            { "Orca", "Orca" },
-            { "Python", "Python" },
-            { "SideWinder", "Sidewinder" },
-            { "Type6", "Type-6 Transporter" },
-            { "Type7", "Type-7 Transporter" },
-            { "Type9", "Type-9 Heavy" },
-            { "Viper", "Viper Mk. III" },
-            { "Viper_MkIV", "Viper Mk. IV" },
-            { "Vulture", "Vulture" }
-        };
-
         public static List<Ship> ShipyardFromJson(Ship activeShip, dynamic json)
         {
             List<Ship> shipyard = new List<Ship>();

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -851,8 +851,6 @@ namespace EddiShipMonitor
             {
                 ship.Role = Role.MultiPurpose;
             }
-            // Remove the ship first (just in case we are trying to add a ship that already exists)
-            _RemoveShip(ship.LocalId);
             _ReplaceOrAddShip(ship);
             writeShips();
         }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -379,6 +379,17 @@ namespace EddiShipMonitor
 
         private void handleShipLoadoutEvent(ShipLoadoutEvent @event)
         {
+            Ship ship = ParseShipLoadoutEvent(@event);
+
+            // Update the global variable
+            EDDI.Instance.CurrentShip = ship;
+
+            AddShip(ship);
+            writeShips();
+        }
+
+        private Ship ParseShipLoadoutEvent(ShipLoadoutEvent @event)
+        {
             // Obtain the ship to which this loadout refers
             Logging.Debug("Current Ship Id is: " + currentShipId + ", Loadout Ship Id is " + @event.shipid);
             Ship ship = GetShip(@event.shipid);
@@ -478,12 +489,7 @@ namespace EddiShipMonitor
 
             // Cargo capacity
             ship.cargocapacity = (int)ship.compartments.Where(c => c.module != null && c.module.basename.Equals("CargoRack")).Sum(c => Math.Pow(2, c.module.@class));
-
-            // Update the global variable
-            EDDI.Instance.CurrentShip = ship;
-
-            AddShip(ship);
-            writeShips();
+            return ship;
         }
 
         private void handleShipRebootedEvent(ShipRebootedEvent @event)

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -853,11 +853,11 @@ namespace EddiShipMonitor
             }
             // Remove the ship first (just in case we are trying to add a ship that already exists)
             _RemoveShip(ship.LocalId);
-            _AddShip(ship);
+            _ReplaceOrAddShip(ship);
             writeShips();
         }
 
-        private void _AddShip(Ship ship)
+        private void _ReplaceOrAddShip(Ship ship)
         {
             if (ship == null)
             {
@@ -865,6 +865,15 @@ namespace EddiShipMonitor
             }
             lock (shipyardLock)
             {
+                for (int i = 0; i < shipyard.Count; i++)
+                {
+                    if (shipyard[i].LocalId == ship.LocalId)
+                    {
+                        shipyard[i] = ship; // this is much more efficient than removing and adding
+                        return;
+                    }
+                }
+                // not found, so add
                 shipyard.Add(ship);
             }
         }

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -61,6 +61,30 @@ namespace UnitTests
         }
 
         [TestMethod]
+        [DeploymentItem("loadout.json")]
+        public void TestLoadoutParsing()
+        {
+            string data = System.IO.File.ReadAllText("loadout.json");
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.eventHandler(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+            Logging.Verbose = true;
+
+            List<Event> events = JournalMonitor.ParseJournalEntry(data);
+            Assert.AreEqual(1, events.Count);
+            ShipLoadoutEvent loadoutEvent = events[0] as ShipLoadoutEvent;
+            Assert.AreEqual("Peppermint", loadoutEvent.shipname);
+            Assert.AreEqual(18, loadoutEvent.compartments.Count);
+            Assert.AreEqual(7, loadoutEvent.hardpoints.Count);
+
+            ShipMonitor shipMonitor = new ShipMonitor();
+            var privateObject = new PrivateObject(shipMonitor);
+            object[] args = new object[]{loadoutEvent};
+            Ship ship = privateObject.Invoke("ParseShipLoadoutEvent", args) as Ship;
+            Assert.AreEqual("Peppermint", ship.name);
+        }
+
+        [TestMethod]
         public void TestShipScenario1()
         {
             int sidewinderId = 901;

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -233,10 +233,15 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="loadout.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="starsystems.txt" />
+    <Content Include="starsystems.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -260,7 +265,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy /y "$(SolutionDir)\SpeechResponder\EDDI.json" "$(ProjectDir)$(OutDir)"
-xcopy /y "$(ProjectDir)starsystems.txt" "$(ProjectDir)$(OutDir)"</PostBuildEvent>
+</PostBuildEvent>
   </PropertyGroup>
   <Import Project="..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.1\build\netstandard2.0\NETStandard.Library.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Tests/loadout.json
+++ b/Tests/loadout.json
@@ -1,0 +1,814 @@
+{
+  "timestamp": "2018-05-03T15:30:12Z",
+  "event": "Loadout",
+  "Ship": "Empire_Trader",
+  "ShipID": 6,
+  "ShipName": "Peppermint",
+  "ShipIdent": "VT-E23",
+  "HullValue": 13943105,
+  "ModulesValue": 111211684,
+  "Rebuy": 6257742,
+  "Modules": [
+    {
+      "Slot": "LargeHardpoint1",
+      "Item": "Hpt_MultiCannon_Gimbal_Large",
+      "On": true,
+      "Priority": 2,
+      "AmmoInClip": 90,
+      "AmmoInHopper": 2100,
+      "Health": 1.0,
+      "Value": 491671,
+      "Engineering": {
+        "Engineer": "Tod 'The Blaster' McQuinn",
+        "EngineerID": 300260,
+        "BlueprintID": 128673493,
+        "BlueprintName": "Weapon_LightWeight",
+        "Level": 4,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 3.026316,
+            "OriginalValue": 8.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 34.711037,
+            "OriginalValue": 64.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 0.862079,
+            "OriginalValue": 0.97,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "DistributorDraw",
+            "Value": 0.209744,
+            "OriginalValue": 0.25,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "LargeHardpoint2",
+      "Item": "Hpt_MultiCannon_Gimbal_Large",
+      "On": true,
+      "Priority": 2,
+      "AmmoInClip": 90,
+      "AmmoInHopper": 2100,
+      "Health": 1.0,
+      "Value": 507579,
+      "Engineering": {
+        "Engineer": "Tod 'The Blaster' McQuinn",
+        "EngineerID": 300260,
+        "BlueprintID": 128673493,
+        "BlueprintName": "Weapon_LightWeight",
+        "Level": 4,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 3.121546,
+            "OriginalValue": 8.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 35.268116,
+            "OriginalValue": 64.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 0.845046,
+            "OriginalValue": 0.97,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "DistributorDraw",
+            "Value": 0.204231,
+            "OriginalValue": 0.25,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "MediumHardpoint1",
+      "Item": "Hpt_PulseLaserBurst_Gimbal_Medium",
+      "On": true,
+      "Priority": 2,
+      "AmmoInClip": 1,
+      "AmmoInHopper": 1,
+      "Health": 1.0,
+      "Value": 41225,
+      "Engineering": {
+        "Engineer": "Broo Tarquin",
+        "EngineerID": 300030,
+        "BlueprintID": 128673368,
+        "BlueprintName": "Weapon_LightWeight",
+        "Level": 4,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 1.44919,
+            "OriginalValue": 4.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 21.830248,
+            "OriginalValue": 40.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 0.881879,
+            "OriginalValue": 1.04,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "DistributorDraw",
+            "Value": 0.417533,
+            "OriginalValue": 0.49,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "MediumHardpoint2",
+      "Item": "Hpt_MiningLaser_Fixed_Medium",
+      "On": false,
+      "Priority": 4,
+      "Health": 1.0,
+      "Value": 26414
+    },
+    {
+      "Slot": "TinyHardpoint1",
+      "Item": "Hpt_PlasmaPointDefence_Turret_Tiny",
+      "On": true,
+      "Priority": 2,
+      "AmmoInClip": 12,
+      "AmmoInHopper": 10000,
+      "Health": 1.0,
+      "Value": 16275,
+      "Engineering": {
+        "Engineer": "Ram Tah",
+        "EngineerID": 300110,
+        "BlueprintID": 128731484,
+        "BlueprintName": "PointDefence_LightWeight",
+        "Level": 4,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 0.151291,
+            "OriginalValue": 0.5,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 15.240648,
+            "OriginalValue": 30.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "TinyHardpoint2",
+      "Item": "Hpt_AntiUnknownShutdown_Tiny",
+      "On": false,
+      "Priority": 3,
+      "Health": 1.0,
+      "Value": 55283
+    },
+    {
+      "Slot": "TinyHardpoint3",
+      "Item": "Hpt_ChaffLauncher_Tiny",
+      "On": true,
+      "Priority": 3,
+      "AmmoInClip": 1,
+      "AmmoInHopper": 10,
+      "Health": 1.0,
+      "Value": 7459,
+      "Engineering": {
+        "Engineer": "Ram Tah",
+        "EngineerID": 300110,
+        "BlueprintID": 128731479,
+        "BlueprintName": "ChaffLauncher_LightWeight",
+        "Level": 4,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 0.428943,
+            "OriginalValue": 1.3,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 10.292671,
+            "OriginalValue": 20.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 0.179695,
+            "OriginalValue": 0.2,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Decal1",
+      "Item": "Decal_Beta_Tester",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Decal2",
+      "Item": "Decal_DistantWorlds",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Decal3",
+      "Item": "Decal_Explorer_Elite",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "PaintJob",
+      "Item": "PaintJob_empiretrader_vibrant_blue",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Armour",
+      "Item": "Empire_Trader_Armour_Grade1",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Engineering": {
+        "Engineer": "Selene Jean",
+        "EngineerID": 300210,
+        "BlueprintID": 128673642,
+        "BlueprintName": "Armour_HeavyDuty",
+        "Level": 3,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "DefenceModifierHealthMultiplier",
+            "Value": 106.324265,
+            "OriginalValue": 79.999992,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "KineticResistance",
+            "Value": -16.792118,
+            "OriginalValue": -20.000004,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "ThermicResistance",
+            "Value": 2.673239,
+            "OriginalValue": 0.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "ExplosiveResistance",
+            "Value": -36.257469,
+            "OriginalValue": -39.999996,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "PowerPlant",
+      "Item": "Int_Powerplant_Size5_Class5",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 4478720
+    },
+    {
+      "Slot": "MainEngines",
+      "Item": "Int_Engine_Size6_Class5",
+      "On": true,
+      "Priority": 0,
+      "Health": 1.0,
+      "Value": 13752601,
+      "Engineering": {
+        "Engineer": "Professor Palin",
+        "EngineerID": 300220,
+        "BlueprintID": 128673667,
+        "BlueprintName": "Engine_Tuned",
+        "Level": 3,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Integrity",
+            "Value": 107.045624,
+            "OriginalValue": 124.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 8.560772,
+            "OriginalValue": 7.56,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "EngineOptimalMass",
+            "Value": 1375.237061,
+            "OriginalValue": 1440.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "EngineOptPerformance",
+            "Value": 109.488525,
+            "OriginalValue": 100.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "EngineHeatRate",
+            "Value": 0.886751,
+            "OriginalValue": 1.3,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "FrameShiftDrive",
+      "Item": "Int_Hyperdrive_Size5_Class5",
+      "On": true,
+      "Priority": 0,
+      "Health": 1.0,
+      "Value": 4338358,
+      "Engineering": {
+        "Engineer": "Felicity Farseer",
+        "EngineerID": 300100,
+        "BlueprintID": 128673694,
+        "BlueprintName": "FSD_LongRange",
+        "Level": 5,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 28.437748,
+            "OriginalValue": 20.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 93.322952,
+            "OriginalValue": 120.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 0.697731,
+            "OriginalValue": 0.6,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "FSDOptimalMass",
+            "Value": 1547.139526,
+            "OriginalValue": 1050.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "MaxFuelPerJump",
+            "Value": 5.199397,
+            "OriginalValue": 5.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "LifeSupport",
+      "Item": "Int_LifeSupport_Size5_Class2",
+      "On": true,
+      "Priority": 2,
+      "Health": 1.0,
+      "Value": 69713,
+      "Engineering": {
+        "Engineer": "Bill Turner",
+        "EngineerID": 300010,
+        "BlueprintID": 128731491,
+        "BlueprintName": "LifeSupport_LightWeight",
+        "Level": 1,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 4.200576,
+            "OriginalValue": 8.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 59.469055,
+            "OriginalValue": 86.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "PowerDistributor",
+      "Item": "Int_PowerDistributor_Size6_Class2",
+      "On": true,
+      "Priority": 2,
+      "Health": 1.0,
+      "Value": 195195,
+      "Engineering": {
+        "Engineer": "The Dweller",
+        "EngineerID": 300180,
+        "BlueprintID": 128673739,
+        "BlueprintName": "PowerDistributor_HighFrequency",
+        "Level": 5,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "PowerDraw",
+            "Value": 0.616769,
+            "OriginalValue": 0.61,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "WeaponsCapacity",
+            "Value": 33.951099,
+            "OriginalValue": 38.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "WeaponsRecharge",
+            "Value": 5.314336,
+            "OriginalValue": 3.9,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "EnginesCapacity",
+            "Value": 23.2297,
+            "OriginalValue": 26.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "EnginesRecharge",
+            "Value": 3.270361,
+            "OriginalValue": 2.4,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "SystemsCapacity",
+            "Value": 23.2297,
+            "OriginalValue": 26.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "SystemsRecharge",
+            "Value": 3.270361,
+            "OriginalValue": 2.4,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Radar",
+      "Item": "Int_Sensors_Size5_Class5",
+      "On": true,
+      "Priority": 2,
+      "Health": 1.0,
+      "Value": 1055122,
+      "Engineering": {
+        "Engineer": "Juri Ishmaak",
+        "EngineerID": 300250,
+        "BlueprintID": 128740672,
+        "BlueprintName": "Sensor_LightWeight",
+        "Level": 4,
+        "Quality": 1.0,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 7.0,
+            "OriginalValue": 20.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 63.600002,
+            "OriginalValue": 106.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "SensorTargetScanAngle",
+            "Value": 24.0,
+            "OriginalValue": 30.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "FuelTank",
+      "Item": "Int_FuelTank_Size4_Class3",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 24730
+    },
+    {
+      "Slot": "Slot01_Size7",
+      "Item": "Int_FuelScoop_Size7_Class5",
+      "On": true,
+      "Priority": 4,
+      "Health": 1.0,
+      "Value": 80011016
+    },
+    {
+      "Slot": "Slot02_Size6",
+      "Item": "Int_CargoRack_Size6_Class1",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 308203
+    },
+    {
+      "Slot": "Slot03_Size4",
+      "Item": "Int_Repairer_Size4_Class5",
+      "On": false,
+      "Priority": 4,
+      "AmmoInClip": 5400,
+      "Health": 1.0,
+      "Value": 4145240,
+      "Engineering": {
+        "Engineer": "Bill Turner",
+        "EngineerID": 300010,
+        "BlueprintID": 128731658,
+        "BlueprintName": "AFM_Shielded",
+        "Level": 3,
+        "Quality": 0.0,
+        "Modifiers": [
+          {
+            "Label": "Integrity",
+            "Value": 186.404724,
+            "OriginalValue": 92.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 3.923744,
+            "OriginalValue": 2.31,
+            "LessIsGood": 1
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Slot04_Size4",
+      "Item": "Int_BuggyBay_Size4_Class2",
+      "On": false,
+      "Priority": 4,
+      "Health": 1.0,
+      "Value": 75816
+    },
+    {
+      "Slot": "Slot05_Size3",
+      "Item": "Int_ShieldGenerator_Size3_Class3_Fast",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 74284,
+      "Engineering": {
+        "Engineer": "Lei Cheung",
+        "EngineerID": 300120,
+        "BlueprintID": 128673828,
+        "BlueprintName": "ShieldGenerator_Optimised",
+        "Level": 4,
+        "Quality": 0.706,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 2.962,
+            "OriginalValue": 5.0,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "Integrity",
+            "Value": 51.200001,
+            "OriginalValue": 64.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "PowerDraw",
+            "Value": 1.19646,
+            "OriginalValue": 1.8,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "ShieldGenOptimalMass",
+            "Value": 156.75,
+            "OriginalValue": 165.0,
+            "LessIsGood": 0
+          },
+          {
+            "Label": "ShieldGenStrength",
+            "Value": 100.250992,
+            "OriginalValue": 90.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Slot06_Size3",
+      "Item": "Int_DroneControl_Repair_Size3_Class2",
+      "On": false,
+      "Priority": 4,
+      "Health": 1.0,
+      "Value": 10530
+    },
+    {
+      "Slot": "Slot07_Size2",
+      "Item": "Int_DetailedSurfaceScanner_Tiny",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 212500,
+      "Engineering": {
+        "Engineer": "Lei Cheung",
+        "EngineerID": 300120,
+        "BlueprintID": 128740156,
+        "BlueprintName": "Sensor_FastScan",
+        "Level": 5,
+        "Quality": 0.9807,
+        "Modifiers": [
+          {
+            "Label": "Mass",
+            "Value": 2.6,
+            "OriginalValue": 1.3,
+            "LessIsGood": 1
+          },
+          {
+            "Label": "DSS_RateMult",
+            "Value": 79.710007,
+            "OriginalValue": 0.0,
+            "LessIsGood": 0
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Slot08_Size2",
+      "Item": "Int_StellarBodyDiscoveryScanner_Advanced",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 1313250
+    },
+    {
+      "Slot": "PlanetaryApproachSuite",
+      "Item": "Int_PlanetApproachSuite",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0,
+      "Value": 500
+    },
+    {
+      "Slot": "Bobble02",
+      "Item": "Bobble_PilotMale",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble03",
+      "Item": "Bobble_TextCaret",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble04",
+      "Item": "Bobble_TextB",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble05",
+      "Item": "Bobble_TextA",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble06",
+      "Item": "Bobble_TextS",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble07",
+      "Item": "Bobble_TextK",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble08",
+      "Item": "Bobble_TextCaret",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "Bobble09",
+      "Item": "Bobble_PilotFemale",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "WeaponColour",
+      "Item": "WeaponCustomisation_Red",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "EngineColour",
+      "Item": "EngineCustomisation_Red",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "ShipName0",
+      "Item": "Nameplate_Explorer02_White",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "ShipName1",
+      "Item": "Nameplate_Explorer02_White",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "ShipID0",
+      "Item": "Nameplate_ShipID_White",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "ShipID1",
+      "Item": "Nameplate_ShipID_White",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "VesselVoice",
+      "Item": "VoicePack_Verity",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "ShipCockpit",
+      "Item": "Empire_Trader_Cockpit",
+      "On": true,
+      "Priority": 1,
+      "Health": 1.0
+    },
+    {
+      "Slot": "CargoHatch",
+      "Item": "ModularCargoBayDoor",
+      "On": false,
+      "Priority": 4,
+      "Health": 1.0
+    }
+  ]
+}

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -1442,16 +1442,19 @@ namespace EddiVoiceAttackResponder
                     vaProxy.SetText(prefix + " system", ship.starsystem);
                     vaProxy.SetText(prefix + " station", ship.station);
                     StarSystem StoredShipStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(ship.starsystem);
-                    // Have to grab a local copy of our star system as CurrentStarSystem might not have been initialised yet
-                    StarSystem ThisStarSystem = StarSystemSqLiteRepository.Instance.GetStarSystem(EDDI.Instance.CurrentStarSystem.name);
 
                     // Work out the distance to the system where the ship is stored if we can
-                    if (ThisStarSystem != null && ThisStarSystem.x != null && StoredShipStarSystem.x != null)
+                    if (EDDI.Instance.CurrentStarSystem != null)
                     {
-                        decimal distance = (decimal)Math.Round(Math.Sqrt(Math.Pow((double)(ThisStarSystem.x - StoredShipStarSystem.x), 2)
-                            + Math.Pow((double)(ThisStarSystem.y - StoredShipStarSystem.y), 2)
-                            + Math.Pow((double)(ThisStarSystem.z - StoredShipStarSystem.z), 2)), 2);
-                        vaProxy.SetDecimal(prefix + " distance", distance);
+                        // CurrentStarSystem might not have been initialised yet so we check. If not, it may be set on the next pass of the setValues() method.
+                        StarSystem ThisStarSystem = StarSystemSqLiteRepository.Instance.GetStarSystem(EDDI.Instance.CurrentStarSystem.name);
+                        if (ThisStarSystem!= null && ThisStarSystem.x != null & StoredShipStarSystem.x != null)
+                        {
+                            decimal distance = (decimal)Math.Round(Math.Sqrt(Math.Pow((double)(ThisStarSystem.x - StoredShipStarSystem.x), 2)
+                                + Math.Pow((double)(ThisStarSystem.y - StoredShipStarSystem.y), 2)
+                                + Math.Pow((double)(ThisStarSystem.z - StoredShipStarSystem.z), 2)), 2);
+                            vaProxy.SetDecimal(prefix + " distance", distance);
+                        }
                     }
                     else
                     {
@@ -1464,6 +1467,7 @@ namespace EddiVoiceAttackResponder
             }
             catch (Exception e)
             {
+                Logging.Error("Failed to set VoiceAttack ship information", e);
                 setStatus(ref vaProxy, "Failed to set ship information", e);
             }
 

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -1448,11 +1448,12 @@ namespace EddiVoiceAttackResponder
                     {
                         // CurrentStarSystem might not have been initialised yet so we check. If not, it may be set on the next pass of the setValues() method.
                         StarSystem ThisStarSystem = StarSystemSqLiteRepository.Instance.GetStarSystem(EDDI.Instance.CurrentStarSystem.name);
-                        if (ThisStarSystem!= null && ThisStarSystem.x != null & StoredShipStarSystem.x != null)
+                        if (ThisStarSystem?.x != null & StoredShipStarSystem?.x != null)
                         {
-                            decimal distance = (decimal)Math.Round(Math.Sqrt(Math.Pow((double)(ThisStarSystem.x - StoredShipStarSystem.x), 2)
-                                + Math.Pow((double)(ThisStarSystem.y - StoredShipStarSystem.y), 2)
-                                + Math.Pow((double)(ThisStarSystem.z - StoredShipStarSystem.z), 2)), 2);
+                            decimal dx = (ThisStarSystem.x - StoredShipStarSystem.x) ?? 0M;
+                            decimal dy = (ThisStarSystem.y - StoredShipStarSystem.y) ?? 0M;
+                            decimal dz = (ThisStarSystem.z - StoredShipStarSystem.z) ?? 0M;
+                            decimal distance = (decimal)(Math.Sqrt((double)(dx * dx + dy * dy + dz * dz)));
                             vaProxy.SetDecimal(prefix + " distance", distance);
                         }
                     }


### PR DESCRIPTION
This is mostly about adding back accessors that Cottle scripts expected, and which were removed in my Great Localization Merge, because I did not appreciate that Cottle used reflection so much.

I'm not averse to adding back these accessors provided it is very clear that they are purely derived properties. Hence I have used the fat arrow `=>` notation for all of them.