### PR TITLE
Hotfix/578 docked event

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -693,9 +693,9 @@ namespace EddiCompanionAppService
                     quote.buyprice = (int)commodity["buyPrice"];
                     quote.stock = (int)commodity["stock"];
                     quote.stockbracket = (int)commodity["stockBracket"];
-                    quote.sellprice = (int)commodity["sellPrice"];
+                    quote.sellprice = commodity["sellPrice"] as int? ?? 0;
                     quote.demand = (int)commodity["demand"];
-                    quote.demandbracket = (int)commodity["demandBracket"];
+                    quote.demandbracket = commodity["demandBracket"] as int? ?? 0;
 
                     List<string> StatusFlags = new List<string>();
                     foreach (dynamic statusFlag in commodity["statusFlags"])

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1130,19 +1130,6 @@ namespace Eddi
             {
                 // In this case body == station 
                 CurrentStellarBody = null;
-
-                // Update the station 
-                Logging.Debug("Now at station " + theEvent.body);
-                Station station = CurrentStarSystem.stations.Find(s => s.name == theEvent.body);
-                if (station == null)
-                {
-                    // This station is unknown to us, might not be in EDDB or we might not have connectivity.  Use a placeholder 
-                    station = new Station();
-                    station.name = theEvent.body;
-                    station.systemname = theEvent.system;
-                }
-
-                CurrentStation = station;
             }
             else if (theEvent.body != null)
             {

--- a/EDDNResponder/EDDNCommodity.cs
+++ b/EDDNResponder/EDDNCommodity.cs
@@ -4,14 +4,15 @@ namespace EDDNResponder
 {
     class EDDNCommodity
     {
+        // Schema reference: https://github.com/EDSM-NET/EDDN/blob/master/schemas/commodity-v3.0.json
         public string name;
         public int meanPrice;
         public int buyPrice;
         public int stock;
-        public dynamic stockBracket;
+        public dynamic stockBracket; // Possible values are 0, 1, 2, 3, or ""
         public int sellPrice;
         public int demand;
-        public dynamic demandBracket;
+        public dynamic demandBracket; // Possible values are 0, 1, 2, 3, or ""
         public List<string> statusFlags;
 
         public bool ShouldSerializestatusFlags()

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -222,12 +222,12 @@ namespace EDDNResponder
                     }
                     EDDNCommodity eddnCommodity = new EDDNCommodity();
                     eddnCommodity.name = commodity.definition.edname;
-                    eddnCommodity.meanPrice = (int)commodity.definition.avgprice;
-                    eddnCommodity.buyPrice = (int)commodity.buyprice;
-                    eddnCommodity.stock = (int)commodity.stock;
+                    eddnCommodity.meanPrice = commodity.definition.avgprice;
+                    eddnCommodity.buyPrice = commodity.buyprice ?? 0;
+                    eddnCommodity.stock = commodity.stock ?? 0;
                     eddnCommodity.stockBracket = commodity.stockbracket;
-                    eddnCommodity.sellPrice = (int)commodity.sellprice;
-                    eddnCommodity.demand = (int)commodity.demand;
+                    eddnCommodity.sellPrice = commodity.sellprice ?? 0;
+                    eddnCommodity.demand = commodity.demand ?? 0;
                     eddnCommodity.demandBracket = commodity.demandbracket;
                     if (commodity.StatusFlags.Count > 0)
                     {
@@ -248,7 +248,7 @@ namespace EDDNResponder
                         data.Add("economies", eddnEconomies);
                     }
                     data.Add("commodities", eddnCommodities);
-                    if (EDDI.Instance.CurrentStation.prohibited.Count > 0)
+                    if (EDDI.Instance.CurrentStation.prohibited?.Count > 0)
                     {
                         data.Add("prohibited", EDDI.Instance.CurrentStation.prohibited);
                     }


### PR DESCRIPTION
Hotfix to correct 'docked' event not triggering when docking.

Removed populating ```CurrentStation``` object in 'SupercruiseExit' event.