### PR TITLE
Ship Role hotfix

### DIFF
--- a/DataDefinitions/Properties/ShipRoles.Designer.cs
+++ b/DataDefinitions/Properties/ShipRoles.Designer.cs
@@ -59,5 +59,167 @@ namespace EddiDataDefinitions.Properties {
                 resourceCulture = value;
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assassination.
+        /// </summary>
+        public static string Assassination {
+            get {
+                return ResourceManager.GetString("Assassination", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bounty hunting.
+        /// </summary>
+        public static string BountyHunting {
+            get {
+                return ResourceManager.GetString("BountyHunting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Combat.
+        /// </summary>
+        public static string Combat {
+            get {
+                return ResourceManager.GetString("Combat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Combat support.
+        /// </summary>
+        public static string CombatSupport {
+            get {
+                return ResourceManager.GetString("CombatSupport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exploration.
+        /// </summary>
+        public static string Exploration {
+            get {
+                return ResourceManager.GetString("Exploration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Journalism.
+        /// </summary>
+        public static string Journalism {
+            get {
+                return ResourceManager.GetString("Journalism", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mining.
+        /// </summary>
+        public static string Mining {
+            get {
+                return ResourceManager.GetString("Mining", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MultiCrew.
+        /// </summary>
+        public static string MultiCrew {
+            get {
+                return ResourceManager.GetString("MultiCrew", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multipurpose.
+        /// </summary>
+        public static string MultiPurpose {
+            get {
+                return ResourceManager.GetString("MultiPurpose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Piracy.
+        /// </summary>
+        public static string Piracy {
+            get {
+                return ResourceManager.GetString("Piracy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Racing.
+        /// </summary>
+        public static string Racing {
+            get {
+                return ResourceManager.GetString("Racing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Refueling.
+        /// </summary>
+        public static string Refueling {
+            get {
+                return ResourceManager.GetString("Refueling", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repair.
+        /// </summary>
+        public static string Repair {
+            get {
+                return ResourceManager.GetString("Repair", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Science.
+        /// </summary>
+        public static string Science {
+            get {
+                return ResourceManager.GetString("Science", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search and Rescue.
+        /// </summary>
+        public static string SearchAndRescue {
+            get {
+                return ResourceManager.GetString("SearchAndRescue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Smuggling.
+        /// </summary>
+        public static string Smuggling {
+            get {
+                return ResourceManager.GetString("Smuggling", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Taxi.
+        /// </summary>
+        public static string Taxi {
+            get {
+                return ResourceManager.GetString("Taxi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trading.
+        /// </summary>
+        public static string Trading {
+            get {
+                return ResourceManager.GetString("Trading", resourceCulture);
+            }
+        }
     }
 }

--- a/DataDefinitions/Properties/ShipRoles.resx
+++ b/DataDefinitions/Properties/ShipRoles.resx
@@ -1,108 +1,127 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
   <data name="Assassination" xml:space="preserve">
     <value>Assassination</value>
     <comment>Ship role Assassination</comment>
   </data>
-  <data name="Bountyhunting" xml:space="preserve">
+  <data name="BountyHunting" xml:space="preserve">
     <value>Bounty hunting</value>
     <comment>Ship role Bountyhunting</comment>
   </data>
@@ -110,7 +129,7 @@
     <value>Combat</value>
     <comment>Ship role Combat</comment>
   </data>
-  <data name="Combatsupport" xml:space="preserve">
+  <data name="CombatSupport" xml:space="preserve">
     <value>Combat support</value>
     <comment>Ship role Combatsupport</comment>
   </data>
@@ -130,7 +149,7 @@
     <value>MultiCrew</value>
     <comment>Ship role MultiCrew</comment>
   </data>
-  <data name="Multipurpose" xml:space="preserve">
+  <data name="MultiPurpose" xml:space="preserve">
     <value>Multipurpose</value>
     <comment>Ship role Multipurpose</comment>
   </data>
@@ -154,7 +173,7 @@
     <value>Science</value>
     <comment>Ship role Science</comment>
   </data>
-  <data name="Searchandrescue" xml:space="preserve">
+  <data name="SearchAndRescue" xml:space="preserve">
     <value>Search and Rescue</value>
     <comment>Ship role Searchandrescue</comment>
   </data>

--- a/DataDefinitions/Role.cs
+++ b/DataDefinitions/Role.cs
@@ -13,42 +13,24 @@ namespace EddiDataDefinitions
             resourceManager = Properties.ShipRoles.ResourceManager;
             resourceManager.IgnoreCase = false;
 
-            Assassination = new Role("Assassination");
-            BountyHunting = new Role("Bountyhunting");
-            Combat = new Role("Combat");
-            CombatSupport = new Role("Combatsupport");
-            Exploration = new Role("Exploration");
-            Journalism = new Role("Journalism");
-            Mining = new Role("Mining");
-            MultiCrew = new Role("MultiCrew");
-            MultiPurpose = new Role("Multipurpose");
-            Piracy = new Role("Piracy");
-            Racing = new Role("Racing");
-            Refueling = new Role("Refueling");
-            Science = new Role("Science");
-            SearchAndRescue = new Role("Searchandrescue");
-            Smuggling = new Role("Smuggling");
-            Taxi = new Role("Taxi");
-            Trading = new Role("Trading");
+            var Assassination = new Role("Assassination");
+            var BountyHunting = new Role("BountyHunting");
+            var Combat = new Role("Combat");
+            var CombatSupport = new Role("CombatSupport");
+            var Exploration = new Role("Exploration");
+            var Journalism = new Role("Journalism");
+            var Mining = new Role("Mining");
+            var MultiCrew = new Role("MultiCrew");
+            var MultiPurpose = new Role("MultiPurpose");
+            var Piracy = new Role("Piracy");
+            var Racing = new Role("Racing");
+            var Refueling = new Role("Refueling");
+            var Science = new Role("Science");
+            var SearchAndRescue = new Role("SearchAndRescue");
+            var Smuggling = new Role("Smuggling");
+            var Taxi = new Role("Taxi");
+            var Trading = new Role("Trading");
         }
-
-        public static readonly Role Assassination;
-        public static readonly Role BountyHunting;
-        public static readonly Role Combat;
-        public static readonly Role CombatSupport;
-        public static readonly Role Exploration;
-        public static readonly Role Journalism;
-        public static readonly Role Mining;
-        public static readonly Role MultiCrew;
-        public static readonly Role MultiPurpose;
-        public static readonly Role Piracy;
-        public static readonly Role Racing;
-        public static readonly Role Refueling;
-        public static readonly Role Science;
-        public static readonly Role SearchAndRescue;
-        public static readonly Role Smuggling;
-        public static readonly Role Trading;
-        public static readonly Role Taxi;
 
         // dummy used to ensure that the static constructor has run
         public Role() : this("")

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -169,6 +169,7 @@ namespace EddiDataDefinitions
                 }
             }
         }
+        [JsonIgnore, Obsolete("Please use localizedName or invariantName")]
         public string role => Role?.localizedName; // This string is made available for Cottle scripts that vary depending on the ship's role. 
 
         [JsonExtensionData]
@@ -287,7 +288,6 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
-            Role = Role.FromEDName("MultiPurpose");
         }
 
         public Ship(long EDID, string EDName, string Manufacturer, List<Translation> PhoneticManufacturer, string Model, List<Translation> PhoneticModel, string Size, int? MilitarySize)
@@ -304,7 +304,6 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
-            Role = Role.FromEDName("MultiPurpose");
         }
 
         public override string ToString()

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -435,7 +435,7 @@ namespace EddiDataDefinitions
                 militarysize = template.militarysize;
                 if (Role == null)
                 {
-                    Role = EddiDataDefinitions.Role.FromEDName("MultiPurpose");
+                    Role = Role.FromEDName("MultiPurpose");
                 }
             }
         }

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -287,6 +287,7 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
+            Role = Role.FromEDName("MultiPurpose");
         }
 
         public Ship(long EDID, string EDName, string Manufacturer, List<Translation> PhoneticManufacturer, string Model, List<Translation> PhoneticModel, string Size, int? MilitarySize)
@@ -303,6 +304,7 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
+            Role = Role.FromEDName("MultiPurpose");
         }
 
         public override string ToString()

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -152,7 +152,7 @@ namespace EddiDataDefinitions
         }
 
         /// <summary>the role of this ship</summary>
-        private Role _Role = Role.MultiPurpose;
+        private Role _Role;
         [JsonProperty("ShipRole")]
         public Role Role
         {
@@ -435,7 +435,7 @@ namespace EddiDataDefinitions
                 militarysize = template.militarysize;
                 if (Role == null)
                 {
-                    Role = EddiDataDefinitions.Role.MultiPurpose;
+                    Role = EddiDataDefinitions.Role.FromEDName("MultiPurpose");
                 }
             }
         }

--- a/ShipMonitor/ConfigurationWindow.xaml
+++ b/ShipMonitor/ConfigurationWindow.xaml
@@ -45,7 +45,7 @@
                     </DataGridTextColumn.ElementStyle>
                 </utility:DataGridNumericColumn>
                 <DataGridTextColumn Header="{x:Static resx:ShipMonitor.header_location}" IsReadOnly="True" Binding="{Binding Path=starsystem}"></DataGridTextColumn>
-                <DataGridComboBoxColumn Header="{x:Static resx:ShipMonitor.header_role}" SelectedItemBinding="{Binding Path=Role, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Source={x:Static eddi:Role.Sorted}}">
+                <DataGridComboBoxColumn Header="{x:Static resx:ShipMonitor.header_role}" Width ="130" SelectedItemBinding="{Binding Path=Role, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Source={x:Static eddi:Role.Sorted}}">
                     <DataGridComboBoxColumn.EditingElementStyle>
                         <Style TargetType="{x:Type ComboBox}">
                             <EventSetter Event="SelectionChanged" Handler="shipsUpdated" />

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -277,6 +277,7 @@ namespace EddiShipMonitor
                     // We don't know of this ship so need to create it
                     ship = ShipDefinitions.FromEDModel(@event.ship);
                     ship.LocalId = (int)@event.shipid;
+                    ship.Role = Role.FromEDName("Multipurpose");
                     AddShip(ship);
                 }
                 setShipName(ship, @event.shipname);
@@ -407,6 +408,7 @@ namespace EddiShipMonitor
                 Logging.Debug("Unknown ship ID " + @event.shipid);
                 ship = ShipDefinitions.FromEDModel(@event.ship);
                 ship.LocalId = (int)@event.shipid;
+                ship.Role = Role.FromEDName("Multipurpose");
             }
 
             // Save a copy of the raw event so that we can send it to other 3rd party apps
@@ -1119,6 +1121,7 @@ namespace EddiShipMonitor
                         // We can make one though
                         ship = ShipDefinitions.FromEDModel(model);
                         ship.LocalId = (int)localId;
+                        ship.Role = Role.FromEDName("Multipurpose");
                         AddShip(ship);
                         currentShipId = ship.LocalId;
                         Logging.Debug("Created ship ID " + localId + ";  " + JsonConvert.SerializeObject(ship));

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -277,7 +277,6 @@ namespace EddiShipMonitor
                     // We don't know of this ship so need to create it
                     ship = ShipDefinitions.FromEDModel(@event.ship);
                     ship.LocalId = (int)@event.shipid;
-                    ship.Role = Role.FromEDName("MultiPurpose");
                     AddShip(ship);
                 }
                 setShipName(ship, @event.shipname);
@@ -408,7 +407,6 @@ namespace EddiShipMonitor
                 Logging.Debug("Unknown ship ID " + @event.shipid);
                 ship = ShipDefinitions.FromEDModel(@event.ship);
                 ship.LocalId = (int)@event.shipid;
-                ship.Role = Role.FromEDName("MultiPurpose");
             }
 
             // Save a copy of the raw event so that we can send it to other 3rd party apps
@@ -1121,7 +1119,6 @@ namespace EddiShipMonitor
                         // We can make one though
                         ship = ShipDefinitions.FromEDModel(model);
                         ship.LocalId = (int)localId;
-                        ship.Role = Role.FromEDName("MultiPurpose");
                         AddShip(ship);
                         currentShipId = ship.LocalId;
                         Logging.Debug("Created ship ID " + localId + ";  " + JsonConvert.SerializeObject(ship));

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -277,7 +277,7 @@ namespace EddiShipMonitor
                     // We don't know of this ship so need to create it
                     ship = ShipDefinitions.FromEDModel(@event.ship);
                     ship.LocalId = (int)@event.shipid;
-                    ship.Role = Role.MultiPurpose;
+                    ship.Role = Role.FromEDName("MultiPurpose");
                     AddShip(ship);
                 }
                 setShipName(ship, @event.shipname);
@@ -408,7 +408,7 @@ namespace EddiShipMonitor
                 Logging.Debug("Unknown ship ID " + @event.shipid);
                 ship = ShipDefinitions.FromEDModel(@event.ship);
                 ship.LocalId = (int)@event.shipid;
-                ship.Role = Role.MultiPurpose;
+                ship.Role = Role.FromEDName("MultiPurpose");
             }
 
             // Save a copy of the raw event so that we can send it to other 3rd party apps
@@ -999,7 +999,7 @@ namespace EddiShipMonitor
             // Ensure that we have a role for this ship
             if (ship.Role == null)
             {
-                ship.Role = Role.MultiPurpose;
+                ship.Role = Role.FromEDName("MultiPurpose");
             }
             _ReplaceOrAddShip(ship);
             writeShips();
@@ -1121,7 +1121,7 @@ namespace EddiShipMonitor
                         // We can make one though
                         ship = ShipDefinitions.FromEDModel(model);
                         ship.LocalId = (int)localId;
-                        ship.Role = Role.MultiPurpose;
+                        ship.Role = Role.FromEDName("MultiPurpose");
                         AddShip(ship);
                         currentShipId = ship.LocalId;
                         Logging.Debug("Created ship ID " + localId + ";  " + JsonConvert.SerializeObject(ship));


### PR DESCRIPTION
Hotifx to properly populate ship.role property and ensure persistence across EDDI sessions.

Note:
Using ``` public static readonly Role MultiPurpose;``` definitions, while syntactically correct, the compiler allows assignments such as ```Role = Role.MultiPurpose;```, but does not work with ResourceBasedLocalizedEDName in properly populating the object. ```Role = Role.FromEDName("MultiPurpose");``` is the proper methodology.