### PR TITLE
Hotfix/731 eddn meanprice

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -293,7 +293,7 @@ namespace EddiCompanionAppService
                     cachedProfile.LastStation.commodities = CommodityQuotesFromProfile(marketJson);
                     cachedProfile.LastStation.prohibited = ProhibitedCommoditiesFromProfile(marketJson);
                 }
-
+                /*
                 if (cachedProfile.LastStation.hasoutfitting ?? false)
                 {
                     Logging.Debug("Getting station outfitting data");
@@ -312,6 +312,7 @@ namespace EddiCompanionAppService
                     JObject shipyardJson = JObject.Parse(shipyard);
                     cachedProfile.LastStation.shipyard = ShipyardFromProfile(shipyardJson);
                 }
+                */
             }
             catch (JsonException ex)
             {

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -293,7 +293,7 @@ namespace EddiCompanionAppService
                     cachedProfile.LastStation.commodities = CommodityQuotesFromProfile(marketJson);
                     cachedProfile.LastStation.prohibited = ProhibitedCommoditiesFromProfile(marketJson);
                 }
-                /*
+                
                 if (cachedProfile.LastStation.hasoutfitting ?? false)
                 {
                     Logging.Debug("Getting station outfitting data");
@@ -312,7 +312,6 @@ namespace EddiCompanionAppService
                     JObject shipyardJson = JObject.Parse(shipyard);
                     cachedProfile.LastStation.shipyard = ShipyardFromProfile(shipyardJson);
                 }
-                */
             }
             catch (JsonException ex)
             {

--- a/DataDefinitions/CommodityDefinition.cs
+++ b/DataDefinitions/CommodityDefinition.cs
@@ -406,8 +406,11 @@ namespace EddiDataDefinitions
         public readonly long EliteID;
         public readonly long? EDDBID;
         public readonly CommodityCategory category;
-        public readonly int avgprice;
         public readonly bool rare;
+
+        // The average price of a commodity can change - thus this cannot be read only.
+        // Instead, this value should be updated whenever revised data is received.
+        public int avgprice; 
 
         // dummy used to ensure that the static constructor has run
         public CommodityDefinition() : this(0, null, "", Unknown)

--- a/DataDefinitions/CommodityDefinition.cs
+++ b/DataDefinitions/CommodityDefinition.cs
@@ -410,7 +410,7 @@ namespace EddiDataDefinitions
 
         // The average price of a commodity can change - thus this cannot be read only.
         // Instead, this value should be updated whenever revised data is received.
-        public int avgprice; 
+        public int avgprice { get; set; } 
 
         // dummy used to ensure that the static constructor has run
         public CommodityDefinition() : this(0, null, "", Unknown)

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -82,7 +82,10 @@ namespace EddiDataDefinitions
         public long? EDDBID => definition?.EDDBID;
         [Obsolete("Please use localizedName or InvariantName")]
         public string category => definition?.category.localizedName;
-        public int? avgprice => definition?.avgprice;
+
+        // Update the definition with the new galactic average price whenever this is set.
+        public int avgprice { get { return definition.avgprice; } set { definition.avgprice = value; } }
+
         public bool rare => definition?.rare ?? false;
 
         public CommodityMarketQuote(CommodityDefinition definition)
@@ -107,6 +110,7 @@ namespace EddiDataDefinitions
             }
             CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef);
             quote.buyprice = (int)capiJSON["buyPrice"];
+            quote.definition.avgprice = (int)capiJSON["meanPrice"];
             quote.stock = (int)capiJSON["stock"];
             quote.stockbracket = (int)capiJSON["stockBracket"];
             quote.sellprice = (int)capiJSON["sellPrice"];

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -130,7 +130,7 @@ namespace EddiDataDefinitions
                 return null;
             }
 
