### PR TITLE
Fix cargo tracking for 'Commodity sold' and 'Cargo depot' events

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -487,20 +487,12 @@ namespace EddiCargoMonitor
                     // Cargo is stolen
                     cargo.stolen -= Math.Min(cargo.stolen, @event.amount);
                 }
-                else if (@event.blackmarket)
+                else if (@event.blackmarket && !@event.illegal)
                 {
-                    if (EDDI.Instance.CurrentStation.prohibited.Contains(cargo.edname))
-                    {
-                        // Owned cargo is prohibited
-                        cargo.owned -= Math.Min(cargo.owned, @event.amount);
-                    }
-                    else
-                    {
-                        // Cargo is mission-related
-                        int amount = Math.Min(cargo.haulage, @event.amount);
-                        cargo.haulage -= amount;
-                        cargo.ejected += amount;
-                    }
+                    // Assume cargo is mission-related
+                    int amount = Math.Min(cargo.haulage, @event.amount);
+                    cargo.haulage -= amount;
+                    cargo.ejected += amount;
                 }
                 else
                 {

--- a/DataDefinitions/HaulageAmount.cs
+++ b/DataDefinitions/HaulageAmount.cs
@@ -14,7 +14,7 @@ namespace EddiDataDefinitions
         public string type => name.Split('_').ElementAtOrDefault(1)?.ToLowerInvariant();
 
         [JsonIgnore]
-        public bool legal => name.ToLowerInvariant().Contains("illegal") ? false : true;
+        public bool legal => !name.ToLowerInvariant().Contains("illegal");
 
         [JsonIgnore]
         public bool wing => name.ToLowerInvariant().Contains("wing");
@@ -25,9 +25,9 @@ namespace EddiDataDefinitions
 
         public int delivered { get; set; }
 
-        public DateTime expiry { get; set; }
-
         public bool shared { get; set; }
+
+        public DateTime expiry { get; set; }
 
         public HaulageAmount() { }
 

--- a/DataDefinitions/HaulageAmount.cs
+++ b/DataDefinitions/HaulageAmount.cs
@@ -16,6 +16,9 @@ namespace EddiDataDefinitions
         [JsonIgnore]
         public bool legal => name.ToLowerInvariant().Contains("illegal") ? false : true;
 
+        [JsonIgnore]
+        public bool wing => name.ToLowerInvariant().Contains("wing");
+
         public int amount { get; set; }
 
         public int collected { get; set; }

--- a/SpeechResponder/EddiSpeechResponder.csproj
+++ b/SpeechResponder/EddiSpeechResponder.csproj
@@ -118,6 +118,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CargoMonitor\EddiCargoMonitor.csproj">
+      <Project>{c1d256ba-68b9-437a-8907-599c3a388c37}</Project>
+      <Name>EddiCargoMonitor</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EDDI\Eddi.csproj">
       <Project>{EC7BA042-A370-447F-8C3E-241358CEBCBB}</Project>
       <Name>Eddi</Name>

--- a/SpeechResponder/Help.md
+++ b/SpeechResponder/Help.md
@@ -321,8 +321,8 @@ CommodityMarketDetails() takes one mandatory argument and two optional arguments
 
 Common usage of this is to provide further information about a commodity, for example:
 
-{set marketcommodity to CommodityStationDetails("Pesticides", "Chelbin Service Station", "Wolf 397")}
-{marketcommodity.name} is selling for {marketcommodity.sellprice} with a current market demand of {marketcommodity.demand} units.
+    {set marketcommodity to CommodityStationDetails("Pesticides", "Chelbin Service Station", "Wolf 397")}
+    {marketcommodity.name} is selling for {marketcommodity.sellprice} with a current market demand of {marketcommodity.demand} units.
 
 ### CargoDetails()
 
@@ -334,13 +334,13 @@ CargoDetails() takes one mandatory argument, of two possible forms.
 
 Common usage of this is to provide further information about a particular cargo, for example:
 
-{set cargo to CargoDetails("Tea")}
-{if cargo && cargo.total > 0: You have {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} in your cargo hold.}
+    {set cargo to CargoDetails("Tea")}
+    {if cargo && cargo.total > 0: You have {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} in your cargo hold.}
 
 or for a mission-related event,
 
-{set cargo to CargoDetails(event.missionid)}
-{if cargo: {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} is in your hold for this mission.}
+    {set cargo to CargoDetails(event.missionid)}
+    {if cargo: {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} is in your hold for this mission.}
 
 ### HaulageDetails()
 
@@ -350,11 +350,11 @@ HaulageDetails() takes one mandatory argument, a mission ID associated with the 
 
 Common usage of this is to provide further information about a particular mission haulage, for example:
 
-{set haulage to HaulageDetails(event.missionid)}
-{if haulage && haulage.deleivered > 0:
-    {set total to haulage.amount + haulage.deleivered}
-	{haulage.type} mission to the cargo depot is {round(haulage.delivered / total * 100, 0)} percent complete.
-}
+    {set haulage to HaulageDetails(event.missionid)}
+    {if haulage && haulage.deleivered > 0:
+        {set total to haulage.amount + haulage.deleivered}
+	    {haulage.type} mission to the cargo depot is {round(haulage.delivered / total * 100, 0)} percent complete.
+    }
 
 ### MaterialDetails()
 

--- a/SpeechResponder/Help.md
+++ b/SpeechResponder/Help.md
@@ -324,6 +324,38 @@ Common usage of this is to provide further information about a commodity, for ex
 {set marketcommodity to CommodityStationDetails("Pesticides", "Chelbin Service Station", "Wolf 397")}
 {marketcommodity.name} is selling for {marketcommodity.sellprice} with a current market demand of {marketcommodity.demand} units.
 
+### CargoDetails()
+
+This function will provide full information for a cargo, carried in the commander's hold.
+
+CargoDetails() takes one mandatory argument, of two possible forms. 
+- The first form, a commodity name of the cargo. If the commodity is not in the hold, a 'null' is returned.
+- The second form, a mission ID associated with the cargo, as haulage. If the mission ID is not associated with haulage, a 'null' is returned.
+
+Common usage of this is to provide further information about a particular cargo, for example:
+
+{set cargo to CargoDetails("Tea")}
+{if cargo && cargo.total > 0: You have {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} in your cargo hold.}
+
+or for a mission-related event,
+
+{set cargo to CargoDetails(event.missionid)}
+{if cargo: {cargo.total} tonne{if cargo.total != 1: s} of {cargo.name} is in your hold for this mission.}
+
+### HaulageDetails()
+
+This function will provide 'haulage' information for a mission-related cargo. See the 'haulage' object for variable details.
+
+HaulageDetails() takes one mandatory argument, a mission ID associated with the haulage. If the mission ID is not associated with haulage, a 'null' is returned.
+
+Common usage of this is to provide further information about a particular mission haulage, for example:
+
+{set haulage to HaulageDetails(event.missionid)}
+{if haulage && haulage.deleivered > 0:
+    {set total to haulage.amount + haulage.deleivered}
+	{haulage.type} mission to the cargo depot is {round(haulage.delivered / total * 100, 0)} percent complete.
+}
+
 ### MaterialDetails()
 
 This function will provide full information for a material given its name.

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -5,6 +5,7 @@ using Cottle.Settings;
 using Cottle.Stores;
 using Cottle.Values;
 using Eddi;
+using EddiCargoMonitor;
 using EddiDataDefinitions;
 using EddiDataProviderService;
 using EddiShipMonitor;
@@ -674,6 +675,31 @@ namespace EddiSpeechResponder
                 }
                 return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
             }, 0, 3);
