### PR TITLE
'Mission warning' event hotfix

### DIFF
--- a/DataDefinitions/Mission.cs
+++ b/DataDefinitions/Mission.cs
@@ -195,6 +195,8 @@ namespace EddiDataDefinitions
         public DateTime? expiry { get; set; }
         [JsonIgnore]
         public long? expiryseconds => (long)expiry?.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+        [JsonIgnore]
+        public bool expiring { get; set; }
 
         // Default Constructor
         public Mission() { }
@@ -208,6 +210,7 @@ namespace EddiDataDefinitions
 			this.expiry = expiry?.ToUniversalTime();
             this.statusDef = Status;
             this.shared = Shared;
+            this.expiring = false;
             destinationsystems = new List<DestinationSystem>();
 
             // Mechanism for identifying chained, 'welcome', and 'special' missions

--- a/MissionMonitor/MissionMonitor.cs
+++ b/MissionMonitor/MissionMonitor.cs
@@ -136,9 +136,17 @@ namespace EddiMissionMonitor
                         {
                             EDDI.Instance.eventHandler(new MissionExpiredEvent(DateTime.Now, mission.missionid, mission.name));
                         }
-                        else if (mission.expiry?.ToLocalTime() < DateTime.Now.AddMinutes(-missionWarning ?? -60))
+                        else if (mission.expiry?.ToLocalTime() < DateTime.Now.AddMinutes(missionWarning ?? 60))
                         {
-                            EDDI.Instance.eventHandler(new MissionWarningEvent(DateTime.Now, mission.missionid, mission.name, span.Minutes));
+                            if (!mission.expiring)
+                            {
+                                mission.expiring = true;
+                                EDDI.Instance.eventHandler(new MissionWarningEvent(DateTime.Now, mission.missionid, mission.name, span.Minutes));
+                            }
+                        }
+                        else if (mission.expiring)
+                        {
+                            mission.expiring = false;
                         }
                     }
                     else


### PR DESCRIPTION
Fix for 'Mission warning' event to properly trigger at start of session.