-            dynamic intOrEmptyString(JObject jObject, string key)
+            dynamic intStringOrNull(JObject jObject, string key)
             {
                 JToken token = jObject[key];
                 switch (token.Type)
@@ -151,10 +151,10 @@ namespace EddiDataDefinitions
             quote.buyprice = (int)capiJSON["buyPrice"];
             quote.avgprice = (int)capiJSON["meanPrice"];
             quote.stock = (int)capiJSON["stock"];
-            quote.stockbracket = intOrEmptyString(capiJSON, "stockBracket");
+            quote.stockbracket = intStringOrNull(capiJSON, "stockBracket");
             quote.sellprice = (int)capiJSON["sellPrice"];
             quote.demand = (int)capiJSON["demand"];
-            quote.demandbracket = intOrEmptyString(capiJSON, "demandBracket");
+            quote.demandbracket = intStringOrNull(capiJSON, "demandBracket");
 
             List<string> StatusFlags = new List<string>();
             foreach (dynamic statusFlag in capiJSON["statusFlags"])

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -9,7 +9,7 @@ namespace EddiDataDefinitions
 {
     public class CommodityMarketQuote
     {
-        // TODO should really be readonly but we need to set it during JSON parsing
+        // should ideally be readonly but we need to set it during JSON parsing
         public CommodityDefinition definition { get; private set; }
 
         [OnDeserialized]

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -87,7 +87,17 @@ namespace EddiDataDefinitions
         public int avgprice
         {
             get { return definition?.avgprice ?? 0; }
-            set { if (definition is null) { return; } else { definition.avgprice = value; } }
+            set
+            {
+                if (definition is null)
+                {
+                    return;
+                }
+                else
+                {
+                    definition.avgprice = value;
+                }
+            }
         }
 
         public bool rare => definition?.rare ?? false;

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -84,11 +84,16 @@ namespace EddiDataDefinitions
         public string category => definition?.category.localizedName;
 
         // Update the definition with the new galactic average price whenever this is set.
-        public int avgprice { get { return definition.avgprice; } set { definition.avgprice = value; } }
+        public int avgprice
+        {
+            get { return definition?.avgprice ?? 0; }
+            set { definition.avgprice = value; }
+        }
 
         public bool rare => definition?.rare ?? false;
 
         // Admin... we only want to send commodity data from the Companion API to EDDN - no other sources.
+        [JsonIgnore]
         public bool fromFDev { get; set; }
 
         public CommodityMarketQuote(CommodityDefinition definition)

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -88,12 +88,16 @@ namespace EddiDataDefinitions
 
         public bool rare => definition?.rare ?? false;
 
+        // Admin... we only want to send commodity data from the Companion API to EDDN - no other sources.
+        public bool fromFDev { get; set; }
+
         public CommodityMarketQuote(CommodityDefinition definition)
         {
             this.definition = definition;
             stockbracket = "";
             demandbracket = "";
             StatusFlags = new List<string>();
+            fromFDev = false;
         }
 
         public static CommodityMarketQuote FromCapiJson(JObject capiJSON)
@@ -123,6 +127,7 @@ namespace EddiDataDefinitions
                 StatusFlags.Add((string)statusFlag);
             }
             quote.StatusFlags = StatusFlags;
+            quote.fromFDev = true;
             return quote;
         }
     }

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -10,7 +10,7 @@ namespace EddiDataDefinitions
     public class CommodityMarketQuote
     {
         // TODO should really be readonly but we need to set it during JSON parsing
-        public CommodityDefinition definition;
+        public CommodityDefinition definition { get; private set; }
 
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context)
@@ -93,10 +93,12 @@ namespace EddiDataDefinitions
                 {
                     return;
                 }
-                else
+                if (!fromFDev)
                 {
-                    definition.avgprice = value;
+                    return;
                 }
+
+                definition.avgprice = value;
             }
         }
 
@@ -128,6 +130,7 @@ namespace EddiDataDefinitions
                 return null;
             }
             CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef);
