### PR TITLE
Fix CurrentStarSystem not matching destination system during `FSD engaged` event

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1001,6 +1001,9 @@ namespace Eddi
             CurrentStation = null;
             CurrentStellarBody = null;
 
+            // Set the destination system as the current star system
+            updateCurrentSystem(@event.system);
+
             return true;
         }
 


### PR DESCRIPTION
Speculative fix for #734