### PR TITLE
Cargo Monitor hotfixes

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -705,13 +705,13 @@ namespace EddiCargoMonitor
                                     cargo.commodityDef = @event.commodityDefinition;
                                     haulage.originsystem = (@event.startmarketid == 0) ? EDDI.Instance?.CurrentStarSystem?.name : null;
                                 }
+                            }
                             else
-                                {
-                                    string originSystem = (@event.startmarketid == 0) ? EDDI.Instance?.CurrentStarSystem?.name : null;
-                                    string type = (@event.startmarketid == 0) ? "MISSION_CollectWing" : "MISSION_DeliveryWing";
-                                    haulage = new Haulage(@event.missionid ?? 0, type, originSystem, amountRemaining, null);
-                                    cargo.haulageData.Add(haulage);
-                                }
+                            {
+                                string originSystem = (@event.startmarketid == 0) ? EDDI.Instance?.CurrentStarSystem?.name : null;
+                                string type = (@event.startmarketid == 0) ? "MISSION_CollectWing" : "MISSION_DeliveryWing";
+                                haulage = new Haulage(@event.missionid ?? 0, type, originSystem, amountRemaining, null);
+                                cargo.haulageData.Add(haulage);
                             }
                         }
                         else
@@ -1222,12 +1222,13 @@ namespace EddiCargoMonitor
             {
                 // Write cargo configuration with current inventory
                 CargoMonitorConfiguration configuration = new CargoMonitorConfiguration();
-                cargoCarried = 0;
-                foreach (Cargo cargo in inventory)
+
+                int sum = inventory.Sum(c => c.total);
+                if (cargoCarried != sum)
                 {
-                    cargoCarried += cargo.total;
+                    cargoCarried = sum;
+                    EDDI.Instance.eventHandler(new CargoUpdatedEvent(DateTime.UtcNow, cargoCarried));
                 }
-                EDDI.Instance.eventHandler(new CargoUpdatedEvent(DateTime.UtcNow, cargoCarried));
                 configuration.cargo = inventory;
                 configuration.cargocarried = cargoCarried;
                 configuration.ToFile();

--- a/DataDefinitions/Haulage.cs
+++ b/DataDefinitions/Haulage.cs
@@ -15,11 +15,11 @@ namespace EddiDataDefinitions
             {"rescuethewares", "salvage"}
         };
 
-        public long missionid { get; private set; }
+        public long missionid { get; set; }
 
-        public string name { get; private set; }
+        public string name { get; set; }
 
-        public string typeEDName { get; private set; }
+        public string typeEDName { get; set; }
 
         [JsonIgnore, Obsolete("Please use localizedName or invariantName")]
         public string type => MissionType.FromEDName(typeEDName)?.localizedName;
@@ -38,7 +38,7 @@ namespace EddiDataDefinitions
         [JsonIgnore]
         public bool wing => name.ToLowerInvariant().Contains("wing");
 
-        public int amount { get; private set; }
+        public int amount { get; set; }
 
         public int remaining { get; set; }
 
@@ -52,7 +52,7 @@ namespace EddiDataDefinitions
 
         public DateTime? expiry { get; set; }
 
-        public bool shared { get; private set; }
+        public bool shared { get; set; }
 
         public Haulage() { }
 
@@ -62,6 +62,8 @@ namespace EddiDataDefinitions
             name = haulage.name;
             typeEDName = haulage.typeEDName;
             originsystem = haulage.originsystem;
+            sourcesystem = haulage.sourcesystem;
+            sourcebody = haulage.sourcebody;
             status = haulage.status;
             amount = haulage.amount;
             startmarketid = haulage.startmarketid;

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -134,10 +134,6 @@ namespace EddiShipMonitor
             {
                 handleCommanderContinuedEvent((CommanderContinuedEvent)@event);
             }
-            else if (@event is CargoInventoryEvent)
-            {
-                handleCargoInventoryEvent((CargoInventoryEvent)@event);
-            }
             else if (@event is CargoUpdatedEvent)
             {
                 handleCargoUpdatedEvent((CargoUpdatedEvent)@event);
@@ -288,16 +284,6 @@ namespace EddiShipMonitor
                 }
                 writeShips();
             }
-        }
-
-        private void handleCargoInventoryEvent(CargoInventoryEvent @event)
-        {
-            Ship ship = GetCurrentShip();
-            if (ship != null)
-            {
-                ship.cargocarried = @event.cargocarried;
-            }
-            writeShips();
         }
 
         private void handleCargoUpdatedEvent(CargoUpdatedEvent @event)


### PR DESCRIPTION
Corrects:
- multiple 'Cargo update' triggers (Issue #873).
- Haulage object private 'sets', resulting in null values
- Typo in Cargo Depot 'delivery' update code.