### PR TITLE
Fix null reference exceptions from edsm.json

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.2-b1
+  * EDSM responder
+    * Fixed a bug that would cause EDDI to crash if our EDSM configuration were set incorrectly.
+
 ### 3.0.1-rc6
   * EDDN responder
     * Fixed symbol for Krait Mk II in shipyard data.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -367,16 +367,24 @@ namespace Eddi
                     }
                     else
                     {
-                        bool responderStarted = responder.Start();
-                        if (responderStarted)
+                        try
                         {
-                            activeResponders.Add(responder);
-                            Logging.Info("Started " + responder.ResponderName());
+                            bool responderStarted = responder.Start();
+                            if (responderStarted)
+                            {
+                                activeResponders.Add(responder);
+                                Logging.Info("Started " + responder.ResponderName());
+                            }
+                            else
+                            {
+                                Logging.Warn("Failed to start " + responder.ResponderName());
+                            }
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            Logging.Warn("Failed to start " + responder.ResponderName());
+                            Logging.Error("Failed to start " + responder.ResponderName(), ex);
                         }
+
                     }
                 }
                 started = true;

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -59,6 +59,7 @@ namespace EddiEdsmResponder
         public void Reload()
         {
             // Set up the star map service
+            starMapService = null;
             StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
             if (starMapCredentials != null && starMapCredentials.apiKey != null)
             {
@@ -78,7 +79,7 @@ namespace EddiEdsmResponder
                 }
                 if (ignoredEvents == null)
                 {
-                    ignoredEvents = starMapService.getIgnoredEvents();
+                    ignoredEvents = starMapService?.getIgnoredEvents();
                 }
             }
 


### PR DESCRIPTION
Exceptions could occur if the commander's name or API key was null and the starMapService consequently wasn't initialized.