### PR TITLE
`Near surface` event from journal `ApproachBody and `LeaveBody` events. Rich data about nearby bodies.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,49 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.1-b3
+  * Core 
+    * EDDI will now track the nearest stellar body and make that data available to EDDI's Speech responder via the `body` variable (planet, moon, etc.).  
+  * Speech Responder 
+    * Updated the 'Near surface' event to include the name of the body that you are approaching or exiting. 
+    * Add a new top level `body` object, which contains details of the nearest stellar body. Any values might be missing, depending on EDDI's configuration and the information available about the body. 
+  * VoiceAttack 
+    * Added the following new variables describing details of the nearest stellar body, with values as described by the 'Body' object 
+      * `{DEC:Body EDDB id}`
+      * `{TXT:Body type}`
+      * `{TXT:Body name}` 
+      * `{TXT:Body system name}`
+      * `{DEC:Body age}`
+      * `{DEC:Body distance}`
+      * `{BOOL:Body landable}` 
+      * `{BOOL:Body tidally locked}` 
+      * `{DEC:Body temperature}` 
+      * `{BOOL:Body main star}` 
+      * `{TXT:Body stellar class}` 
+      * `{TXT:Body luminosity class}` 
+      * `{DEC:Body solar mass}` 
+      * `{DEC:Body solar radius}` 
+      * `{TXT:Body chromaticity}` 
+      * `{DEC:Body radius probability}` 
+      * `{DEC:Body mass probability}` 
+      * `{DEC:Body temp probability}` 
+      * `{DEC:Body age probability}` 
+      * `{DEC:Body periapsis}` 
+      * `{TXT:Body atmosphere}` 
+      * `{DEC:Body tilt}` 
+      * `{DEC:Body earth mass}` 
+      * `{DEC:Body gravity}` 
+      * `{DEC:Body eccentricity}` 
+      * `{DEC:Body inclination}` 
+      * `{DEC:Body orbital period}` 
+      * `{DEC:Body radius}` 
+      * `{DEC:Body rotational period}` 
+      * `{DEC:Body semi major axis}` 
+      * `{DEC:Body pressure}` 
+      * `{TXT:Body terraform state}` 
+      * `{TXT:Body planet type}` 
+      * `{TXT:Body reserves}` 
+
 ### 3.0.1-b2
   * Localization
     * EDDI is now localized! You can choose your language in the EDDI tab or just go with the system default.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -790,7 +790,7 @@ namespace Eddi
 
             if (theEvent.docked == true || theEvent.bodytype.ToLowerInvariant() == "station")
             {
-                // In this case body === station
+                // In this case body === station and our body information is invalid
                 CurrentStellarBody = null;
 
                 // Force first location update even if it matches with 'firstLocation' bool
@@ -860,7 +860,7 @@ namespace Eddi
             }
             else
             {
-                // We are near neither at stellar body nor a station. 
+                // We are near neither a stellar body nor a station. 
                 CurrentStellarBody = null;
                 CurrentStation = null;
             }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -90,6 +90,7 @@ namespace Eddi
         public DateTime ApiTimeStamp { get; private set; }
         //public ObservableCollection<Ship> Shipyard { get; private set; } = new ObservableCollection<Ship>();
         public Station CurrentStation { get; private set; }
+        public Body CurrentStellarBody { get; private set; }
 
         // Services made available from EDDI
         public StarMapService starMapService { get; private set; }
@@ -673,6 +674,10 @@ namespace Eddi
                     {
                         passEvent = eventStatus((StatusEvent)@event);
                     }
+                    else if (@event is NearSurfaceEvent)
+                    {
+                        passEvent = eventNearSurface((NearSurfaceEvent)@event);
+                    }
                     // Additional processing is over, send to the event responders if required
                     if (passEvent)
                     {
@@ -783,8 +788,11 @@ namespace Eddi
                 CurrentStarSystem.population = theEvent.population;
             }
 
-            if (theEvent.docked == true)
+            if (theEvent.docked == true || theEvent.bodytype.ToLowerInvariant() == "station")
             {
+                // In this case body === station
+                CurrentStellarBody = null;
+
                 // Force first location update even if it matches with 'firstLocation' bool
                 if (!firstLocation && (CurrentStation != null && CurrentStation.name == theEvent.station))
                 {
@@ -823,9 +831,37 @@ namespace Eddi
                     updateThread.Start();
                 }
             }
+            else if (theEvent.body != null)
+            {
+                // If we are not at a station then our station information is invalid 
+                CurrentStation = null;
+
+                // Force first location update even if it matches with 'firstLocation' bool 
+                if (!firstLocation && (CurrentStellarBody != null && CurrentStellarBody.name == theEvent.body))
+                {
+                    // We are already at this body; nothing to do 
+                    Logging.Debug("Already at body " + theEvent.body);
+                    return false;
+                }
+                firstLocation = false;
+
+                // Update the body 
+                Logging.Debug("Now at body " + theEvent.body);
+                Body body = CurrentStarSystem.bodies.Find(s => s.name == theEvent.body);
+                if (body == null)
+                {
+                    // This body is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder 
+                    body = new Body();
+                    body.name = theEvent.body;
+                    body.systemname = theEvent.system;
+                }
+
+                CurrentStellarBody = body;
+            }
             else
             {
-                // If we are not docked then our station information is invalid
+                // We are near neither at stellar body nor a station. 
+                CurrentStellarBody = null;
                 CurrentStation = null;
             }
 
@@ -898,6 +934,7 @@ namespace Eddi
             }
 
             CurrentStation = station;
+            CurrentStellarBody = null;
 
             // Kick off the profile refresh if the companion API is available
             if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.READY)
@@ -924,9 +961,6 @@ namespace Eddi
         {
             // Call refreshProfile() to ensure that our ship is up-to-date
             refreshProfile();
-
-            // Remove information about the station
-            CurrentStation = null;
 
             return true;
         }
@@ -964,6 +998,10 @@ namespace Eddi
 
             // We are in the ship
             Vehicle = Constants.VEHICLE_SHIP;
+
+            // Remove information about the current station and stellar body 
+            CurrentStation = null;
+            CurrentStellarBody = null;
 
             return true;
         }
@@ -1087,6 +1125,44 @@ namespace Eddi
         private bool eventEnteredNormalSpace(EnteredNormalSpaceEvent theEvent)
         {
             Environment = Constants.ENVIRONMENT_NORMAL_SPACE;
+
+            if (theEvent.bodytype.ToLowerInvariant() == "station")
+            {
+                // In this case body == station 
+                CurrentStellarBody = null;
+
+                // Update the station 
+                Logging.Debug("Now at station " + theEvent.body);
+                Station station = CurrentStarSystem.stations.Find(s => s.name == theEvent.body);
+                if (station == null)
+                {
+                    // This station is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder 
+                    station = new Station();
+                    station.name = theEvent.body;
+                    station.systemname = theEvent.system;
+                }
+
+                CurrentStation = station;
+            }
+            else if (theEvent.body != null)
+            {
+                // If we are not at a station then our station information is invalid 
+                CurrentStation = null;
+
+                // Update the body 
+                Logging.Debug("Now at body " + theEvent.body);
+                Body body = CurrentStarSystem.bodies.Find(s => s.name == theEvent.body);
+                if (body == null)
+                {
+                    // This body is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder 
+                    body = new Body();
+                    body.name = theEvent.body;
+                    body.systemname = theEvent.system;
+                }
+
+                CurrentStellarBody = body;
+            }
+
             updateCurrentSystem(theEvent.system);
             return true;
         }
@@ -1251,6 +1327,34 @@ namespace Eddi
                 Environment = Constants.ENVIRONMENT_SUPERCRUISE;
             }
             Vehicle = theEvent.status.vehicle;
+            return true;
+        }
+
+        private bool eventNearSurface(NearSurfaceEvent theEvent)
+        {
+            if (theEvent.approaching_surface)
+            {
+                // Update the body we are approaching 
+                Logging.Debug("Now at body " + theEvent.body);
+                Body body = CurrentStarSystem.bodies.Find(s => s.name == theEvent.body);
+                if (body == null)
+                {
+                    // This body is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder 
+                    body = new Body();
+                    body.name = theEvent.body;
+                    body.systemname = theEvent.system;
+                }
+
+                CurrentStellarBody = body;
+            }
+            else
+            {
+                // Clear the body we are leaving 
+                CurrentStellarBody = null;
+            }
+
+            updateCurrentSystem(theEvent.system);
+
             return true;
         }
 

--- a/Events/NearSurfaceEvent.cs
+++ b/Events/NearSurfaceEvent.cs
@@ -15,14 +15,19 @@ namespace EddiEvents
         static NearSurfaceEvent()
         {
             VARIABLES.Add("approaching_surface", "A boolean value. True if you are entering the gravity well and and false if you are leaving");
+            VARIABLES.Add("system", "The name of the starsystem");
+            VARIABLES.Add("body", "The name of the body");
         }
 
-        [JsonProperty("near_surface")]
         public bool approaching_surface { get; private set; }
+        public string system { get; private set; }
+        public string body { get; private set; }
 
-        public NearSurfaceEvent(DateTime timestamp, bool nearSurface) : base(timestamp, NAME)
+        public NearSurfaceEvent(DateTime timestamp, bool approachingSurface, string system, string body) : base(timestamp, NAME)
         {
-            this.approaching_surface = nearSurface;
+            this.approaching_surface = approachingSurface;
+            this.system = system;
+            this.body = body;
         }
     }
 }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -548,19 +548,17 @@ namespace EddiJournalMonitor
                             break;
                         case "ApproachBody":
                             {
-                                bool approachingSurface = true;
                                 string system = JsonParsing.getString(data, "StarSystem");
                                 string body = JsonParsing.getString(data, "Body");
-                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                                events.Add(new NearSurfaceEvent(timestamp, true, system, body) { raw = line });
                             }
                             handled = true;
                             break;
                         case "LeaveBody":
                             {
-                                bool approachingSurface = false;
                                 string system = JsonParsing.getString(data, "StarSystem");
                                 string body = JsonParsing.getString(data, "Body");
-                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                                events.Add(new NearSurfaceEvent(timestamp, false, system, body) { raw = line });
                             }
                             handled = true;
                             break;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -546,6 +546,24 @@ namespace EddiJournalMonitor
                             events.Add(new CockpitBreachedEvent(timestamp) { raw = line });
                             handled = true;
                             break;
+                        case "ApproachBody":
+                            {
+                                bool approachingSurface = true;
+                                string system = JsonParsing.getString(data, "StarSystem");
+                                string body = JsonParsing.getString(data, "Body");
+                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                            }
+                            handled = true;
+                            break;
+                        case "LeaveBody":
+                            {
+                                bool approachingSurface = false;
+                                string system = JsonParsing.getString(data, "StarSystem");
+                                string body = JsonParsing.getString(data, "Body");
+                                events.Add(new NearSurfaceEvent(timestamp, approachingSurface, system, body) { raw = line });
+                            }
+                            handled = true;
+                            break;
                         case "ApproachSettlement":
                             {
                                 object val;

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -233,6 +233,11 @@ namespace EddiSpeechResponder
                 dict["station"] = new ReflectionValue(EDDI.Instance.CurrentStation);
             }
 
+            if (EDDI.Instance.CurrentStellarBody != null)
+            {
+                dict["body"] = new ReflectionValue(EDDI.Instance.CurrentStellarBody);
+            }
+
             if (StatusMonitor.currentStatus != null)
             {
                 dict["status"] = new ReflectionValue(StatusMonitor.currentStatus);

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -281,11 +281,6 @@ namespace EddiStatusMonitor
                 EDDI.Instance.eventHandler(new StatusEvent(thisStatus.timestamp, thisStatus));
 
                 // Trigger events for changed status, as applicable
-                if (thisStatus.near_surface != lastStatus.near_surface 
-                    && thisStatus.vehicle == Constants.VEHICLE_SHIP)
-                {
-                    EDDI.Instance.eventHandler(new NearSurfaceEvent(thisStatus.timestamp, thisStatus.near_surface));
-                }
                 if (thisStatus.srv_turret_deployed != lastStatus.srv_turret_deployed)
                 {
                     EDDI.Instance.eventHandler(new SRVTurretEvent(thisStatus.timestamp, thisStatus.srv_turret_deployed));

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -1178,6 +1178,15 @@ namespace EddiVoiceAttackResponder
 
             try
             {
+                setDetailedBodyValues(EDDI.Instance.CurrentStellarBody, "Body", ref vaProxy);
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set stellar body", ex);
+            }
+
+            try
+            {
                 setStationValues(EDDI.Instance.CurrentStation, "Last station", ref vaProxy);
             }
             catch (Exception ex)
@@ -1548,6 +1557,56 @@ namespace EddiVoiceAttackResponder
             {
                 vaProxy.SetDecimal(prefix + " age", (decimal)(long)body.age);
             }
+            Logging.Debug("Set body information (" + prefix + ")");
+        }
+
+        private static void setDetailedBodyValues(Body body, string prefix, ref dynamic vaProxy)
+        {
+            Logging.Debug("Setting current stellar body information");
+            vaProxy.SetDecimal(prefix + " EDDB id", body?.EDDBID);
+            vaProxy.SetText(prefix + " type", body?.type);
+            vaProxy.SetText(prefix + " name", body?.name);
+            vaProxy.SetText(prefix + " system name", body?.systemname);
+            if (body?.age == null)
+            {
+                vaProxy.SetDecimal(prefix + " age", null);
+            }
+            else
+            {
+                vaProxy.SetDecimal(prefix + " age", (decimal)(long)body.age);
+            }
+            vaProxy.SetDecimal(prefix + " distance", body?.distance);
+            vaProxy.SetBoolean(prefix + " landable", body?.landable);
+            vaProxy.SetBoolean(prefix + " tidally locked", body?.tidallylocked);
+            vaProxy.SetDecimal(prefix + " temperature", body?.temperature);
+            // Star specific items 
+            vaProxy.SetBoolean(prefix + " main star", body?.mainstar);
+            vaProxy.SetText(prefix + " stellar class", body?.stellarclass);
+            vaProxy.SetText(prefix + " luminosity class", body?.luminosityclass);
+            vaProxy.SetDecimal(prefix + " solar mass", body?.solarmass);
+            vaProxy.SetDecimal(prefix + " solar radius", body?.solarradius);
+            vaProxy.SetText(prefix + " chromaticity", body?.chromaticity);
+            vaProxy.SetDecimal(prefix + " radius probability", body?.radiusprobability);
+            vaProxy.SetDecimal(prefix + " mass probability", body?.massprobability);
+            vaProxy.SetDecimal(prefix + " temp probability", body?.tempprobability);
+            vaProxy.SetDecimal(prefix + " age probability", body?.ageprobability);
+            // Body specific items 
+            vaProxy.SetDecimal(prefix + " periapsis", body?.periapsis);
+            vaProxy.SetText(prefix + " atmosphere", body?.atmosphere);
+            vaProxy.SetDecimal(prefix + " tilt", body?.tilt);
+            vaProxy.SetDecimal(prefix + " earth mass", body?.earthmass);
+            vaProxy.SetDecimal(prefix + " gravity", body?.gravity);
+            vaProxy.SetDecimal(prefix + " eccentricity", body?.eccentricity);
+            vaProxy.SetDecimal(prefix + " inclination", body?.inclination);
+            vaProxy.SetDecimal(prefix + " orbital period", body?.orbitalperiod);
+            vaProxy.SetDecimal(prefix + " radius", body?.radius);
+            vaProxy.SetDecimal(prefix + " rotational period", body?.rotationalperiod);
+            vaProxy.SetDecimal(prefix + " semi major axis", body?.semimajoraxis);
+            vaProxy.SetDecimal(prefix + " pressure", body?.pressure);
+            vaProxy.SetText(prefix + " terraform state", body?.terraformstate);
+            vaProxy.SetText(prefix + " planet type", body?.planettype);
+            vaProxy.SetText(prefix + " reserves", body?.reserves);
+
             Logging.Debug("Set body information (" + prefix + ")");
         }
 


### PR DESCRIPTION
Ref. #417
Add a new top level `body` object, much like the current `station` object that is already present.
Modify the `Near surface` event to use body and system data and make available rich data about nearby bodies.