### PR TITLE
Speculative fix for rollbar module NullReferenceExceptions (rollbar item 1700 & 1707).

### DIFF
--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1016,8 +1016,7 @@ namespace EddiShipMonitor
             {
                 do
                 {
-                    EDDI.Instance.refreshProfile();
-                    await Task.Delay(TimeSpan.FromSeconds(20));
+                    await Task.Run(() => EDDI.Instance.refreshProfile());
                     ship = GetShip(shipid);
                 } while (ship != null);
             }
@@ -1153,8 +1152,7 @@ namespace EddiShipMonitor
             {
                 do
                 {
-                    EDDI.Instance.refreshProfile();
-                    await Task.Delay(TimeSpan.FromSeconds(20));
+                    await Task.Run(() => EDDI.Instance.refreshProfile());
                     ship = GetShip(shipid);
                 } while (ship != null);
             }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1008,9 +1008,19 @@ namespace EddiShipMonitor
             }
         }
 
-        private void AddModule(int shipid, string slot, Module module)
+        private async void AddModule(int shipid, string slot, Module module)
         {
             Ship ship = GetShip(shipid);
+
+            if (ship == null)
+            {
+                do
+                {
+                    EDDI.Instance.refreshProfile();
+                    await Task.Delay(TimeSpan.FromSeconds(20));
+                    ship = GetShip(shipid);
+                } while (ship != null);
+            }
 
             switch (slot)
             {
@@ -1135,9 +1145,19 @@ namespace EddiShipMonitor
             }
         }
 
-        private void RemoveModule(int shipid, string slot, Module replacement = null)
+        private async void RemoveModule(int shipid, string slot, Module replacement = null)
         {
             Ship ship = GetShip(shipid);
+
+            if (ship == null)
+            {
+                do
+                {
+                    EDDI.Instance.refreshProfile();
+                    await Task.Delay(TimeSpan.FromSeconds(20));
+                    ship = GetShip(shipid);
+                } while (ship != null);
+            }
 
             if (replacement != null)
             {


### PR DESCRIPTION
https://rollbar.com/T-kael/EDDI/items/1707/
https://rollbar.com/T-kael/EDDI/items/1700/

The most likely source of this error would be incomplete ship data - a shipId that is not locally retrievable. Force a refresh from the Frontier API if `ship == null`.