+            quote.fromFDev = true;
             quote.buyprice = (int)capiJSON["buyPrice"];
             quote.avgprice = (int)capiJSON["meanPrice"];
             quote.stock = (int)capiJSON["stock"];
@@ -142,7 +145,6 @@ namespace EddiDataDefinitions
                 StatusFlags.Add((string)statusFlag);
             }
             quote.StatusFlags = StatusFlags;
-            quote.fromFDev = true;
             return quote;
         }
     }

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -129,15 +129,32 @@ namespace EddiDataDefinitions
                 }
                 return null;
             }
+
+            dynamic intOrEmptyString(JObject jObject, string key)
+            {
+                JToken token = jObject[key];
+                switch (token.Type)
+                {
+                    case JTokenType.Integer:
+                        return (int)token;
+                    case JTokenType.String:
+                        return (string)token;
+                    case JTokenType.None:
+                        return null;
+                    default:
+                        return token.ToString();
+                }
+            }
+
             CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef);
             quote.fromFDev = true;
             quote.buyprice = (int)capiJSON["buyPrice"];
             quote.avgprice = (int)capiJSON["meanPrice"];
             quote.stock = (int)capiJSON["stock"];
-            quote.stockbracket = (int)capiJSON["stockBracket"];
+            quote.stockbracket = intOrEmptyString(capiJSON, "stockBracket");
             quote.sellprice = (int)capiJSON["sellPrice"];
             quote.demand = (int)capiJSON["demand"];
-            quote.demandbracket = (int)capiJSON["demandBracket"];
+            quote.demandbracket = intOrEmptyString(capiJSON, "demandBracket");
 
             List<string> StatusFlags = new List<string>();
             foreach (dynamic statusFlag in capiJSON["statusFlags"])

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -87,12 +87,12 @@ namespace EddiDataDefinitions
         public int avgprice
         {
             get { return definition?.avgprice ?? 0; }
-            set { definition.avgprice = value; }
+            set { if (definition is null) { return; } else { definition.avgprice = value; } }
         }
 
         public bool rare => definition?.rare ?? false;
 
-        // Admin... we only want to send commodity data from the Companion API to EDDN - no other sources.
+        // Admin... we only want to send commodity data from the Companion API or market.json to EDDN - no data from 3rd party other sources.
         [JsonIgnore]
         public bool fromFDev { get; set; }
 
@@ -119,7 +119,7 @@ namespace EddiDataDefinitions
             }
             CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef);
             quote.buyprice = (int)capiJSON["buyPrice"];
-            quote.definition.avgprice = (int)capiJSON["meanPrice"];
+            quote.avgprice = (int)capiJSON["meanPrice"];
             quote.stock = (int)capiJSON["stock"];
             quote.stockbracket = (int)capiJSON["stockBracket"];
             quote.sellprice = (int)capiJSON["sellPrice"];

