### PR TITLE
Make system validation more flexible

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1886,7 +1886,7 @@ namespace Eddi
                 if (HomeStarSystem != null)
                 {
                     Logging.Debug("Home star system is " + HomeStarSystem.name);
-                    configuration.validSystem = HomeStarSystem.bodies.Count > 0;
+                    configuration.validSystem = HomeStarSystem.bodies.Count > 0 || HomeStarSystem.stations.Count > 0 || HomeStarSystem.population > 0;
                 }
             }
             return configuration;


### PR DESCRIPTION
It was only passing if the system contained bodies (planets, moons, etc.). A system with a station but no planets failed validation. Expanded validation to check for bodies, stations, or population. If any of the three are present, the system is valid.
Ref. #792