### PR TITLE
Correct misreporting of ship fuel levels when refueling in dock.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,10 +5,12 @@ Full details of the variables available for each noted event, and VoiceAttack in
 ### 3.0.1-b5
   * Core
     * Updated system definition to include new variable `lastVisitSeconds`. 
+    * Updated the `Ship refueled` event to include new boolean value `full`. True if this is a full refill and false if this is a partial refill.
   * Speech responder
     * Updated `Commodity sales check` script to make use of `CommodityMarketDetails()` function.
     * Fixed a bug that had made `{ship.role}` inaccessible via scripts.
     * Updated `FSD engaged` script to correct a bug that was preventing sub-function `System report` from ever running.
+    * Updated `Ship refueled` script to correct a bug that would cause it to sometimes report more than 100% fuel after refueling.
   * Added the following Cottle function, documented in [the SpeechResponder documentation](https://github.com/EDCD/EDDI/blob/master/SpeechResponder/Help.md):
      * `CommodityMarketDetails()` for retrieving market information about commodities.
 

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2077,7 +2077,7 @@ namespace EddiJournalMonitor
                                 data.TryGetValue("Cost", out val);
                                 long price = (long)val;
 
-                                events.Add(new ShipRefuelledEvent(timestamp, "Market", price, amount, null) { raw = line });
+                                events.Add(new ShipRefuelledEvent(timestamp, "Market", price, amount, null, false) { raw = line });
                                 handled = true;
                                 break;
                             }
@@ -2088,7 +2088,7 @@ namespace EddiJournalMonitor
                                 data.TryGetValue("Cost", out val);
                                 long price = (long)val;
 
-                                events.Add(new ShipRefuelledEvent(timestamp, "Market", price, amount, null) { raw = line });
+                                events.Add(new ShipRefuelledEvent(timestamp, "Market", price, amount, null, true) { raw = line });
                                 handled = true;
                                 break;
                             }
@@ -2097,7 +2097,9 @@ namespace EddiJournalMonitor
                                 decimal amount = JsonParsing.getDecimal(data, "Scooped");
                                 decimal total = JsonParsing.getDecimal(data, "Total");
 
-                                events.Add(new ShipRefuelledEvent(timestamp, "Scoop", null, amount, total) { raw = line });
+                                events.Add(new ShipRefuelledEvent(timestamp, "Scoop", null, amount, total, 
+                                    EDDI.Instance.CurrentShip == null ? false : EDDI.Instance.CurrentShip.fueltanktotalcapacity == null ? false : 
+                                    Math.Round(total) == EDDI.Instance.CurrentShip.fueltanktotalcapacity) { raw = line });
                                 handled = true;
                                 break;
                             }

--- a/ShipMonitor/ShipRefuelledEvent.cs
+++ b/ShipMonitor/ShipRefuelledEvent.cs
@@ -18,6 +18,7 @@ namespace EddiShipMonitor
             VARIABLES.Add("price", "The price of refuelling (only available if the source is Market)");
             VARIABLES.Add("amount", "The amount of fuel obtained");
             VARIABLES.Add("total", "The new fuel level (only available if the source is Scoop)");
+            VARIABLES.Add("full", "Whether this is a full refuel");
         }
 
         public string source { get; private set; }
@@ -28,12 +29,15 @@ namespace EddiShipMonitor
 
         public decimal? total { get; private set; }
 
-        public ShipRefuelledEvent(DateTime timestamp, string source, long? price, decimal amount, decimal? total) : base(timestamp, NAME)
+        public bool full { get; private set; }
+
+        public ShipRefuelledEvent(DateTime timestamp, string source, long? price, decimal amount, decimal? total, bool full = false) : base(timestamp, NAME)
         {
             this.source = source;
             this.price = price;
             this.amount = amount;
             this.total = total;
+            this.full = full;
         }
     }
 }

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1482,7 +1482,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{if event.total:\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.total = ship.fueltanktotalcapacity:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
+      "script": "{if event.source = \"Scoop\":\r\n   {SetState('eddi_context_fuel_remaining', event.total)}\r\n|elif event.full:\r\n   {SetState('eddi_context_fuel_remaining', ship.fueltanktotalcapacity)}\r\n|else:\r\n   {SetState('eddi_context_fuel_remaining', state.eddi_context_fuel_remaining + event.amount)}\r\n}\r\n\r\n{Pause(2000)}\r\n{if event.full:\r\n   {set refueled_desc to OneOf(\"fully refuelled\", \"at maximum fuel capacity\",\"at 100% fuel capacity\")}\r\n   {OneOf(\"Refueled\", \"Fuel at maximum\", \"Maximum fuel\", \"{ShipName()} is now {refueled_desc}\" )}\r\n|else:\r\n   {if event.amount <= 5.0000:\r\n      {F('Fuel check')}\r\n   }\r\n}",
       "default": true,
       "name": "Ship refuelled",
       "description": "Triggered when you refuel your ship"


### PR DESCRIPTION
Add new event property `full` designating whether this is a full fillup or partial, and revise scripts accordingly.
Fix for #581.