### PR TITLE
Fixed Cargo Monitor exceptions  from Rollbar

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -338,6 +338,9 @@ namespace EddiCargoMonitor
                                 }
                                 break;
                         }
+                        haulage.sourcesystem = EDDI.Instance?.CurrentStarSystem?.name;
+                        haulage.sourcebody = EDDI.Instance?.CurrentStellarBody?.name;
+
                         if (handled)
                         {
                             break;
@@ -450,6 +453,12 @@ namespace EddiCargoMonitor
             {
                 cargo.owned += @event.amount;
                 cargo.CalculateNeed();
+                Haulage haulage = cargo.haulageData.FirstOrDefault(h => h.typeEDName.Contains("Collect"));
+                if (haulage != null)
+                {
+                    haulage.sourcesystem = EDDI.Instance?.CurrentStarSystem?.name;
+                    haulage.sourcebody = EDDI.Instance?.CurrentStation?.name;
+                }
             }
             else
             {
@@ -890,8 +899,17 @@ namespace EddiCargoMonitor
                         Haulage haulage = new Haulage(@event.missionid ?? 0, @event.name, originSystem, @event.amount ?? 0, @event.expiry)
                         {
                             startmarketid = (type.Contains("delivery") && !naval) ? EDDI.Instance?.CurrentStation?.marketId ?? 0 : 0,
-                            endmarketid = (type.Contains("collect")) ? EDDI.Instance?.CurrentStation?.marketId ?? 0 : 0
+                            endmarketid = (type.Contains("collect")) ? EDDI.Instance?.CurrentStation?.marketId ?? 0 : 0,
                         };
+                        if (type.Contains("delivery") || type == "smuggle")
+                        {
+                            haulage.sourcesystem = EDDI.Instance?.CurrentStarSystem?.name;
+                            haulage.sourcebody = EDDI.Instance?.CurrentStation?.name;
+                        }
+                        else if (type == "rescue" || type == "salvage")
+                        {
+                            haulage.sourcesystem = @event.destinationsystem;
+                        }
 
                         cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
                         if (cargo != null)
@@ -915,7 +933,7 @@ namespace EddiCargoMonitor
             }
         }
 
