### PR TITLE
Fix shipmonitor.json not recording full module object properties

### DIFF
--- a/DataDefinitions/Module.cs
+++ b/DataDefinitions/Module.cs
@@ -1,4 +1,6 @@
-﻿namespace EddiDataDefinitions
+﻿using Newtonsoft.Json;
+
+namespace EddiDataDefinitions
 {
     public partial class Module : ResourceBasedLocalizedEDName<Module>
     {
@@ -10,26 +12,41 @@
         }
 
         // Definition of the module
+        [JsonProperty]
         public int @class { get; set; }
+        [JsonProperty]
         public string grade { get; set; }
+        [JsonProperty]
         public long value { get; set; } // The undiscounted value
+
         // Additional definition for some items
+        [JsonProperty]
         public int? ShipId { get; set; } // Only for bulkheads
+        [JsonProperty]
         public ModuleMount? mount { get; set; } // Only for weapons
+        [JsonProperty]
         public int? clipcapacity { get; set; } // Only for weapons
+        [JsonProperty]
         public int? hoppercapacity { get; set; } // Only for weapons
 
         // State of the module
+        [JsonProperty]
         public long price { get; set; } // How much we actually paid for it
+        [JsonProperty]
         public bool enabled { get; set; }
+        [JsonProperty]
         public int priority { get; set; }
+        [JsonProperty]
         public decimal health { get; set; }
+        [JsonProperty]
         public bool modified { get; set; } // If the module has been modified
 
         // Admin
         // The ID in Elite: Dangerous' database
+        [JsonProperty]
         public long EDID { get; set; }
         // The ID in eddb.io
+        [JsonProperty]
         public long EDDBID { get; set; }
 
         // TEMP

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.2-b1
+  * Ship monitor
+    * Fixed a bug that was preventing full module details from being saved to our config files correctly. 
+
 ### 3.0.1-rc6
   * EDDN responder
     * Fixed symbol for Krait Mk II in shipyard data.

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -522,6 +522,21 @@ namespace EddiJournalMonitor
                                         {
                                             // This is a compartment
                                             Compartment compartment = new Compartment() { name = slot };
+
+                                            // Compartment slots are in the form of "Slotnn_Sizen" or "Militarynn"
+                                            if (slot.Contains("Slot"))
+                                            {
+                                                Match matches = Regex.Match(compartment.name, @"Size([0-9]+)");
+                                                if (matches.Success)
+                                                {
+                                                    compartment.size = Int32.Parse(matches.Groups[1].Value);
+                                                }
+                                            }
+                                            else if (slot.Contains("Military"))
+                                            {
+                                                compartment.size = (int)ShipDefinitions.FromEDModel(ship)?.militarysize;
+                                            }
+
                                             Module module = Module.FromEDName(item);
                                             if (module == null)
                                             {


### PR DESCRIPTION
Fix #769. ShipMonitor.json wasn't being serialized with full module objects. 
Add logic to identify compartment size from loadout events.