### PR TITLE
Catch null reference of CommodityQuote with null CommodityDefinition

### DIFF
--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -216,6 +216,10 @@ namespace EDDNResponder
                 List<EDDNCommodity> eddnCommodities = new List<EDDNCommodity>();
                 foreach (CommodityMarketQuote commodity in EDDI.Instance.CurrentStation.commodities)
                 {
+                    if (commodity.definition == null)
+                    {
+                        continue;
+                    }
                     if (commodity.definition.category == CommodityCategory.NonMarketable)
                     {
                         continue;


### PR DESCRIPTION
Going forward, we may want to assert an invariant that a CommodityQuote has a non-null CommodityDefinition.