### PR TITLE
Resolve differences between `Body scanned` event properties and `BodyDetails()` properties.

### DIFF
--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -47,13 +47,15 @@ namespace EddiEvents
 
         public string name { get; private set; }
 
+        public string planettype { get { return bodyclass; } } // This is the object property reported from the BodyDetails() function
+
         public string bodyclass { get; private set; }
 
         public decimal? earthmass { get; private set; }
 
         public decimal? radius { get; private set; }
 
-        public decimal gravity{ get; private set; }
+        public decimal gravity { get; private set; }
 
         public decimal? temperature { get; private set; }
 
@@ -65,17 +67,23 @@ namespace EddiEvents
 
         public string atmosphere { get; private set; }
 
-        public Volcanism volcanism{ get; private set; }
+        public Volcanism volcanism { get; private set; }
+
+        public decimal distance { get { return distancefromarrival; } } // This is the object property reported from the BodyDetails() function
 
         public decimal distancefromarrival { get; private set; }
 
         public decimal orbitalperiod { get; private set; }
+
+        public decimal rotationalperiod { get { return rotationperiod; } } // This is the object property reported from the BodyDetails() function
 
         public decimal rotationperiod { get; private set; }
 
         public decimal? semimajoraxis { get; private set; }
 
         public decimal? eccentricity { get; private set; }
+
+        public decimal? inclination { get { return orbitalinclination; } } // This is the object property reported from the BodyDetails() function
 
         public decimal? orbitalinclination { get; private set; }
 
@@ -88,6 +96,8 @@ namespace EddiEvents
         public List<MaterialPresence> materials { get; private set; }
 
         public string terraformstate { get; private set; }
+
+        public decimal? tilt { get { return axialtilt; } } // This is the object property reported from the BodyDetails() function
 
         public decimal? axialtilt { get; private set; }
 

--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -47,7 +47,7 @@ namespace EddiEvents
 
         public string name { get; private set; }
 
-        public string planettype { get { return bodyclass; } } // This is the object property reported from the BodyDetails() function
+        public string planettype => bodyclass;  // This is the object property reported from the BodyDetails() function
 
         public string bodyclass { get; private set; }
 
@@ -69,13 +69,13 @@ namespace EddiEvents
 
         public Volcanism volcanism { get; private set; }
 
-        public decimal distance { get { return distancefromarrival; } } // This is the object property reported from the BodyDetails() function
+        public decimal distance => distancefromarrival;  // This is the object property reported from the BodyDetails() function
 
         public decimal distancefromarrival { get; private set; }
 
         public decimal orbitalperiod { get; private set; }
 
-        public decimal rotationalperiod { get { return rotationperiod; } } // This is the object property reported from the BodyDetails() function
+        public decimal rotationalperiod => rotationperiod;  // This is the object property reported from the BodyDetails() function
 
         public decimal rotationperiod { get; private set; }
 
@@ -83,7 +83,7 @@ namespace EddiEvents
 
         public decimal? eccentricity { get; private set; }
 
-        public decimal? inclination { get { return orbitalinclination; } } // This is the object property reported from the BodyDetails() function
+        public decimal? inclination => orbitalinclination;  // This is the object property reported from the BodyDetails() function
 
         public decimal? orbitalinclination { get; private set; }
 
@@ -97,7 +97,7 @@ namespace EddiEvents
 
         public string terraformstate { get; private set; }
 
-        public decimal? tilt { get { return axialtilt; } } // This is the object property reported from the BodyDetails() function
+        public decimal? tilt => axialtilt;  // This is the object property reported from the BodyDetails() function
 
         public decimal? axialtilt { get; private set; }
 

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -80,7 +80,7 @@ namespace EddiEvents
 
         public string chromaticity { get; private set; }
 
-        public decimal distance { get { return distancefromarrival; } } // Object property as reported from the BodyDetails() function
+        public decimal distance => distancefromarrival;  // Object property as reported from the BodyDetails() function
 
         public decimal distancefromarrival { get; private set; }
 

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -80,6 +80,8 @@ namespace EddiEvents
 
         public string chromaticity { get; private set; }
 
+        public decimal distance { get { return distancefromarrival; } } // Object property as reported from the BodyDetails() function
+
         public decimal distancefromarrival { get; private set; }
 
         public decimal? orbitalperiod { get; private set; }


### PR DESCRIPTION
Fix for #559. 