### PR TITLE
Add a 'glide` event (mostly for added immersion)

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,7 +2,7 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
-### 3.0.2
+### Development
   * Speech responder
     * Added new event: `Glide`, triggered when your ship enters or exits glide near a planet's surface
     * Revised script: `Entered normal space` to not announce that we are entering normal space during a glide.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,11 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.0.2
+  * Speech responder
+    * Added new event: `Glide`, triggered when your ship enters or exits glide near a planet's surface
+    * Revised script: `Entered normal space` to not announce that we are entering normal space during a glide.
+
 ### 3.0.1-rc6
   * EDDN responder
     * Fixed symbol for Krait Mk II in shipyard data.

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeltScannedEvent.cs" />
     <Compile Include="CargoDepotEvent.cs" />
     <Compile Include="CargoWingUpdateEvent.cs" />
+    <Compile Include="GlideEvent.cs" />
     <Compile Include="FighterRebuiltEvent.cs" />
     <Compile Include="JetConeDamageEvent.cs" />
     <Compile Include="MaterialTradedEvent.cs" />

--- a/Events/GlideEvent.cs
+++ b/Events/GlideEvent.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class GlideEvent : Event
+    {
+        public const string NAME = "Glide";
+        public const string DESCRIPTION = "Triggered when your ship enters or exits glide";
+        public const string SAMPLE = null;
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static GlideEvent()
+        {
+            VARIABLES.Add("status", "The glide status (either \"started\" or \"stopped\")");
+        }
+
+        [JsonProperty("status")]
+        public string status { get; private set; }
+
+        public GlideEvent(DateTime timestamp, string status) : base(timestamp, NAME)
+        {
+            this.status = status;
+        }
+    }
+}

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -537,8 +537,8 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{Pause(5000)}\r\n\r\n{OneOf(\"{ShipName()} has\", \"\")} {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n{if event.bodytype = 'Planet':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n|elif event.bodytype = 'Star':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n  |elif event.bodytype = 'Station':\r\n    {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n}.\r\n",
-      "default": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
+      "default": false,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -730,6 +730,15 @@
       "default": true,
       "name": "Galnet unread report",
       "description": "Report on unread news"
+    },
+    "Glide": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
+      "default": false,
+      "name": "Glide",
+      "description": "Triggered when your ship enters or exits glide"
     },
     "Heat damage": {
       "enabled": true,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -538,7 +538,7 @@
       "priority": 3,
       "responder": true,
       "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'fsd')}\r\n{SetState('eddi_context_last_action', 'disengage')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_body_name', event.body)}\r\n{SetState('eddi_context_body_system', event.system)}\r\n\r\n{if status.near_surface && status.fsd_status != \"masslock\":\r\n    {Pause(5000)}\r\n\r\n    {OneOf(\"{ShipName()} has\", \"\")} \r\n    {OneOf(\"left supercruise\", \"{OneOf(\\\"entered\\\", \\\"returned to\\\", \\\"dropped to\\\")} normal space\")}\r\n\r\n    {if event.bodytype = 'Planet':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} planet {P(event.body)}\r\n    |elif event.bodytype = 'Star':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} star {P(event.body)}\r\n    |elif event.bodytype = 'Station':\r\n        {OneOf(\"near\", \"close to\", \"in the vicinity of\")} {P(event.body)}\r\n    }.\r\n}\r\n",
-      "default": false,
+      "default": true,
       "name": "Entered normal space",
       "description": "Triggered when your ship enters normal space"
     },
@@ -736,7 +736,7 @@
       "priority": 3,
       "responder": true,
       "script": "{if event.status = \"started\":\r\n   {Pause(1500)}\r\n   Glide \r\n   {Occasionally(2, \"mode\")} \r\n   {OneOf(\"initiated\", \"engaged\")}\r\n|elif event.status = \"stopped\":\r\n   Glide completed.\r\n}",
-      "default": false,
+      "default": true,
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -24,6 +24,7 @@ namespace EddiStatusMonitor
         private string Directory = GetSavedGamesDir();
         public static Status currentStatus { get; set; } = new Status();
         public static Status lastStatus { get; set; } = new Status();
+        private static bool gliding = false; 
 
         // Keep track of status
         private bool running;
@@ -328,6 +329,11 @@ namespace EddiStatusMonitor
                         EDDI.Instance.eventHandler(new ShipLowFuelEvent(thisStatus.timestamp));
                     }
                 }
+                if (gliding && thisStatus.fsd_status == "cooldown")
+                {
+                    EDDI.Instance.eventHandler(new GlideEvent(currentStatus.timestamp, "stopped"));
+                    gliding = false;
+                }
             }
         }
 
@@ -353,6 +359,21 @@ namespace EddiStatusMonitor
 
         public void PreHandle(Event @event)
         {
+            // Some events can be derived from our status during a given event
+            if (@event is EnteredNormalSpaceEvent)
+            {
+                handleEnteredNormalSpaceEvent(@event);
+            }
+        }
+
+        private void handleEnteredNormalSpaceEvent(Event @event)
+        {
+            // We can derive a "Glide" event from the context in our status
+            if (currentStatus.near_surface && currentStatus.fsd_status == "masslock")
+            {
+                EDDI.Instance.eventHandler(new GlideEvent(currentStatus.timestamp, "started"));
+                gliding = true;
+            }
         }
 
         public void PostHandle(Event @event)


### PR DESCRIPTION
This has been something I've had scratched onto the back of an envelope for a little while. 
This new event allows EDDI to announce both the beginning and completion of the glide as you approach a planet's surface, and revises the `Entered normal space` event so that it doesn't speak in the middle of the glide.