### PR TITLE
Hotfix/532 shipmonitor launchbay status

### DIFF
--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -760,6 +760,18 @@ namespace EddiShipMonitor
                         ship = profileCurrentShip;
                         AddShip(ship);
                     }
+                    // Ship launchbay data is exclusively from the API, always update.
+                    else
+                    {
+                        if (profileCurrentShip.launchbays == null || !profileCurrentShip.launchbays.Any())
+                        {
+                            ship.launchbays.Clear();
+                        }
+                        else
+                        {
+                            ship.launchbays = profileCurrentShip.launchbays;
+                        }
+                    }
                     Logging.Debug("Ship is: " + JsonConvert.SerializeObject(ship));
                 }
             }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -733,6 +733,7 @@ namespace EddiShipMonitor
             refreshProfileDelayed(@event.shipid, currentProfileId).GetAwaiter().GetResult();
         }
 
+        // Note: At a minimum, the API Profile data is required to update the current ship's launchbay status
         public void HandleProfile(JObject profile)
         {
             // Obtain the current ship from the profile


### PR DESCRIPTION
Corrected Issue #532 where API Profile ship data was not used to update launchbay status for 'known' ships, previously seen and saved in the shipmonitor.json. The API Profile is the sole source of launchbay data.