### PR TITLE
Dramatically reduced CPU utilization in VoiceAtttack

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,9 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.1-rc4
+  * Dramatically reduced CPU load for VoiceAttack users running EDDI as a plugin.
+
 ### 3.0.1-rc3
   * Core
     * Added data definitions for the new ships and modules in Chapter 2.

--- a/VoiceAttackResponder/VoiceAttackResponder.cs
+++ b/VoiceAttackResponder/VoiceAttackResponder.cs
@@ -3,6 +3,7 @@ using Utilities;
 using EddiEvents;
 using Newtonsoft.Json;
 using System.Windows.Controls;
+using System;
 
 namespace EddiVoiceAttackResponder
 {
@@ -11,6 +12,8 @@ namespace EddiVoiceAttackResponder
     /// </summary>
     class VoiceAttackResponder : EDDIResponder
     {
+        public static event EventHandler<Event> OnEvent;
+
         public string ResponderName()
         {
             return "VoiceAttack responder";
@@ -40,6 +43,7 @@ namespace EddiVoiceAttackResponder
         {
             Logging.Debug("Received event " + JsonConvert.SerializeObject(theEvent));
             VoiceAttackPlugin.EventQueue.Add(theEvent);
+            OnEvent(this, theEvent);
         }
 
         public bool Start()


### PR DESCRIPTION
Trigger VoiceAttack variable updating via event handling rather than through continuously pushed loops. Fix for #720.