### PR TITLE
If passed a null edName, return null

### DIFF
--- a/DataDefinitions/ModuleDefinitions.cs
+++ b/DataDefinitions/ModuleDefinitions.cs
@@ -1090,6 +1090,7 @@ namespace EddiDataDefinitions
         
         new public static Module FromEDName(string rawEDName)
         {
+            if (rawEDName == null) { return null; }
             string edName = NormalizedEDName(rawEDName);
             return ResourceBasedLocalizedEDName<Module>.FromEDName(edName);
         }


### PR DESCRIPTION
 When you buy a module, only one of SellItem or StoredItem is populated, depending whether you sell or store the existing module. Or both can be absent if you are filling an empty slot. 

ParseJournalEntry in JournalMonitor.cs line 1021 was not testing before passing the null string to Module.FromEDName(), but I think it is reasonable for Module.FromEDName() ro return null when passed a null input.