--- a/EDDNResponder/EDDNCommodity.cs
+++ b/EDDNResponder/EDDNCommodity.cs
@@ -8,7 +8,6 @@ namespace EDDNResponder
     {
         // Schema reference: https://github.com/EDSM-NET/EDDN/blob/master/schemas/commodity-v3.0.json
         public string name;
-        [JsonIgnore] // do not send until #731 is fixed https://github.com/EDCD/EDDI/issues/731
         public int meanPrice;
         public int buyPrice;
         public int stock;

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -168,7 +168,12 @@ namespace EDDNResponder
 
             EDDNBody body = new EDDNBody();
             body.header = generateHeader();
+#if RELEASE
             body.schemaRef = "https://eddn.edcd.io/schemas/journal/1" + (EDDI.Instance.inBeta ? "/test" : "");
+#else
+            // Use the test schema while in development.
+            body.schemaRef = "https://eddn.edcd.io/schemas/journal/1/test";
+#endif
             body.message = data;
 
             sendMessage(body);
@@ -196,9 +201,6 @@ namespace EDDNResponder
 
         private void sendCommodityInformation()
         {
-            // It's possible that the commodity data, if it is here, has already come from EDDB.  We use the average price
-            // as a marker: this isn't visible in EDDB, so if we have average price we know that this is data from the companion
-            // API and should be reported
             if (EDDI.Instance.CurrentStation != null && EDDI.Instance.CurrentStation.commodities != null && EDDI.Instance.CurrentStation.commodities.Count > 0)
             {
                 List<EDDNEconomy> eddnEconomies = new List<EDDNEconomy>();
@@ -245,7 +247,12 @@ namespace EDDNResponder
 
                     EDDNBody body = new EDDNBody();
                     body.header = generateHeader();
+#if RELEASE
                     body.schemaRef = "https://eddn.edcd.io/schemas/commodity/3" + (EDDI.Instance.inBeta ? "/test" : "");
+#else
+                    // Use the test schema while in development.
+                    body.schemaRef = "https://eddn.edcd.io/schemas/commodity/3/test";
+#endif
                     body.message = data;
 
                     Logging.Debug("EDDN message is: " + JsonConvert.SerializeObject(body));
@@ -280,7 +287,12 @@ namespace EDDNResponder
 
                     EDDNBody body = new EDDNBody();
                     body.header = generateHeader();
+#if RELEASE
                     body.schemaRef = "https://eddn.edcd.io/schemas/outfitting/2" + (EDDI.Instance.inBeta ? "/test" : "");
+#else
+                    // Use the test schema while in development.
+                    body.schemaRef = "https://eddn.edcd.io/schemas/outfitting/2/test";
+#endif
                     body.message = data;
 
                     sendMessage(body);
@@ -309,7 +321,12 @@ namespace EDDNResponder
 
                     EDDNBody body = new EDDNBody();
                     body.header = generateHeader();
+#if RELEASE
                     body.schemaRef = "https://eddn.edcd.io/schemas/shipyard/2" + (EDDI.Instance.inBeta ? "/test" : "");
+#else
+                    // Use the test schema while in development.
+                    body.schemaRef = "https://eddn.edcd.io/schemas/shipyard/2/test";
+#endif
                     body.message = data;
 
                     sendMessage(body);

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -203,42 +203,8 @@ namespace EDDNResponder
         {
             if (EDDI.Instance.CurrentStation != null && EDDI.Instance.CurrentStation.commodities != null && EDDI.Instance.CurrentStation.commodities.Count > 0)
             {
-                List<EDDNEconomy> eddnEconomies = new List<EDDNEconomy>();
-                if (EDDI.Instance.CurrentStation.economies != null)
-                {
-                    foreach (CompanionAppEconomy economy in EDDI.Instance.CurrentStation.economies)
-                    {
-                        EDDNEconomy eddnEconomy = new EDDNEconomy(economy);
-                        eddnEconomies.Add(eddnEconomy);
-                    }
-                }
-
-                List<EDDNCommodity> eddnCommodities = new List<EDDNCommodity>();
-                foreach (CommodityMarketQuote quote in EDDI.Instance.CurrentStation.commodities)
-                {
-                    if (quote.definition == null)
-                    {
-                        continue;
-                    }
-                    if (!quote.fromFDev)
-                    {
-                        // We only want data from the Frontier API (or market.json)
-                        // Data from 3rd parties (EDDB, EDSM, EDDP, etc.) is not acceptable.
-                        continue;
-                    }
-                    if (quote.avgprice == 0)
-                    {
-                        // Check that the average price is greater than zero.
-                        continue;
-                    }
-                    if (quote.definition.category == CommodityCategory.NonMarketable)
-                    {
-                        // Include only marketable commodities.
-                        continue;
-                    }
-                    EDDNCommodity eddnCommodity = new EDDNCommodity(quote);
-                    eddnCommodities.Add(eddnCommodity);
-                };
+                List<EDDNEconomy> eddnEconomies = prepareEconomyInformation();
+                List<EDDNCommodity> eddnCommodities = prepareCommodityInformation();
 
                 // Only send the message if we have commodities
                 if (eddnCommodities.Count > 0)
@@ -271,6 +237,52 @@ namespace EDDNResponder
                     sendMessage(body);
                 }
             }
+        }
+
+        private static List<EDDNEconomy> prepareEconomyInformation()
+        {
+            List<EDDNEconomy> eddnEconomies = new List<EDDNEconomy>();
+            if (EDDI.Instance.CurrentStation.economies != null)
+            {
+                foreach (CompanionAppEconomy economy in EDDI.Instance.CurrentStation.economies)
+                {
+                    EDDNEconomy eddnEconomy = new EDDNEconomy(economy);
+                    eddnEconomies.Add(eddnEconomy);
+                }
+            }
+
+            return eddnEconomies;
+        }
+
+        private static List<EDDNCommodity> prepareCommodityInformation()
+        {
+            List<EDDNCommodity> eddnCommodities = new List<EDDNCommodity>();
+            foreach (CommodityMarketQuote quote in EDDI.Instance.CurrentStation.commodities)
+            {
+                if (quote.definition == null)
+                {
+                    continue;
+                }
+                if (!quote.fromFDev)
+                {
+                    // We only want data from the Frontier API (or market.json)
+                    // Data from 3rd parties (EDDB, EDSM, EDDP, etc.) is not acceptable.
+                    continue;
+                }
+                if (quote.avgprice == 0)
+                {
+                    // Check that the average price is greater than zero.
+                    continue;
+                }
+                if (quote.definition.category == CommodityCategory.NonMarketable)
+                {
+                    // Include only marketable commodities.
+                    continue;
+                }
+                EDDNCommodity eddnCommodity = new EDDNCommodity(quote);
+                eddnCommodities.Add(eddnCommodity);
+            };
+            return eddnCommodities;
         }
 
         private void sendOutfittingInformation()

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -220,6 +220,12 @@ namespace EDDNResponder
                     {
                         continue;
                     }
+                    if (!quote.fromFDev)
+                    {
+                        // We only want data from the Frontier API (or market.json)
+                        // Data from 3rd parties (EDDB, EDSM, EDDP, etc.) is not acceptable.
+                        continue;
+                    }
                     if (quote.avgprice == 0)
                     {
                         // Check that the average price is greater than zero.

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -231,18 +231,9 @@ namespace EDDNResponder
                         // Check that the average price is greater than zero.
                         continue;
                     }
-                    if (quote.demand > 0 && quote.buyprice == 0)
-                    {
-                        // When there is demand, there should always be a buy price
-                        continue;
-                    }
-                    if (quote.stock > 0 && quote.sellprice == 0)
-                    {
-                        // When there is stock, there should always be a sell price
-                        continue;
-                    }
                     if (quote.definition.category == CommodityCategory.NonMarketable)
                     {
+                        // Include only marketable commodities.
                         continue;
                     }
                     EDDNCommodity eddnCommodity = new EDDNCommodity(quote);

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -220,6 +220,21 @@ namespace EDDNResponder
                     {
                         continue;
                     }
+                    if (quote.avgprice == 0)
+                    {
+                        // Check that the average price is greater than zero.
+                        continue;
+                    }
+                    if (quote.demand > 0 && quote.buyprice == 0)
+                    {
+                        // When there is demand, there should always be a buy price
+                        continue;
+                    }
+                    if (quote.stock > 0 && quote.sellprice == 0)
+                    {
+                        // When there is stock, there should always be a sell price
+                        continue;
+                    }
                     if (quote.definition.category == CommodityCategory.NonMarketable)
                     {
                         continue;

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -107,6 +107,23 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestParseCAPICommodityQuoteNotOverwritten()
+        {
+            CommodityMarketQuote quote = CannedCAPIQuote();
+            CommodityMarketQuote oldQuote = new CommodityMarketQuote(quote.definition);
+            oldQuote.avgprice = 99999999;
+            Assert.AreEqual(313, quote.buyprice);
+            Assert.AreEqual(281, quote.sellprice);
+            Assert.AreEqual(294, quote.avgprice);
+            Assert.AreEqual(0, quote.demandbracket);
+            Assert.AreEqual(2, quote.stockbracket);
+            Assert.AreEqual(31881, quote.stock);
+            Assert.AreEqual(1, quote.demand);
+            Assert.AreEqual(0, quote.StatusFlags.Count);
+            Assert.IsTrue(quote.fromFDev);
+        }
+
+        [TestMethod]
         public void TestEddnCommodityQuote()
         {
             CommodityMarketQuote quote = CannedCAPIQuote();

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -65,6 +65,7 @@ namespace UnitTests
             Assert.AreEqual("Medicines", commodity.definition.category.invariantName);
             Assert.AreEqual(6779, commodity.avgprice);
             Assert.IsFalse(commodity.rare);
+            Assert.IsFalse(commodity.fromFDev);
         }
 
         private static CommodityMarketQuote CannedCAPIQuote()
@@ -86,6 +87,7 @@ namespace UnitTests
             }";
             JObject jObject = JObject.Parse(json);
             CommodityMarketQuote quote = CommodityMarketQuote.FromCapiJson(jObject);
+            quote.fromFDev = true;
             return quote;
         }
 
@@ -101,6 +103,7 @@ namespace UnitTests
             Assert.AreEqual(31881, quote.stock);
             Assert.AreEqual(1, quote.demand);
             Assert.AreEqual(0, quote.StatusFlags.Count);
+            Assert.IsTrue(quote.fromFDev);
         }
 
         [TestMethod]

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -77,7 +77,7 @@ namespace UnitTests
                 ""buyPrice"": 313,
                 ""sellPrice"": 281,
                 ""meanPrice"": 294,
