### PR TITLE
Mitigate Rollbar error reporting causing slow startup

### DIFF
--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Linq;
+using System.Threading;
 
 namespace Utilities
 {
@@ -158,22 +159,27 @@ namespace Utilities
                 thisData.Remove("demandbracket");
                 thisData.Remove("StatusFlags");
 
-                // Report only unique messages and data
-                if (isUniqueMessage(message, thisData))
-                {
-                    RollbarLocator.RollbarInstance.Info(message, thisData);
-                    Info("Reporting unique data, anonymous ID " + RollbarLocator.RollbarInstance.Config.Person.Id + ": " + message + thisData);
-                }
-                else
-                {
-                    Warn(@"Unable to report message """ + message + @""". Invalid data type " + data.GetType());
-                }
+                Task rollbarReport = Task.Run(() => _Report(message, data, thisData));
             }
             catch (Exception)
             {
                 // Nothing to do
             }
 #endif
+        }
+
+        private static void _Report(string message, object data, Dictionary<string, object> thisData)
+        {
+            // Report only unique messages and data
+            if (isUniqueMessage(message, thisData))
+            {
+                RollbarLocator.RollbarInstance.Info(message, thisData);
+                Info("Reporting unique data, anonymous ID " + RollbarLocator.RollbarInstance.Config.Person.Id + ": " + message + thisData);
+            }
+            else
+            {
+                Warn(@"Unable to report message """ + message + @""". Invalid data type " + data.GetType());
+            }
         }
     }
 


### PR DESCRIPTION
Other errors trigger rollbar reports but rollbar seems to be at fault for slowing starts when this occurs by locking the applicable thread while it queries the Rollbar API and sends reports.
For all reports other than unhandled exceptions, this PR shifts rollbar API queries and reporting to an asynchronous tasks thread pool where they will be less disruptive.