### PR TITLE
#602 Fix SAR event commodity property

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -829,7 +829,7 @@ namespace EddiCargoMonitor
 
         public void _handleSearchAndRescueEvent(SearchAndRescueEvent @event)
         {
-            Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
+            Cargo cargo = GetCargoWithEDName(@event.commodity?.edname);
             if (cargo != null)
             {
                 cargo.owned -= Math.Min(cargo.owned, @event.amount ?? 0);

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.1-rc1
+  * Core 
+    * The Search and rescue event was having its `commodity` property set to just the commodity name, rather than the commodity definition object that scripts expect. Fixed.
+
 ### 3.0.1-b4
   * Core
     * Fixed issues arising in betas 2 and 3: data written to file by old code was not being read correctly by new code. This manifested in various ways: too many to list.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,10 +2,12 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
-### 3.0.1-rc1
+### 3.0.1-b5
   * Core 
     * The Search and rescue event was having its `commodity` property set to just the commodity name, rather than the commodity definition object that scripts expect. Fixed.
-
+  * VoiceAttack
+    * The Search and rescue event has a new variable `{TXT:localizedcommodityname}` as the `commodity` varaible is now an object.
+    
 ### 3.0.1-b4
   * Core
     * Fixed issues arising in betas 2 and 3: data written to file by old code was not being read correctly by new code. This manifested in various ways: too many to list.

--- a/Events/SearchAndRescueEvent.cs
+++ b/Events/SearchAndRescueEvent.cs
@@ -15,6 +15,7 @@ namespace EddiEvents
         static SearchAndRescueEvent()
         {
     	    VARIABLES.Add("commodity", "The commodity recovered");
+            VARIABLES.Add("localizedcommodityname", "The localized name of the commodity recovered");
             VARIABLES.Add("amount", "The amount of the item recovered");
             VARIABLES.Add("reward", "The monetary reward for completing the search and rescue");
         }
@@ -22,6 +23,8 @@ namespace EddiEvents
         public int? amount { get; }
 
         public long reward { get; }
+
+        public string localizedcommodityname => commodity.localizedName;
 
         [JsonProperty("commodity")]
         public CommodityDefinition commodity { get; }

--- a/Events/SearchAndRescueEvent.cs
+++ b/Events/SearchAndRescueEvent.cs
@@ -14,7 +14,7 @@ namespace EddiEvents
 
         static SearchAndRescueEvent()
         {
-    	    VARIABLES.Add("commodity", "The commodity recovered");
+    	    VARIABLES.Add("commodity", "The commodity (object) recovered");
             VARIABLES.Add("localizedcommodityname", "The localized name of the commodity recovered");
             VARIABLES.Add("amount", "The amount of the item recovered");
             VARIABLES.Add("reward", "The monetary reward for completing the search and rescue");

--- a/Events/SearchAndRescueEvent.cs
+++ b/Events/SearchAndRescueEvent.cs
@@ -1,4 +1,5 @@
 using EddiDataDefinitions;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -13,24 +14,23 @@ namespace EddiEvents
 
         static SearchAndRescueEvent()
         {
-    	    VARIABLES.Add("commodity", "The name of the item recovered");
+    	    VARIABLES.Add("commodity", "The commodity recovered");
             VARIABLES.Add("amount", "The amount of the item recovered");
             VARIABLES.Add("reward", "The monetary reward for completing the search and rescue");
         }
-
-        public string commodity => commodityDefinition?.localizedName ?? "unknown commodity";
 
         public int? amount { get; }
 
         public long reward { get; }
 
-        public CommodityDefinition commodityDefinition { get; }
+        [JsonProperty("commodity")]
+        public CommodityDefinition commodity { get; }
 
         public SearchAndRescueEvent(DateTime timestamp, CommodityDefinition commodity, int? amount, long reward) : base(timestamp, NAME)
         {
             this.amount = amount;
             this.reward = reward;
-            this.commodityDefinition = commodity;
+            this.commodity = commodity;
         }
     }
 }

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -286,5 +286,16 @@ namespace UnitTests
             // Clean up
             Eddi.EDDI.Instance.Cmdr.friends.Remove(testFriend);
         }
+
+        [TestMethod]
+        public void TestJournalSearchAndRescue()
+        {
+            string line = @"{""timestamp"":""2018-05-26T22:04:09Z"",""event"":""SearchAndRescue"",""MarketID"":3228973824,""Name"":""usscargoblackbox"",""Name_Localised"":""Black Box"",""Count"":1,""Reward"":21184}";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            Assert.IsTrue(events.Count == 1);
+            SearchAndRescueEvent sarEvent = (SearchAndRescueEvent)events[0];
+            Assert.AreEqual("Black Box", sarEvent.commodity.invariantName);
+            Assert.AreEqual("Salvage", sarEvent.commodity.category.invariantName);
+        }
     }
 }


### PR DESCRIPTION
There seems to be some inconsistency here between documentation and reality. The Cottle scripts expect `commodity` to be an object with properties `name` and `rare`. The docs and wiki say that `commodity is a string, being the localized name of the commodity.

I have restored the object behavior as it is more useful, but I'm uncertain what consequences this will have to Voice Attack, so I really need some VA users to test it please!