### PR TITLE
Fixup small translation errors and omissions

### DIFF
--- a/CargoMonitor/Properties/CargoMonitor.es.resx
+++ b/CargoMonitor/Properties/CargoMonitor.es.resx
@@ -152,5 +152,7 @@
   <data name="para2" xml:space="preserve">
     <value>Tenga en cuenta que si su inventario es incorrecto, deberá iniciar o reiniciar Elite para que esta información se actualice.</value>
   </data>
-
+  <data name="header_need" xml:space="preserve">
+    <value>Necesario</value>
+  </data>
 </root>

--- a/CargoMonitor/Properties/CargoMonitor.fr.resx
+++ b/CargoMonitor/Properties/CargoMonitor.fr.resx
@@ -152,5 +152,7 @@
   <data name="para2" xml:space="preserve">
     <value>Notez que si votre inventaire est incorrect, vous devrez démarrer ou redémarrer Elite et cette information sera mise à jour.</value>
   </data>
-
+  <data name="header_need" xml:space="preserve">
+    <value>Nécessaire</value>
+  </data>
 </root>

--- a/EDDI.sln
+++ b/EDDI.sln
@@ -183,6 +183,8 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
+		RESX_TaskErrorCategory = Message
+		RESX_AutoCreateNewLanguageFiles = True
 		SolutionGuid = {28C2EDB6-0FA0-409F-987C-7A24F542D0CF}
 	EndGlobalSection
 EndGlobal

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -660,7 +660,7 @@ namespace Eddi
             companionAppCodeText.Text = "";
             companionAppCodeLabel.Visibility = Visibility.Hidden;
             companionAppCodeText.Visibility = Visibility.Hidden;
-            companionAppNextButton.Content = "Next";
+            companionAppNextButton.Content = Properties.EddiResources.next;
         }
 
         private void setUpCompanionAppStage2(string message = null)
@@ -688,7 +688,7 @@ namespace Eddi
         {
             if (message == null)
             {
-                companionAppText.Text = "Complete";
+                companionAppText.Text = Properties.EddiResources.complete;
             }
             else
             {

--- a/EDDI/Properties/EddiResources.Designer.cs
+++ b/EDDI/Properties/EddiResources.Designer.cs
@@ -142,7 +142,7 @@ namespace Eddi.Properties {
                 return ResourceManager.GetString("failed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You do not have a connection to the Frontier API at this time. Please enter your Elite Dangerous email address and password below..
         /// </summary>


### PR DESCRIPTION
1. French and Spanish translations for "Needed" Cargo Monitor header (I've asked the chat in EDDI to confirm my tranlsations and they have)
2. Fixed some strings that were not converted to reference resx strings in Frontier API log in dialogs