### PR TITLE
Create a `Bounty paid` event and update the `Fine paid` event.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -21,6 +21,8 @@ Full details of the variables available for each noted event, and VoiceAttack in
     * Added `Cargo scoop` event
     * Added `Landing gear` event
     * Added `Lights` event
+    * Added `Bounty paid` event
+    * Updated the properties available from the `Fines paid` event. (Note that legacy fines were discontinued with Elite Dangerous version 3.0, the `legacy` boolean has been removed from this event.)
   * Status monitor
     * `Status.hardpoints_deployed` is now locked to false while we are in supercruise.
   * VoiceAttack responder

--- a/Events/BountyPaidEvent.cs
+++ b/Events/BountyPaidEvent.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class BountyPaidEvent : Event
+    {
+        public const string NAME = "Bounty paid";
+        public const string DESCRIPTION = "Triggered when you pay a bounty";
+        public const string SAMPLE = "{ \"timestamp\":\"2018-03-19T10:25:10Z\", \"event\":\"PayBounties\", \"Amount\":400, \"Faction\":\"$faction_Federation;\", \"Faction_Localised\":\"Federation\", \"ShipID\":9, \"BrokerPercentage\":25.000000 }";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static BountyPaidEvent()
+        {
+            VARIABLES.Add("amount", "The amount of the bounty paid");
+            VARIABLES.Add("brokerpercentage", "Broker precentage fee (if paid via a Broker)");
+            VARIABLES.Add("faction", "The faction to which the bounty was paid");
+            VARIABLES.Add("shipid", "The ship id of the ship associated with the fine");
+        }
+
+        [JsonProperty("amount")]
+        public long amount { get; private set; }
+
+        [JsonProperty("brokerpercentage")]
+        public decimal? brokerpercentage { get; private set; }
+
+        [JsonProperty("faction")]
+        public string faction { get; private set; }
+
+        [JsonProperty("shipid")]
+        public int shipid { get; private set; }
+
+        public BountyPaidEvent(DateTime timestamp, long amount, decimal? brokerpercentage, string faction, int shipId) : base(timestamp, NAME)
+        {
+            this.amount = amount;
+            this.brokerpercentage = brokerpercentage;
+            this.faction = faction;
+            this.shipid = shipId;
+        }
+    }
+}

--- a/Events/BountyPaidEvent.cs
+++ b/Events/BountyPaidEvent.cs
@@ -15,7 +15,7 @@ namespace EddiEvents
         static BountyPaidEvent()
         {
             VARIABLES.Add("amount", "The amount of the bounty paid");
-            VARIABLES.Add("brokerpercentage", "Broker precentage fee (if paid via a Broker)");
+            VARIABLES.Add("brokerpercentage", "Broker percentage (if paid via a Broker)");
             VARIABLES.Add("faction", "The faction to which the bounty was paid");
             VARIABLES.Add("shipid", "The ship id of the ship associated with the fine");
         }

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeltScannedEvent.cs" />
     <Compile Include="CargoDepotEvent.cs" />
     <Compile Include="CargoWingUpdateEvent.cs" />
+    <Compile Include="BountyPaidEvent.cs" />
     <Compile Include="UnhandledEvent.cs" />
     <Compile Include="FighterRebuiltEvent.cs" />
     <Compile Include="JetConeDamageEvent.cs" />

--- a/Events/FinePaidEvent.cs
+++ b/Events/FinePaidEvent.cs
@@ -8,7 +8,7 @@ namespace EddiEvents
     {
         public const string NAME = "Fine paid";
         public const string DESCRIPTION = "Triggered when you pay a fine";
-        public const string SAMPLE = "{ \"timestamp\":\"2016-10-06T09:30:36Z\", \"event\":\"PayLegacyFines\", \"Amount\":255 }";
+        public const string SAMPLE = "{ \"timestamp\":\"2018-03-19T10:24:21Z\", \"event\":\"PayFines\", \"Amount\":250, \"AllFines\":false, \"Faction\":\"Batz Transport Commodities\", \"ShipID\":9 }";
 
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
@@ -16,7 +16,9 @@ namespace EddiEvents
         {
             VARIABLES.Add("amount", "The amount of the fine paid");
             VARIABLES.Add("brokerpercentage", "Broker precentage fee (if paid via a Broker)");
-            VARIABLES.Add("legacy", "True if the payment is for a legacy fine");
+            VARIABLES.Add("allfines", "Whether this payments covers all current fines (true or false)");
+            VARIABLES.Add("faction", "The faction to which the fine was paid (if the payment does not cover all current fines)");
+            VARIABLES.Add("shipid", "The ship id of the ship associated with the fine");
         }
 
         [JsonProperty("amount")]
@@ -25,13 +27,22 @@ namespace EddiEvents
         [JsonProperty("brokerpercentage")]
         public decimal? brokerpercentage { get; private set; }
 
-        [JsonProperty("legacy")]
-        public bool legacy { get; private set; }
+        [JsonProperty("allfines")]
+        public bool allfines { get; private set; }
 
-        public FinePaidEvent(DateTime timestamp, long amount, decimal? brokerpercentage, bool legacy) : base(timestamp, NAME)
+        [JsonProperty("faction")]
+        public string faction { get; private set; }
+
+        [JsonProperty("shipid")]
+        public int shipid { get; private set; }
+
+        public FinePaidEvent(DateTime timestamp, long amount, decimal? brokerpercentage, bool allFines, string faction, int shipId) : base(timestamp, NAME)
         {
             this.amount = amount;
-            this.legacy = legacy;
+            this.brokerpercentage = brokerpercentage;
+            this.allfines = allFines;
+            this.faction = faction;
+            this.shipid = shipId;
         }
     }
 }

