### PR TITLE
Create a generic event handler for unknown events.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.1.0-b1
+  * Core
+    * Fixed a bug that was preventing some events from being passed to EDSM.
+
 ### 3.0.1-rc6
   * EDDN responder
     * Fixed symbol for Krait Mk II in shipyard data.

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeltScannedEvent.cs" />
     <Compile Include="CargoDepotEvent.cs" />
     <Compile Include="CargoWingUpdateEvent.cs" />
+    <Compile Include="UnhandledEvent.cs" />
     <Compile Include="FighterRebuiltEvent.cs" />
     <Compile Include="JetConeDamageEvent.cs" />
     <Compile Include="MaterialTradedEvent.cs" />

--- a/Events/UnhandledEvent.cs
+++ b/Events/UnhandledEvent.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class UnhandledEvent : Event
+    {
+        public const string NAME = "Unhandled event";
+        public const string DESCRIPTION = "Triggered when EDDI encounters an event that we don't otherwise handle";
+        public const string SAMPLE = null;
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static UnhandledEvent()
+        {
+        }
+
+        public string edType { get; private set; }
+
+        public UnhandledEvent(DateTime timestamp, string type) : base(timestamp, NAME)
+        {
+            this.edType = type;
+        }
+    }
+}

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2729,6 +2729,9 @@ namespace EddiJournalMonitor
                     {
                         Logging.Debug("Unhandled event: " + line);
 
+                        // Pass a basic event so that responders can react appropriately.
+                        // For example, the EDSM responder will handle raw events.
+                        events.Add(new UnhandledEvent(timestamp, edType) { raw = line });
                     }
                 }
             }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -267,9 +267,9 @@ namespace EddiSpeechResponder
             // Report missing scripts, except those we have specifically named
             /// `Belt scanned` is a useless event, only exists so that the count on nav beacon scans comes out right
             /// `Jumping` is a deprecated event
-            /// `Status` is an event which shares status updates with monitors / responders but is not intended to be user facing
-            string[] ignoredEventKeys = { "Belt scanned", "Jumping", "Status" };
-            missingScripts.RemoveAll(t => t == "Belt scanned" || t == "Jumping" || t == "Status");
+            /// `Status` and `Unhandled event` are events which shares updates with monitors / responders but are not intended to be user facing
+            string[] ignoredEventKeys = { "Belt scanned", "Jumping", "Status", "Unhandled event" };
+            missingScripts.RemoveAll(t => t == "Belt scanned" || t == "Jumping" || t == "Status" || t == "Unhandled event" );
             if (missingScripts.Count > 0)
             {
                 Logging.Info("Failed to find scripts" + string.Join(";", missingScripts));

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -59,7 +59,7 @@ namespace EddiVoiceAttackResponder
                 // Add notifiers for events we want to react to 
                 EDDI.Instance.State.CollectionChanged += (s, e) => setDictionaryValues(EDDI.Instance.State, "state", ref vaProxy);
                 SpeechService.Instance.PropertyChanged += (s, e) => setSpeaking(SpeechService.eddiSpeaking, ref vaProxy);
-                VoiceAttackResponder.OnEvent += (s, theEvent) => updateValuesOnEvent(theEvent, ref vaProxy);
+                VoiceAttackResponder.RaiseEvent += (s, theEvent) => updateValuesOnEvent(theEvent, ref vaProxy);
 
                 // Display instance information if available
                 if (EDDI.Instance.UpgradeRequired)

--- a/VoiceAttackResponder/VoiceAttackResponder.cs
+++ b/VoiceAttackResponder/VoiceAttackResponder.cs
@@ -12,7 +12,15 @@ namespace EddiVoiceAttackResponder
     /// </summary>
     class VoiceAttackResponder : EDDIResponder
     {
-        public static event EventHandler<Event> OnEvent;
+        public static event EventHandler<Event> RaiseEvent;
+
+        protected virtual void OnEvent(EventArgs @eventArgs, Event @event)
+        {
+            if (RaiseEvent != null)
+            {
+                RaiseEvent(@eventArgs, @event);
+            }
+        }
 
         public string ResponderName()
         {
@@ -43,7 +51,7 @@ namespace EddiVoiceAttackResponder
         {
             Logging.Debug("Received event " + JsonConvert.SerializeObject(theEvent));
             VoiceAttackPlugin.EventQueue.Add(theEvent);
-            OnEvent(this, theEvent);
+            OnEvent(new EventArgs(), theEvent);
         }
 
         public bool Start()


### PR DESCRIPTION
This will allow unknown events to be passed to monitors and responders even if we don't have a definition for that event yet.
To address issue #776.

Also corrects a null reference exception generated because EventArgs weren't being properly set.