### PR TITLE
Fix System.ArgumentException: Cannot set voice. No matching voice is installed or the voice was disabled

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -15,6 +15,7 @@ using System.Speech.Synthesis;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Utilities;
 
 namespace EddiSpeechService
@@ -365,43 +366,44 @@ namespace EddiSpeechService
                             try
                             {
                                 Logging.Debug("Selecting voice " + voice);
-                                Thread t = new Thread(() => synth.SelectVoice(voice));
+                                Task t = new Task(() => synth.SelectVoice(voice));
                                 t.Start();
-                                if (!t.Join(TimeSpan.FromSeconds(2)))
+                                if (!t.Wait(TimeSpan.FromSeconds(2)))
                                 {
-                                    t.Abort();
-                                    Logging.Warn("Failed to select voice " + voice + " (1)");
+                                    t.Dispose();
+                                    Logging.Warn("Failed to select voice " + voice + " (timed out)");
                                 }
                             }
                             catch (Exception ex)
                             {
-                                Logging.Warn("Failed to select voice " + voice + " (2)", ex);
+                                Logging.Warn("Failed to select voice " + voice, ex);
                             }
                         }
-                        Logging.Debug("Post-selection");
-
-                        Logging.Debug("Configuration is " + configuration == null ? "<null>" : JsonConvert.SerializeObject(configuration));
-                        synth.Rate = configuration.Rate;
-                        synth.Volume = configuration.Volume;
-
-                        synth.SetOutputToWaveStream(stream);
-
-                        // Keep XML version at 1.0. Version 1.1 is not recommended for general use. https://en.wikipedia.org/wiki/XML#Versions
-                        if (speech.Contains("<"))
+                        if (synth.Voice != null)
                         {
-                            Logging.Debug("Obtaining best guess culture");
-                            string culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
-                            Logging.Debug("Best guess culture is " + culture);
-                            speech = @"<?xml version=""1.0"" encoding=""UTF-8""?><speak version=""1.0"" xmlns=""http://www.w3.org/2001/10/synthesis""" + culture + ">" + escapeSsml(speech) + @"</speak>";
-                            Logging.Debug("Feeding SSML to synthesizer: " + escapeSsml(speech));
-                            synth.SpeakSsml(speech);
+                            Logging.Debug("Configuration is " + configuration == null ? "<null>" : JsonConvert.SerializeObject(configuration));
+                            synth.Rate = configuration.Rate;
+                            synth.Volume = configuration.Volume;
+
+                            synth.SetOutputToWaveStream(stream);
+
+                            // Keep XML version at 1.0. Version 1.1 is not recommended for general use. https://en.wikipedia.org/wiki/XML#Versions
+                            if (speech.Contains("<"))
+                            {
+                                Logging.Debug("Obtaining best guess culture");
+                                string culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
+                                Logging.Debug("Best guess culture is " + culture);
+                                speech = @"<?xml version=""1.0"" encoding=""UTF-8""?><speak version=""1.0"" xmlns=""http://www.w3.org/2001/10/synthesis""" + culture + ">" + escapeSsml(speech) + @"</speak>";
+                                Logging.Debug("Feeding SSML to synthesizer: " + escapeSsml(speech));
+                                synth.SpeakSsml(speech);
+                            }
+                            else
+                            {
+                                Logging.Debug("Feeding normal text to synthesizer: " + speech);
+                                synth.Speak(speech);
+                            }
+                            stream.ToArray();
                         }
-                        else
-                        {
-                            Logging.Debug("Feeding normal text to synthesizer: " + speech);
-                            synth.Speak(speech);
-                        }
-                        stream.ToArray();
                     }
                 }
                 catch (ThreadAbortException)

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -28,6 +28,7 @@ namespace EddiSpeechService
         private static readonly object activeSpeechLock = new object();
         private ISoundOut activeSpeech;
         private int activeSpeechPriority;
+        SpeechSynthesizer synth = new SpeechSynthesizer();
 
         private static bool _eddiSpeaking;
         public static bool eddiSpeaking