-                ""demandBracket"": 0,
+                ""demandBracket"": """",
                 ""stockBracket"": 2,
                 ""stock"": 31881,
                 ""demand"": 1,
@@ -98,7 +98,7 @@ namespace UnitTests
             Assert.AreEqual(313, quote.buyprice);
             Assert.AreEqual(281, quote.sellprice);
             Assert.AreEqual(294, quote.avgprice);
-            Assert.AreEqual(0, quote.demandbracket);
+            Assert.AreEqual("", quote.demandbracket);
             Assert.AreEqual(2, quote.stockbracket);
             Assert.AreEqual(31881, quote.stock);
             Assert.AreEqual(1, quote.demand);
@@ -115,7 +115,7 @@ namespace UnitTests
             Assert.AreEqual(313, quote.buyprice);
             Assert.AreEqual(281, quote.sellprice);
             Assert.AreEqual(294, quote.avgprice);
-            Assert.AreEqual(0, quote.demandbracket);
+            Assert.AreEqual("", quote.demandbracket);
             Assert.AreEqual(2, quote.stockbracket);
             Assert.AreEqual(31881, quote.stock);
             Assert.AreEqual(1, quote.demand);

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -95,7 +95,7 @@ namespace UnitTests
             CommodityMarketQuote quote = CannedCAPIQuote();
             Assert.AreEqual(313, quote.buyprice);
             Assert.AreEqual(281, quote.sellprice);
-            // Assert.AreEqual(294, quote.avgprice); // TODO: re-enable when #731 is fixed
+            Assert.AreEqual(294, quote.avgprice);
             Assert.AreEqual(0, quote.demandbracket);
             Assert.AreEqual(2, quote.stockbracket);
             Assert.AreEqual(31881, quote.stock);


### PR DESCRIPTION
Fixes #731.

Read average commodity prices from CAPI data and pass to EDDN.

Great care needs to be taken to ensure that average prices from other sources are ignored.