### PR TITLE
Prevent Status.hardpoints_deployed being set to true in supercruise

### DIFF
--- a/DataDefinitions/Status.cs
+++ b/DataDefinitions/Status.cs
@@ -75,7 +75,7 @@ namespace EddiDataDefinitions
 
         // FDev changes hardpoints status when the discovery scanner is used in supercruise. 
         // We want to keep hardpoints_deployed false if we are in supercruise.
-        public bool hardpoints_deployed => ((flags & Flags.HardpointsDeployed) != 0) & !((flags & Flags.Supercruise) != 0);
+        public bool hardpoints_deployed => ((flags & Flags.HardpointsDeployed) != 0) && !supercruise;
 
         // Variables set from pips (these are not always present in the event)
         public decimal? pips_sys = 0;

--- a/DataDefinitions/Status.cs
+++ b/DataDefinitions/Status.cs
@@ -66,13 +66,16 @@ namespace EddiDataDefinitions
         public bool cargo_scoop_deployed => (flags & Flags.CargoScoopDeployed) != 0;
         public bool lights_on => (flags & Flags.LightsOn) != 0;
         public bool in_wing => (flags & Flags.InWing) != 0;
-        public bool hardpoints_deployed => (flags & Flags.HardpointsDeployed) != 0;
         public bool flight_assist_off => (flags & Flags.FlightAssistOff) != 0;
         public bool supercruise => (flags & Flags.Supercruise) != 0;
         public bool shields_up => (flags & Flags.ShieldsUp) != 0;
         public bool landing_gear_down => (flags & Flags.LandingGearDown) != 0;
         public bool landed => (flags & Flags.Landed) != 0;
         public bool docked => (flags & Flags.Docked) != 0;
+
+        // FDev changes hardpoints status when the discovery scanner is used in supercruise. 
+        // We want to keep hardpoints_deployed false if we are in supercruise.
+        public bool hardpoints_deployed => ((flags & Flags.HardpointsDeployed) != 0) & !((flags & Flags.Supercruise) != 0);
 
         // Variables set from pips (these are not always present in the event)
         public decimal? pips_sys = 0;

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.2-b1
+  * Status monitor
+    * `Status.hardpoints_deployed` is now locked to false while we are in supercruise.
+
 ### 3.0.1-rc6
   * EDDN responder
     * Fixed symbol for Krait Mk II in shipyard data.


### PR DESCRIPTION
FDev sets Status.hardpoints_deployed to true when you use the discovery scanner in supercruise. This has undesirable consequences, so we need to keep Status.hardpoints_deployed false while we are in supercruise.

Fixes #772