### PR TITLE
Fix EDSM Sync reset bug

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,7 +4,7 @@ Full details of the variables available for each noted event, and VoiceAttack in
 
 ### 3.0.1-b3
   * EDSM responder
-    * Fixed a bug that was reseting system visit totals during syncs with EDSM.
+    * Fixed a bug that was reseting system visit totals during syncs with EDSM. Please re-obtain logs from EDSM to update in the information in your local database.
 
 ### 3.0.1-b2
   * Localization

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.1-b3
+  * EDSM responder
+    * Fixed a bug that was reseting system visit totals during syncs with EDSM.
+
 ### 3.0.1-b2
   * Localization
     * EDDI is now localized! You can choose your language in the EDDI tab or just go with the system default.

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -294,17 +294,13 @@ namespace EddiStarMapService
             foreach (string system in systemLogs.Keys)
             {
                 StarSystem CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(system, false);
-                if (since.HasValue)
+                if (since != null)
                 {
-                    // If we're obtaining new logs since our last update, we need to increment the value
-                    CurrentStarSystem.visits += systemLogs[system].visits;
-                }
-                else
-                {
-                    // If we're re-obtaining and resetting the flight logs, we need to replace the value
+                    /// If we're re-obtaining and resetting the flight logs, we need to replace the value.
+                    /// Otherwise, the event handler increments system visits.
                     CurrentStarSystem.visits = systemLogs[system].visits;
+                    CurrentStarSystem.lastvisit = systemLogs[system].lastVisit;
                 }
-                CurrentStarSystem.lastvisit = systemLogs[system].lastVisit;
                 if (comments.ContainsKey(system))
                 {
                     CurrentStarSystem.comment = comments[system];

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -294,7 +294,7 @@ namespace EddiStarMapService
             foreach (string system in systemLogs.Keys)
             {
                 StarSystem CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(system, false);
-                if (since != null)
+                if (since == null)
                 {
                     /// If we're re-obtaining and resetting the flight logs, we need to replace the value.
                     /// Otherwise, the event handler increments system visits.

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -264,7 +264,7 @@ namespace EddiStarMapService
                     {
                         Dictionary<string, StarMapLogInfo> systemLogs = getStarMapLog(syncStartTime);
                         syncStartTime = DateTime.Compare(syncEndTime, syncStartTime.AddDays(7)) > 0 ? syncStartTime.AddDays(7) : syncEndTime;
-                        SyncUpdate(comments, syncSystems, systemLogs);
+                        SyncUpdate(comments, syncSystems, systemLogs, since);
                     } while (DateTime.Compare(syncEndTime, syncStartTime) > 0); // Do this while syncEndTime is greater than than syncStartTime
                 }
                 else
@@ -289,7 +289,7 @@ namespace EddiStarMapService
             }
         }
 
-        private static void SyncUpdate(Dictionary<string, string> comments, List<StarSystem> syncSystems, Dictionary<string, StarMapLogInfo> systemLogs, DateTime? since)
+        private static void SyncUpdate(Dictionary<string, string> comments, List<StarSystem> syncSystems, Dictionary<string, StarMapLogInfo> systemLogs, DateTime? since = null)
         {
             foreach (string system in systemLogs.Keys)
             {


### PR DESCRIPTION
Ref. #566
1. When syncing more than a week of logs, EDSM would only return the first week. EDDI will now keep asking for logs until we have everything since our last sync date.
2.  When `since` has a value and we are doing a partial sync, we don't need to increment system visits. System visits are handled by the event handler for the `Jumped` event. We only need to write this value when doing a full sync.