--- a/Events/FinePaidEvent.cs
+++ b/Events/FinePaidEvent.cs
@@ -15,7 +15,7 @@ namespace EddiEvents
         static FinePaidEvent()
         {
             VARIABLES.Add("amount", "The amount of the fine paid");
-            VARIABLES.Add("brokerpercentage", "Broker precentage fee (if paid via a Broker)");
+            VARIABLES.Add("brokerpercentage", "Broker percentage (if paid via a Broker)");
             VARIABLES.Add("allfines", "Whether this payments covers all current fines (true or false)");
             VARIABLES.Add("faction", "The faction to which the fine was paid (if the payment does not cover all current fines)");
             VARIABLES.Add("shipid", "The ship id of the ship associated with the fine");

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2048,23 +2048,30 @@ namespace EddiJournalMonitor
                                 handled = true;
                                 break;
                             }
+                        case "PayBounties":
+                            {
+                                data.TryGetValue("Amount", out object val);
+                                long amount = (long)val;
+                                decimal? brokerpercentage = JsonParsing.getOptionalDecimal(data, "BrokerPercentage");
+                                string faction = getFaction(data, "Faction");
+                                data.TryGetValue("ShipID", out val);
+                                int shipId = (int)(long)val;
+
+                                events.Add(new BountyPaidEvent(timestamp, amount, brokerpercentage, faction, shipId) { raw = line });
+                                handled = true;
+                                break;
+                            }
                         case "PayFines":
                             {
                                 data.TryGetValue("Amount", out object val);
                                 long amount = (long)val;
                                 decimal? brokerpercentage = JsonParsing.getOptionalDecimal(data, "BrokerPercentage");
+                                bool allFines = JsonParsing.getBool(data, "AllFines");
+                                string faction = getFaction(data, "Faction");
+                                data.TryGetValue("ShipID", out val);
+                                int shipId = (int)(long)val;
 
-                                events.Add(new FinePaidEvent(timestamp, amount, brokerpercentage, false) { raw = line });
-                                handled = true;
-                                break;
-                            }
-                        case "PayLegacyFines":
-                            {
-                                data.TryGetValue("Amount", out object val);
-                                long amount = (long)val;
-                                decimal? brokerpercentage = JsonParsing.getOptionalDecimal(data, "BrokerPercentage");
-
-                                events.Add(new FinePaidEvent(timestamp, amount, brokerpercentage, true) { raw = line });
+                                events.Add(new FinePaidEvent(timestamp, amount, brokerpercentage, allFines, faction, shipId) { raw = line });
                                 handled = true;
                                 break;
                             }
@@ -3014,7 +3021,7 @@ namespace EddiJournalMonitor
         {
             string faction = JsonParsing.getString(data, key);
             // Might be a superpower...
-            Superpower superpowerFaction = Superpower.AllOfThem.FirstOrDefault(x => x.basename == faction);
+            Superpower superpowerFaction = Superpower.From(faction);
             return superpowerFaction?.invariantName ?? faction;
         }
 

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -83,6 +83,15 @@
       "name": "Bounty incurred",
       "description": "Triggered when you incur a bounty"
     },
+    "Bounty paid": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'bounty')}\r\n{SetState('eddi_context_last_action', 'pay')}\r\n{SetState('eddi_context_fine_amount', event.amount)}\r\n\r\n\r\nPaid bounty of {Humanise(event.amount)} credits.",
+      "default": true,
+      "name": "Bounty paid",
+      "description": "Triggered when you pay a bounty"
+    },
     "Bounty redeemed": {
       "enabled": true,
       "priority": 3,


### PR DESCRIPTION
- Create new event `Bounty paid`, resolves #788 
- Update  `Fines paid` event per post-3.0 journal manual.
- Remove legacy fines properties and remove `PayLegacyFines` from the journal monitor - this event was deprecated with 3.0.
- Revise the retrieval of superpowers from the getFaction method so that it properly identifies and retrieves superpower names.