+
+            store["CargoDetails"] = new NativeFunction((values) =>
+            {
+                Cottle.Value value = values[0];
+                Cargo result = null;
+                string edname = string.Empty;
+
+                if (value.Type == Cottle.ValueContent.String)
+                {
+                    edname = CommodityDefinition.FromName(value.AsString).edname;
+                    result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor")).GetCargoWithEDName(edname);
+                }
+                else if (value.Type == Cottle.ValueContent.Number)
+                {
+                    result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor")).GetCargoWithMissionId((long)value.AsNumber);
+                }
+                return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
+            }, 1);
+
+            store["HaulageDetails"] = new NativeFunction((values) =>
+            {
+                HaulageAmount result = null;
+                result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor")).GetHaulageWithMissionId((long)values[0].AsNumber);
+                return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
+            }, 1);
 
             store["BlueprintDetails"] = new NativeFunction((values) =>
             {

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -244,9 +244,25 @@ Details of an individual commodity being carried.
 	- `category` the category of the commodity (e.g. Foods, Machinery, Technology)
     - `stolen` the number of units flagged as stolen
     - `haulage` the number of units associated with a mission
+	- 'haulageamounts' list of mission related specifics for associated haulage
     - `owned` the number of units privately purchased or collected (not stolen or mission related)
     - `total` the total number of units
     - `price` the price of an individual unit
+
+## Haulage
+
+Mission-related details of haulage within the 'haulageamounts' object, used by the Cargo Monitor.
+
+	- 'missionid' unique identifier ID of the mission
+	- 'name' name of mission
+	- 'type' type (altruism, delivery, massacre, etc) of the mission
+	- 'legal' true if the mission is legal
+	- 'wing' true if wing mission
+	- 'shared' true if the mission was shared by a wing-mate
+	- 'amount' amount of the commodity involved in the mission
+	- 'collected' amount of the commodity collected in a wing mission
+	- 'delivered' amount of the commodity delivered in a wing mission
+	- 'expiry' expiry date and time of the mission
 
 ## Commodity
 

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when engaging with a mission depot }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionid)}\r\n\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    |else:\r\n        Solo\r\n    }\r\n\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
+      "description": "Triggered when engaging with a mission depot"
     },
     "Cargo inventory": {
       "enabled": true,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -96,10 +96,10 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n}\r\n\r\n{if event.updatetype != \"WingUpdate\":\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {if remaining = 0:\r\n        Wing mission requirements are now completed.\r\n    |elif event.updatetype = \"Deliver\":\r\n        Wing mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}",
+      "script": "{_ Cargo depot }\r\n{_ Triggered when collecting or delivering cargo for a wing mission }\r\n\r\n\r\n{if event.updatetype = \"Collect\":\r\n    You have collected {event.amount} tonne{if event.amount != 1:s} of {event.commodity} from the mission depot.\r\n|elif event.updatetype = \"Deliver\":\r\n    You have delivered {event.amount} tonne{if event.amount != 1:s} of {event.commodity} to the mission depot.\r\n\r\n    {Pause(500)}\r\n    {set remaining to event.totaltodeliver - event.delivered}\r\n    {set haulage to HaulageDetails(event.missionsid)}\r\n    {if find(haulage.name, \"Wing\") > -1:\r\n        Wing\r\n    |elif find(haulage.name, \"Rank\") > -1:\r\n        Naval\r\n    }\r\n    {if remaining = 0:\r\n        mission requirements are now completed.\r\n    |else:\r\n        mission is now {round(event.delivered / event.totaltodeliver * 100, 0)} percent complete.\r\n    }\r\n}\r\n",
       "default": true,
       "name": "Cargo depot",
-      "description": "Triggered when collecting or delivering cargo for a wing mission"
+      "description": "Triggered when collecting cargo from or delivering cargo to mission depot"
     },
     "Cargo inventory": {
       "enabled": true,


### PR DESCRIPTION
This PR addressed Issues #759 and #771.

1. There is a 'hole' the 'Commodity sold' event where it is difficult to determine whether a commodity sold in the black market is haulage or owned. Added check to classify as owned if commodity is prohibited.

Note: This will still be problematical if cmdr has not previously visited the station as EDDP data does not include prohibited commodities. Future change to phase out EDDP and use EliteBGS API will correct this.

2. 'Cargo Depot' (and, as a result, 'Mission completed') did not account for game mechanics change for solo 'source and return' missions implemented in 3.1. Now using haulage.amount to accurately track progress of the mission.

3. Added CargoDetails() and HaulageDetails() functions for Cottle scripting.