-        private void handleMissionCompletedEvent(MissionCompletedEvent @event)
+            private void handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
             if (@event.commodityDefinition != null || @event.commodityrewards != null)
             {

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -1017,8 +1017,7 @@ namespace EddiCargoMonitor
 
         public void _handleMissionExpiredEvent(MissionExpiredEvent @event)
         {
-            Cargo cargo = GetCargoWithMissionId(@event.missionid ?? 0);
-            Haulage haulage = cargo.haulageData.FirstOrDefault(ha => ha.missionid == @event.missionid);
+            Haulage haulage = GetHaulageWithMissionId(@event.missionid ?? 0);
             if (haulage != null)
             {
                 haulage.status = "Failed";

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -239,7 +239,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCargoInventoryEvent(CargoInventoryEvent @event)
+        private void _handleCargoInventoryEvent(CargoInventoryEvent @event)
         {
             // CargoInventoryEvent does not contain missionid or cost information so fill in gaps here
             foreach (Cargo cargo in @event.inventory)
@@ -296,7 +296,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCommodityCollectedEvent(CommodityCollectedEvent @event)
+        private void _handleCommodityCollectedEvent(CommodityCollectedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
@@ -374,7 +374,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCommodityEjectedEvent(CommodityEjectedEvent @event)
+        private void _handleCommodityEjectedEvent(CommodityEjectedEvent @event)
         {
             Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
@@ -445,7 +445,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCommodityPurchasedEvent(CommodityPurchasedEvent @event)
+        private void _handleCommodityPurchasedEvent(CommodityPurchasedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
@@ -478,7 +478,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCommodityRefinedEvent(CommodityRefinedEvent @event)
+        private void _handleCommodityRefinedEvent(CommodityRefinedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
@@ -505,7 +505,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCommoditySoldEvent(CommoditySoldEvent @event)
+        private void _handleCommoditySoldEvent(CommoditySoldEvent @event)
         {
             Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
@@ -537,7 +537,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handlePowerCommodityObtainedEvent(PowerCommodityObtainedEvent @event)
+        private void _handlePowerCommodityObtainedEvent(PowerCommodityObtainedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
@@ -564,7 +564,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handlePowerCommodityDeliveredEvent(PowerCommodityDeliveredEvent @event)
+        private void _handlePowerCommodityDeliveredEvent(PowerCommodityDeliveredEvent @event)
         {
             Cargo cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
             if (cargo != null)
@@ -580,7 +580,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleLimpetPurchasedEvent(LimpetPurchasedEvent @event)
+        private void _handleLimpetPurchasedEvent(LimpetPurchasedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName("Drones");
@@ -606,7 +606,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleLimpetSoldEvent(LimpetSoldEvent @event)
+        private void _handleLimpetSoldEvent(LimpetSoldEvent @event)
         {
             Cargo cargo = GetCargoWithEDName("Drones");
             if (cargo != null)
@@ -622,7 +622,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleLimpetLaunchedEvent()
+        private void _handleLimpetLaunchedEvent()
         {
             Cargo cargo = GetCargoWithEDName("Drones");
             if (cargo != null)
@@ -638,7 +638,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleCargoDepotEvent(CargoDepotEvent @event)
+        private void _handleCargoDepotEvent(CargoDepotEvent @event)
         {
             Cargo cargo = new Cargo();
             Haulage haulage = new Haulage();
@@ -811,7 +811,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleMissionsEvent(MissionsEvent @event)
+        private void _handleMissionsEvent(MissionsEvent @event)
         {
             foreach (Cargo cargo in inventory.ToList())
             {
@@ -832,7 +832,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleMissionAbandonedEvent(MissionAbandonedEvent @event)
+        private void _handleMissionAbandonedEvent(MissionAbandonedEvent @event)
         {
             Haulage haulage = GetHaulageWithMissionId(@event.missionid ?? 0);
             if (haulage != null)
@@ -876,7 +876,7 @@ namespace EddiCargoMonitor
             }
         }
 
-        public void _handleMissionAcceptedEvent(MissionAcceptedEvent @event)
+        private void _handleMissionAcceptedEvent(MissionAcceptedEvent @event)
         {
             Cargo cargo = new Cargo();
             string type = @event.name.Split('_').ElementAtOrDefault(1).ToLowerInvariant();
@@ -933,7 +933,7 @@ namespace EddiCargoMonitor
             }
         }
 
-            private void handleMissionCompletedEvent(MissionCompletedEvent @event)
+        private void handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
             if (@event.commodityDefinition != null || @event.commodityrewards != null)
             {
@@ -942,7 +942,7 @@ namespace EddiCargoMonitor
             }
         }
 
-        public void _handleMissionCompletedEvent(MissionCompletedEvent @event)
+        private void _handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName(@event.commodityDefinition?.edname);
@@ -1033,7 +1033,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleMissionExpiredEvent(MissionExpiredEvent @event)
+        private void _handleMissionExpiredEvent(MissionExpiredEvent @event)
         {
             Haulage haulage = GetHaulageWithMissionId(@event.missionid ?? 0);
             if (haulage != null)
@@ -1048,7 +1048,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleMissionFailedEvent(MissionFailedEvent @event)
+        private void _handleMissionFailedEvent(MissionFailedEvent @event)
         {
             Haulage haulage = GetHaulageWithMissionId(@event.missionid ?? 0);
             if (haulage != null)
@@ -1093,7 +1093,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleMissionRedirectedEvent(MissionRedirectedEvent @event)
+        private void _handleMissionRedirectedEvent(MissionRedirectedEvent @event)
         {
             // Adjust cargo haulage & stolen amounts to account for completed missions
             Haulage haulage = GetHaulageWithMissionId(@event.missionid ?? 0);
@@ -1124,7 +1124,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleSearchAndRescueEvent(SearchAndRescueEvent @event)
+        private void _handleSearchAndRescueEvent(SearchAndRescueEvent @event)
         {
             Cargo cargo = GetCargoWithEDName(@event.commodity?.edname);
             if (cargo != null)
@@ -1143,7 +1143,7 @@ namespace EddiCargoMonitor
             }
         }
 
-        public void _handleSynthesisedEvent()
+        private void _handleSynthesisedEvent()
         {
             Cargo cargo = new Cargo();
             cargo = GetCargoWithEDName("Drones");
@@ -1169,7 +1169,7 @@ namespace EddiCargoMonitor
             writeInventory();
         }
 
-        public void _handleTechnologyBrokerEvent(TechnologyBrokerEvent @event)
+        private void _handleTechnologyBrokerEvent(TechnologyBrokerEvent @event)
         {
             foreach (CommodityAmount commodityAmount in @event.commodities)
             {

--- a/DataDefinitions/Haulage.cs
+++ b/DataDefinitions/Haulage.cs
@@ -19,6 +19,10 @@ namespace EddiDataDefinitions
 
         public string originsystem { get; set; }
 
+        public string sourcesystem { get; set; }
+
+        public string sourcebody { get; set; }
+
         [JsonIgnore]
         public bool legal => !name.ToLowerInvariant().Contains("illegal");
 

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -17,7 +17,6 @@ namespace UnitTests
     {
         CargoMonitor cargoMonitor = new CargoMonitor();
         Cargo cargo;
-        Haulage haulage;
         string line;
         List<Event> events;
 
@@ -94,11 +93,12 @@ namespace UnitTests
         public void TestCargoEventsScenario()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             // CargoEvent
             line = @"{""timestamp"": ""2018-05-05T19:12:10Z"", ""event"": ""Cargo"", ""Inventory"": [ { ""Name"": ""damagedescapepod"", ""Name_Localised"": ""Damaged Escape Pod"", ""Count"": 4, ""Stolen"": 0 }, { ""Name"": ""usscargoblackbox"", ""Name_Localised"": ""Black Box"", ""Count"": 4, ""Stolen"": 4 }, { ""Name"": ""drones"", ""Name_Localised"": ""Limpet"", ""Count"": 21, ""Stolen"": 0 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoInventoryEvent((CargoInventoryEvent)events[0]);
+            privateObject.Invoke("_handleCargoInventoryEvent", new object[] { events[0] });
             Assert.AreEqual(3, cargoMonitor.inventory.Count);
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
@@ -110,7 +110,7 @@ namespace UnitTests
             // CargoCollectedEvent
             line = @"{""timestamp"":""2016-06-10T14:32:03Z"",""event"":""CollectCargo"",""Type"":""agriculturalmedicines"",""Stolen"":true}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityCollectedEvent((CommodityCollectedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityCollectedEvent", new object[] { events[0] });
             Assert.AreEqual(4, cargoMonitor.inventory.Count);
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "AgriculturalMedicines");
@@ -122,7 +122,7 @@ namespace UnitTests
             // CargoEjectedEvent
             line = @"{""timestamp"": ""2016-06-10T14:32:03Z"", ""event"": ""EjectCargo"", ""Type"":""drones"", ""Count"":2, ""Abandoned"":true}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityEjectedEvent((CommodityEjectedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityEjectedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual(19, cargo.total);
@@ -134,7 +134,7 @@ namespace UnitTests
             // CargoPurchasedEvent
             line = @"{ ""timestamp"":""2018-04-07T16:29:39Z"", ""event"":""MarketBuy"", ""MarketID"":3224801280, ""Type"":""coffee"", ""Count"":1, ""BuyPrice"":1198, ""TotalCost"":1198 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityPurchasedEvent((CommodityPurchasedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityPurchasedEvent", new object[] { events[0] });
 
             Assert.AreEqual(5, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Coffee");
@@ -146,7 +146,7 @@ namespace UnitTests
             // CargoRefinedEvent
             line = @"{ ""timestamp"":""2016-09-30T18:00:22Z"", ""event"":""MiningRefined"", ""Type"":""$hydrogenperoxide_name;"", ""Type_Localised"":""Hydrogen Peroxide"" }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityRefinedEvent((CommodityRefinedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityRefinedEvent", new object[] { events[0] });
 
             Assert.AreEqual(6, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "HydrogenPeroxide");
@@ -158,7 +158,7 @@ namespace UnitTests
             // CargoSoldEvent
             line = @"{ ""timestamp"":""2018-04-07T16:29:44Z"", ""event"":""MarketSell"", ""MarketID"":3224801280, ""Type"":""coffee"", ""Count"":1, ""SellPrice"":1138, ""TotalSale"":1138, ""AvgPricePaid"":1198 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommoditySoldEvent((CommoditySoldEvent)events[0]);
+            privateObject.Invoke("_handleCommoditySoldEvent", new object[] { events[0] });
 
             Assert.AreEqual(5, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Coffee");
@@ -167,7 +167,7 @@ namespace UnitTests
             // CargoPowerCommodityObtainedEvent
             line = @"{ ""timestamp"":""2016-12-02T16:10:26Z"", ""event"":""PowerplayCollect"", ""Power"":""Aisling Duval"", ""Type"":""$aislingmediamaterials_name;"", ""Type_Localised"":""Aisling Media Materials"", ""Count"":3 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handlePowerCommodityObtainedEvent((PowerCommodityObtainedEvent)events[0]);
+            privateObject.Invoke("_handlePowerCommodityObtainedEvent", new object[] { events[0] });
 
             Assert.AreEqual(6, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname.ToLowerInvariant() == "aislingmediamaterials");
@@ -181,7 +181,7 @@ namespace UnitTests
             // CargoPowerCommodityDeliveredEvent
             line = @"{ ""timestamp"":""2016-12-02T16:10:26Z"", ""event"":""PowerplayDeliver"", ""Power"":""Aisling Duval"", ""Type"":""$aislingmediamaterials_name;"", ""Type_Localised"":""Aisling Media Materials"", ""Count"":3 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handlePowerCommodityDeliveredEvent((PowerCommodityDeliveredEvent)events[0]);
+            privateObject.Invoke("_handlePowerCommodityDeliveredEvent", new object[] { events[0] });
 
             Assert.AreEqual(5, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname.ToLowerInvariant() == "aislingmediamaterials");
@@ -192,10 +192,11 @@ namespace UnitTests
         public void TestCargoLimpetScenario()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             line = @"{""timestamp"": ""2018-05-05T19:12:10Z"", ""event"": ""Cargo"", ""Inventory"": [ { ""Name"": ""damagedescapepod"", ""Name_Localised"": ""Damaged Escape Pod"", ""Count"": 4, ""Stolen"": 0 }, { ""Name"": ""usscargoblackbox"", ""Name_Localised"": ""Black Box"", ""Count"": 4, ""Stolen"": 4 }, { ""Name"": ""drones"", ""Name_Localised"": ""Limpet"", ""Count"": 21, ""Stolen"": 0 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoInventoryEvent((CargoInventoryEvent)events[0]);
+            privateObject.Invoke("_handleCargoInventoryEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual("Limpet", cargo.invariantName);
@@ -206,7 +207,7 @@ namespace UnitTests
             // CargoLimpetPurchasedEvent
             line = @"{ ""timestamp"":""2016-09-21T06:53:53Z"", ""event"":""BuyDrones"", ""Type"":""Drones"", ""Count"":19, ""BuyPrice"":101, ""TotalCost"":1919 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleLimpetPurchasedEvent((LimpetPurchasedEvent)events[0]);
+            privateObject.Invoke("_handleLimpetPurchasedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual("Limpet", cargo.invariantName);
@@ -217,7 +218,7 @@ namespace UnitTests
             // CargoLimpetSoldEvent
             line = @"{ ""timestamp"":""2016-09-24T00:03:25Z"", ""event"":""SellDrones"", ""Type"":""Drones"", ""Count"":8, ""SellPrice"":101, ""TotalSale"":808 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleLimpetSoldEvent((LimpetSoldEvent)events[0]);
+            privateObject.Invoke("_handleLimpetSoldEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual("Limpet", cargo.invariantName);
@@ -228,7 +229,7 @@ namespace UnitTests
             // CargoLimpetLaunchedEvent
             line = @"{ ""timestamp"":""2018-04-07T20:05:07Z"", ""event"":""LaunchDrone"", ""Type"":""Collection"" }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleLimpetLaunchedEvent();
+            privateObject.Invoke("_handleLimpetLaunchedEvent", new object[] {});
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual("Limpet", cargo.invariantName);
@@ -241,10 +242,11 @@ namespace UnitTests
         public void TestCargoMissionScenario()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             line = @"{""timestamp"": ""2018-05-05T19:12:10Z"", ""event"": ""Cargo"", ""Inventory"": [ { ""Name"": ""damagedescapepod"", ""Name_Localised"": ""Damaged Escape Pod"", ""Count"": 4, ""Stolen"": 0 }, { ""Name"": ""usscargoblackbox"", ""Name_Localised"": ""Black Box"", ""Count"": 4, ""Stolen"": 4 }, { ""Name"": ""drones"", ""Name_Localised"": ""Limpet"", ""Count"": 21, ""Stolen"": 0 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoInventoryEvent((CargoInventoryEvent)events[0]);
+            privateObject.Invoke("_handleCargoInventoryEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
             Assert.AreEqual("Limpet", cargo.invariantName);
@@ -255,10 +257,10 @@ namespace UnitTests
             // CargoMissionAcceptedEvent - Check to see if this is a cargo mission and update our inventory accordingly
             line = @"{ ""timestamp"": ""2018-05-05T19:42:20Z"", ""event"": ""MissionAccepted"", ""Faction"": ""Elite Knights"", ""Name"": ""Mission_Salvage_Planet"", ""LocalisedName"": ""Salvage 3 Structural Regulators"", ""Commodity"": ""$StructuralRegulators_Name;"", ""Commodity_Localised"": ""Structural Regulators"", ""Count"": 3, ""DestinationSystem"": ""Merope"", ""Expiry"": ""2018-05-12T15:20:27Z"", ""Wing"": false, ""Influence"": ""Med"", ""Reputation"": ""Med"", ""Reward"": 557296, ""MissionID"": 375682327 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionAcceptedEvent((MissionAcceptedEvent)events[0]);
+            privateObject.Invoke("_handleMissionAcceptedEvent", new object[] { events[0] });
             line = @"{ ""timestamp"": ""2018-05-05T19:42:20Z"", ""event"": ""MissionAccepted"", ""Faction"": ""Merope Expeditionary Fleet"", ""Name"": ""Mission_Salvage_Planet"", ""LocalisedName"": ""Salvage 4 Structural Regulators"", ""Commodity"": ""$StructuralRegulators_Name;"", ""Commodity_Localised"": ""Structural Regulators"", ""Count"": 4, ""DestinationSystem"": ""HIP 17692"", ""Expiry"": ""2018-05-12T15:20:27Z"", ""Wing"": false, ""Influence"": ""Med"", ""Reputation"": ""Med"", ""Reward"": 557296, ""MissionID"": 375660729 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionAcceptedEvent((MissionAcceptedEvent)events[0]);
+            privateObject.Invoke("_handleMissionAcceptedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "StructuralRegulators");
             Assert.AreEqual("Structural Regulators", cargo.invariantName);
@@ -274,10 +276,10 @@ namespace UnitTests
             // CargoCollectedEvent
             line = @"{""timestamp"":""2018-05-05T19:42:20Z"",""event"":""CollectCargo"",""Type"":""$StructuralRegulators_Name;"",""Stolen"":false}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityCollectedEvent((CommodityCollectedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityCollectedEvent", new object[] { events[0] });
             line = @"{""timestamp"":""2018-05-05T19:42:20Z"",""event"":""CollectCargo"",""Type"":""$StructuralRegulators_Name;"",""Stolen"":false}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityCollectedEvent((CommodityCollectedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityCollectedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "StructuralRegulators");
             Assert.AreEqual(2, cargo.total);
@@ -289,7 +291,7 @@ namespace UnitTests
             // CargoMissionAbandonedEvent - If we abandon a mission with cargo it becomes stolen
             line = @"{ ""timestamp"":""2018-05-05T19:42:20Z"", ""event"":""MissionAbandoned"", ""Name"":""Mission_Salvage_Planet"", ""MissionID"":375682327 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionAbandonedEvent((MissionAbandonedEvent)events[0]);
+            privateObject.Invoke("_handleMissionAbandonedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "StructuralRegulators");
             Assert.AreEqual(2, cargo.total);
@@ -300,7 +302,7 @@ namespace UnitTests
             // CargoMissionCompletedEvent - Check to see if this is a cargo mission and update our inventory accordingly
             line = @"{ ""timestamp"": ""2018-05-05T22:27:58Z"", ""event"": ""MissionCompleted"", ""Faction"": ""Merope Expeditionary Fleet"", ""Name"": ""Mission_Salvage_Planet_name"", ""MissionID"": 375660729, ""Commodity"": ""$StructuralRegulators_Name;"", ""Commodity_Localised"": ""Structural Regulators"", ""Count"": 4, ""DestinationSystem"": ""HIP 17692"", ""Reward"": 624016, ""FactionEffects"": [ { ""Faction"": ""Merope Expeditionary Fleet"", ""Effects"": [ { ""Effect"": ""$MISSIONUTIL_Interaction_Summary_civilUnrest_down;"", ""Effect_Localised"": ""$#MinorFaction; are happy to report improved civil contentment, making a period of civil unrest unlikely."", ""Trend"": ""DownGood"" } ], ""Influence"": [ { ""SystemAddress"": 224644818084, ""Trend"": ""UpGood"" } ], ""Reputation"": ""UpGood"" } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionCompletedEvent((MissionCompletedEvent)events[0]);
+            privateObject.Invoke("_handleMissionCompletedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "StructuralRegulators");
             Assert.IsNull(cargo);
@@ -308,13 +310,13 @@ namespace UnitTests
             // CargoMissionFailedEvent - If we fail a mission with cargo it becomes stolen
             line = @"{ ""timestamp"": ""2018-05-05T19:42:20Z"", ""event"": ""MissionAccepted"", ""Faction"": ""Elite Knights"", ""Name"": ""Mission_Salvage_Planet"", ""LocalisedName"": ""Salvage 3 Structural Regulators"", ""Commodity"": ""$StructuralRegulators_Name;"", ""Commodity_Localised"": ""Structural Regulators"", ""Count"": 3, ""DestinationSystem"": ""Merope"", ""Expiry"": ""2018-05-12T15:20:27Z"", ""Wing"": false, ""Influence"": ""Med"", ""Reputation"": ""Med"", ""Reward"": 557296, ""MissionID"": 375682327 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionAcceptedEvent((MissionAcceptedEvent)events[0]);
+            privateObject.Invoke("_handleMissionAcceptedEvent", new object[] { events[0] });
             line = @"{""timestamp"":""2018-05-05T19:42:20Z"",""event"":""CollectCargo"",""Type"":""$StructuralRegulators_Name;"",""Stolen"":false}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCommodityCollectedEvent((CommodityCollectedEvent)events[0]);
+            privateObject.Invoke("_handleCommodityCollectedEvent", new object[] { events[0] });
             line = @"{ ""timestamp"":""2018-05-05T19:42:20Z"", ""event"":""MissionFailed"", ""Name"":""Mission_Salvage_Planet"", ""MissionID"":375682327 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionFailedEvent((MissionFailedEvent)events[0]);
+            privateObject.Invoke("_handleMissionFailedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "StructuralRegulators");
             Assert.AreEqual(1, cargo.total);
@@ -325,7 +327,7 @@ namespace UnitTests
             // CargoDepotEvent - Check response for missed 'Mission accepted' event. Verify both cargo and haulage are created
             line = @"{ ""timestamp"":""2018-08-26T02:55:10Z"", ""event"":""CargoDepot"", ""MissionID"":413748324, ""UpdateType"":""Deliver"", ""CargoType"":""Tantalum"", ""Count"":54, ""StartMarketID"":0, ""EndMarketID"":3224777216, ""ItemsCollected"":0, ""ItemsDelivered"":54, ""TotalItemsToDeliver"":70, ""Progress"":0.000000 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoDepotEvent((CargoDepotEvent)events[0]);
+            privateObject.Invoke("_handleCargoDepotEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Tantalum");
             Assert.IsNotNull(cargo);
@@ -341,7 +343,7 @@ namespace UnitTests
             // Cargo Delivery 'Mission accepted' Event with 'Cargo Depot' events
             line = @"{ ""timestamp"":""2018-08-26T00:50:48Z"", ""event"":""MissionAccepted"", ""Faction"":""Calennero State Industries"", ""Name"":""Mission_Delivery_Boom"", ""LocalisedName"":""Boom time delivery of 60 units of Silver"", ""Commodity"":""$Silver_Name;"", ""Commodity_Localised"":""Silver"", ""Count"":60, ""DestinationSystem"":""HIP 20277"", ""DestinationStation"":""Fabian City"", ""Expiry"":""2018-08-27T00:48:38Z"", ""Wing"":false, ""Influence"":""Med"", ""Reputation"":""Med"", ""Reward"":25000000, ""MissionID"":413748339 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleMissionAcceptedEvent((MissionAcceptedEvent)events[0]);
+            privateObject.Invoke("_handleMissionAcceptedEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Silver");
             Assert.IsNotNull(cargo);
@@ -356,7 +358,7 @@ namespace UnitTests
 
             line = @"{ ""timestamp"":""2018-08-26T02:55:10Z"", ""event"":""CargoDepot"", ""MissionID"":413748339, ""UpdateType"":""Collect"", ""CargoType"":""Silver"", ""Count"":60, ""StartMarketID"":3225297216, ""EndMarketID"":3224777216, ""ItemsCollected"":60, ""ItemsDelivered"":0, ""TotalItemsToDeliver"":60, ""Progress"":0.000000 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoDepotEvent((CargoDepotEvent)events[0]);
+            privateObject.Invoke("_handleCargoDepotEvent", new object[] { events[0] });
 
             Assert.AreEqual(60, cargo.total);
             Assert.AreEqual(60, cargo.haulage);
@@ -367,7 +369,7 @@ namespace UnitTests
 
             line = @"{ ""timestamp"":""2018-08-26T03:55:10Z"", ""event"":""CargoDepot"", ""MissionID"":413748339, ""UpdateType"":""Deliver"", ""CargoType"":""Silver"", ""Count"":60, ""StartMarketID"":3225297216, ""EndMarketID"":3224777216, ""ItemsCollected"":60, ""ItemsDelivered"":60, ""TotalItemsToDeliver"":60, ""Progress"":0.000000 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoDepotEvent((CargoDepotEvent)events[0]);
+            privateObject.Invoke("_handleCargoDepotEvent", new object[] { events[0] });
 
             Assert.AreEqual(0, cargo.total);
             Assert.AreEqual(0, cargo.haulage);
@@ -379,10 +381,11 @@ namespace UnitTests
         public void TestCargoSearchAndRescue()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             line = @"{""timestamp"": ""2018-05-05T19:12:10Z"", ""event"": ""Cargo"", ""Inventory"": [ { ""Name"": ""damagedescapepod"", ""Name_Localised"": ""Damaged Escape Pod"", ""Count"": 4, ""Stolen"": 0 }, { ""Name"": ""usscargoblackbox"", ""Name_Localised"": ""Black Box"", ""Count"": 4, ""Stolen"": 4 }, { ""Name"": ""drones"", ""Name_Localised"": ""Limpet"", ""Count"": 21, ""Stolen"": 0 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoInventoryEvent((CargoInventoryEvent)events[0]);
+            privateObject.Invoke("_handleCargoInventoryEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "DamagedEscapePod");
             Assert.AreEqual(4, cargo.total);
@@ -392,7 +395,7 @@ namespace UnitTests
             // CargoSearchAndRescueEvent
             line = @"{ ""timestamp"":""2017-08-26T01:58:24Z"", ""event"":""SearchAndRescue"", ""Name"":""damagedescapepod"", ""Count"":2, ""Reward"":5310, ""MarketID"":128666762 }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleSearchAndRescueEvent((SearchAndRescueEvent)events[0]);
+            privateObject.Invoke("_handleSearchAndRescueEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "DamagedEscapePod");
             Assert.AreEqual(2, cargo.total);
@@ -405,11 +408,12 @@ namespace UnitTests
         public void TestCargoSynthesis()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             // CargoSynthesisedEvent
             line = @"{ ""timestamp"": ""2018-05-05T21:08:41Z"", ""event"": ""Synthesis"", ""Name"": ""Limpet Basic"", ""Materials"": [ { ""Name"": ""iron"", ""Count"": 10 }, { ""Name"": ""nickel"", ""Count"": 10 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleSynthesisedEvent();
+            privateObject.Invoke("_handleSynthesisedEvent", new object[] {});
 
             Assert.AreEqual(1, cargoMonitor.inventory.Count);
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Drones");
@@ -422,10 +426,11 @@ namespace UnitTests
         public void TestCargoTechnologyBroker()
         {
             cargoMonitor.initializeCargoMonitor(new CargoMonitorConfiguration());
+            var privateObject = new PrivateObject(cargoMonitor);
 
             line = @"{""timestamp"": ""2018-05-05T19:12:10Z"", ""event"": ""Cargo"", ""Inventory"": [ { ""Name"": ""iondistributor"", ""Name_Localised"": ""Ion Distributor"", ""Count"": 10, ""Stolen"": 0 }, { ""Name"": ""usscargoblackbox"", ""Name_Localised"": ""Black Box"", ""Count"": 4, ""Stolen"": 4 }, { ""Name"": ""drones"", ""Name_Localised"": ""Limpet"", ""Count"": 21, ""Stolen"": 0 } ] }";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleCargoInventoryEvent((CargoInventoryEvent)events[0]);
+            privateObject.Invoke("_handleCargoInventoryEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "IonDistributor");
             Assert.AreEqual(10, cargo.total);
@@ -435,7 +440,7 @@ namespace UnitTests
             // CargoTechnologyBrokerEvent
             line = @"{ ""timestamp"":""2018-03-02T11:28:44Z"", ""event"":""TechnologyBroker"", ""BrokerType"":""Human"", ""MarketID"":128151032, ""ItemsUnlocked"":[{ ""Name"":""Hpt_PlasmaShockCannon_Fixed_Medium"", ""Name_Localised"":""Shock Cannon"" }], ""Commodities"":[{ ""Name"":""iondistributor"", ""Name_Localised"":""Ion Distributor"", ""Count"":6 }], ""Materials"":[ { ""Name"":""vanadium"", ""Count"":30, ""Category"":""Raw"" }, { ""Name"":""tungsten"", ""Count"":30, ""Category"":""Raw"" }, { ""Name"":""rhenium"", ""Count"":36, ""Category"":""Raw"" }, { ""Name"":""technetium"", ""Count"":30, ""Category"":""Raw""}]}";
             events = JournalMonitor.ParseJournalEntry(line);
-            cargoMonitor._handleTechnologyBrokerEvent((TechnologyBrokerEvent)events[0]);
+            privateObject.Invoke("_handleTechnologyBrokerEvent", new object[] { events[0] });
 
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "IonDistributor");
             Assert.AreEqual(4, cargo.total);


### PR DESCRIPTION
Fixed 'Object reference not set to an instance of an object' exceptions reported by Rollbar, associated with the Cargo Monitor 'Cargo depot' and 'Mission abandoned' event handlers.

Added relevant unit testing in CargoMonitorTests.