@@ -359,7 +360,7 @@ namespace EddiSpeechService
             {
                 try
                 {
-                    using (SpeechSynthesizer synth = new SpeechSynthesizer())
+                    using (synth)
                     {
                         if (voice != null)
                         {

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -352,7 +352,7 @@ namespace EddiSpeechService
             return null;
         }
 
-        // Speak using the MS speech synthesizer
+        // Speak using the Windows SAPI speech synthesizer
         private void speak(MemoryStream stream, string voice, string speech)
         {
             var synthThread = new Thread(() =>
@@ -361,12 +361,12 @@ namespace EddiSpeechService
                 {
                     using (SpeechSynthesizer synth = new SpeechSynthesizer())
                     {
-                        if (voice != null && !voice.Contains("Microsoft Server Speech Text to Speech Voice"))
+                        if (voice != null)
                         {
                             try
                             {
                                 Logging.Debug("Selecting voice " + voice);
-                                Task t = new Task(() => synth.SelectVoice(voice));
+                                Task t = new Task(() => selectVoice(voice, synth));
                                 t.Start();
                                 if (!t.Wait(TimeSpan.FromSeconds(2)))
                                 {
@@ -423,6 +423,17 @@ namespace EddiSpeechService
             synthThread.Start();
             synthThread.Join();
             stream.Position = 0;
+        }
+
+        private static void selectVoice(string voice, SpeechSynthesizer synth)
+        {
+            foreach (InstalledVoice vc in synth.GetInstalledVoices())
+            {
+                if (vc.Enabled && vc.VoiceInfo.Name == voice && !vc.VoiceInfo.Name.Contains("Microsoft Server Speech Text to Speech Voice"))
+                {
+                    synth.SelectVoice(voice);
+                }
+            }
         }
 
         private string bestGuessCulture(SpeechSynthesizer synth)

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -379,31 +379,28 @@ namespace EddiSpeechService
                                 Logging.Warn("Failed to select voice " + voice, ex);
                             }
                         }
-                        if (synth.Voice != null)
+                        Logging.Debug("Configuration is " + configuration == null ? "<null>" : JsonConvert.SerializeObject(configuration));
+                        synth.Rate = configuration.Rate;
+                        synth.Volume = configuration.Volume;
+
+                        synth.SetOutputToWaveStream(stream);
+
+                        // Keep XML version at 1.0. Version 1.1 is not recommended for general use. https://en.wikipedia.org/wiki/XML#Versions
+                        if (speech.Contains("<"))
                         {
-                            Logging.Debug("Configuration is " + configuration == null ? "<null>" : JsonConvert.SerializeObject(configuration));
-                            synth.Rate = configuration.Rate;
-                            synth.Volume = configuration.Volume;
-
-                            synth.SetOutputToWaveStream(stream);
-
-                            // Keep XML version at 1.0. Version 1.1 is not recommended for general use. https://en.wikipedia.org/wiki/XML#Versions
-                            if (speech.Contains("<"))
-                            {
-                                Logging.Debug("Obtaining best guess culture");
-                                string culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
-                                Logging.Debug("Best guess culture is " + culture);
-                                speech = @"<?xml version=""1.0"" encoding=""UTF-8""?><speak version=""1.0"" xmlns=""http://www.w3.org/2001/10/synthesis""" + culture + ">" + escapeSsml(speech) + @"</speak>";
-                                Logging.Debug("Feeding SSML to synthesizer: " + escapeSsml(speech));
-                                synth.SpeakSsml(speech);
-                            }
-                            else
-                            {
-                                Logging.Debug("Feeding normal text to synthesizer: " + speech);
-                                synth.Speak(speech);
-                            }
-                            stream.ToArray();
+                            Logging.Debug("Obtaining best guess culture");
+                            string culture = @" xml:lang=""" + bestGuessCulture(synth) + @"""";
+                            Logging.Debug("Best guess culture is " + culture);
+                            speech = @"<?xml version=""1.0"" encoding=""UTF-8""?><speak version=""1.0"" xmlns=""http://www.w3.org/2001/10/synthesis""" + culture + ">" + escapeSsml(speech) + @"</speak>";
+                            Logging.Debug("Feeding SSML to synthesizer: " + escapeSsml(speech));
+                            synth.SpeakSsml(speech);
                         }
+                        else
+                        {
+                            Logging.Debug("Feeding normal text to synthesizer: " + speech);
+                            synth.Speak(speech);
+                        }
+                        stream.ToArray();
                     }
                 }
                 catch (ThreadAbortException)

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -535,5 +535,14 @@ namespace SpeechTests
             Logging.Verbose = true;
             SpeechService.Instance.Say(null, "Your python has touched down.", true, 3, null, true);
         }
+
+        [TestMethod, TestCategory("Speech")]
+        public void TestSpeechNullInvalidVoice()
+        {
+            // Test null voice
+            SpeechService.Instance.Say(null, "This is the default voice", true, 3, null, false);
+            // Test invalid voice
+            SpeechService.Instance.Say(null, "I will use this voice when the voice is null or invalid", true, 3, "No such voice", false);
+        }
     }
 }

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -540,9 +540,9 @@ namespace SpeechTests
         public void TestSpeechNullInvalidVoice()
         {
             // Test null voice
-            SpeechService.Instance.Say(null, "This is the default voice", true, 3, null, false);
+            SpeechService.Instance.Say(null, "Testing null voice", true, 3, null, false);
             // Test invalid voice
-            SpeechService.Instance.Say(null, "I will use this voice when the voice is null or invalid", true, 3, "No such voice", false);
+            SpeechService.Instance.Say(null, "Testing invalid voice", true, 3, "No such voice", false);
         }
     }
 }


### PR DESCRIPTION
Fix exception described by #821 & Rollbar data.
- Select voice using a Task rather than a thread (try-catch statements obtain exception info from a Task better than from another thread)
- Make sure that the configured voice is still valid prior to final selection.
- Implement an appropriate speech test for a null or invalid voice.
(Note that if synth.SelectVoice() is not called, the speech synthesizer will use the system default voice).

Resolves #821.