### PR TITLE
Implement a JsonConverter that uses FromEDName()

### DIFF
--- a/DataDefinitions/Module.cs
+++ b/DataDefinitions/Module.cs
@@ -57,7 +57,7 @@ namespace EddiDataDefinitions
         [JsonProperty]
         public long EDDBID { get; set; }
 
-        // TEMP
+        [JsonIgnore]
         public string EDName { get => edname; }
 
         public string LocalizedMountName()

--- a/DataDefinitions/ResourceBasedLocalizedEDName.cs
+++ b/DataDefinitions/ResourceBasedLocalizedEDName.cs
@@ -1,15 +1,68 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Resources;
-using System.Runtime.Serialization;
 using Utilities;
 
 namespace EddiDataDefinitions
 {
-    [JsonObject(MemberSerialization.OptIn)]
+    // A JsonConverter that correctly initialises ResourceBasedLocalizedEDName<T> instances using their static FromEDName() method.
+    // Unfortunately we cannot make this a generic type as they are not allowed as parameters for JsonConverterAttribute (or any attribute for that matter),
+    // so instead we have to access FromEDName() via the reflection API.
+    public class JsonConverterFromEDName : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => typeof(ResourceBasedLocalizedEDName<>).IsAssignableFrom(objectType);
+        public override bool CanRead => true;
+        public override bool CanWrite => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            try
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonToken.None:
+                    case JsonToken.Null:
+                    case JsonToken.Undefined:
+                    case JsonToken.EndObject:
+                    case JsonToken.EndArray:
+                        return null;
+                    default:
+                        break;
+                }
+                if (reader.TokenType == JsonToken.Null)
+                {
+                    return null;
+                }
+                JObject jsonObject = JObject.Load(reader);
+                bool success = jsonObject.TryGetValue("edname", out JToken token);
+                if (!success)
+                {
+                    return null;
+                }
+                string edname = token.Value<string>();
+                MethodInfo method = objectType.GetMethod("FromEDName", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy, null, new Type[] { typeof(string) }, null);
+                object result = method?.Invoke(null, new object[] { edname });
+                return result;
+            }
+            catch (Exception)
+            {
+                // let the Json.Net machinery handle the exceptoion
+                throw;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [JsonObject(MemberSerialization.OptIn), JsonConverter(typeof(JsonConverterFromEDName))]
     public class ResourceBasedLocalizedEDName<T> where T : ResourceBasedLocalizedEDName<T>, new()
     {
         static ResourceBasedLocalizedEDName()
@@ -20,21 +73,14 @@ namespace EddiDataDefinitions
         protected static ResourceManager resourceManager;
         protected static Func<string, T> missingEDNameHandler;
 
-        [JsonProperty] // Required by the constructor
-        public readonly string edname;
-
-        [JsonProperty] // Required by the constructor
-        public readonly string basename;
+        [JsonIgnore]
+        public readonly string edname; // must not be JsonProperty as that lets Json.NET modify it, which causes chaos
 
         [JsonIgnore]
-        public string invariantName
-        {
-            get
-            {
-                string invariantName = resourceManager.GetString(basename, CultureInfo.InvariantCulture) ?? basename;
-                return invariantName;
-            }
-        }
+        public readonly string basename; // must not be JsonProperty as that lets Json.NET modify it, which causes chaos
+
+        [JsonIgnore]
+        public string invariantName => resourceManager.GetString(basename, CultureInfo.InvariantCulture) ?? basename;
 
         [JsonIgnore]
         public string fallbackLocalizedName { get; set; } = null;

--- a/DataDefinitions/ResourceBasedLocalizedEDName.cs
+++ b/DataDefinitions/ResourceBasedLocalizedEDName.cs
@@ -79,11 +79,11 @@ namespace EddiDataDefinitions
         protected static ResourceManager resourceManager;
         protected static Func<string, T> missingEDNameHandler;
 
-        [JsonIgnore]
-        public readonly string edname; // must not be JsonProperty as that lets Json.NET modify it, which causes chaos
+        [JsonProperty]
+        public readonly string edname;
 
         [JsonIgnore]
-        public readonly string basename; // must not be JsonProperty as that lets Json.NET modify it, which causes chaos
+        public readonly string basename;
 
         [JsonIgnore]
         public string invariantName => resourceManager.GetString(basename, CultureInfo.InvariantCulture) ?? basename;

--- a/DataDefinitions/ResourceBasedLocalizedEDName.cs
+++ b/DataDefinitions/ResourceBasedLocalizedEDName.cs
@@ -47,7 +47,7 @@ namespace EddiDataDefinitions
             }
             catch (Exception)
             {
-                // let the Json.Net machinery handle the exceptoion
+                // let the Json.Net machinery handle the exception
                 throw;
             }
         }

--- a/DataDefinitions/ResourceBasedLocalizedEDName.cs
+++ b/DataDefinitions/ResourceBasedLocalizedEDName.cs
@@ -23,6 +23,7 @@ namespace EddiDataDefinitions
         {
             try
             {
+                // bail early on known null cases
                 switch (reader.TokenType)
                 {
                     case JsonToken.None:
@@ -34,6 +35,8 @@ namespace EddiDataDefinitions
                     default:
                         break;
                 }
+
+                // get the edname
                 JObject jsonObject = JObject.Load(reader);
                 bool success = jsonObject.TryGetValue("edname", out JToken token);
                 if (!success)
@@ -41,8 +44,15 @@ namespace EddiDataDefinitions
                     return null;
                 }
                 string edname = token.Value<string>();
-                MethodInfo method = objectType.GetMethod("FromEDName", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy, null, new Type[] { typeof(string) }, null);
-                object result = method?.Invoke(null, new object[] { edname });
+
+                // get the FromEDName() method
+                const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy;
+                Type[] argumentTypes = new Type[] { typeof(string) };
+                MethodInfo method = objectType.GetMethod("FromEDName", bindingFlags, binder: null, types: argumentTypes, modifiers: null);
+
+                // invoke the method
+                object[] parameters = new object[] { edname };
+                object result = method?.Invoke(null, parameters);
                 return result;
             }
             catch (Exception)

--- a/DataDefinitions/ResourceBasedLocalizedEDName.cs
+++ b/DataDefinitions/ResourceBasedLocalizedEDName.cs
@@ -34,10 +34,6 @@ namespace EddiDataDefinitions
                     default:
                         break;
                 }
-                if (reader.TokenType == JsonToken.Null)
-                {
-                    return null;
-                }
                 JObject jsonObject = JObject.Load(reader);
                 bool success = jsonObject.TryGetValue("edname", out JToken token);
                 if (!success)

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -151,9 +151,20 @@ namespace EddiDataDefinitions
             }
         }
 
+        // The type of mission
+        public string roleEDName
+        {
+            get => Role.edname;
+            set
+            {
+                Role rDef = Role.FromEDName(value);
+                this.Role = rDef;
+            }
+        }
+
         /// <summary>the role of this ship</summary>
         private Role _Role = Role.MultiPurpose;
-        [JsonProperty("ShipRole")]
+        [JsonIgnore]
         public Role Role
         {
             get
@@ -169,6 +180,8 @@ namespace EddiDataDefinitions
                 }
             }
         }
+
+        [JsonIgnore, Obsolete("Please use localizedName or invariantName")]
         public string role => Role?.localizedName; // This string is made available for Cottle scripts that vary depending on the ship's role. 
 
         [JsonExtensionData]

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -168,7 +168,7 @@ namespace EddiJournalMonitor
                                 decimal distance = JsonParsing.getDecimal(data, "JumpDist");
                                 Superpower allegiance = getAllegiance(data, "SystemAllegiance");
                                 string faction = getFaction(data, "SystemFaction");
-                                SystemState factionState = SystemState.FromEDName(JsonParsing.getString(data, "FactionState"));
+                                SystemState factionState = SystemState.FromEDName(JsonParsing.getString(data, "FactionState") ?? "None");
                                 Economy economy = Economy.FromEDName(JsonParsing.getString(data, "SystemEconomy"));
                                 Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy"));
                                 Government government = Government.FromEDName(JsonParsing.getString(data, "SystemGovernment"));

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -378,117 +378,90 @@ namespace UnitTests
         public void TestJournalJumpedEvent()
         {
             string line = @"{
-	""timestamp"": ""2018-08-08T06: 56: 20Z"",
-	""event"": ""FSDJump"",
-	""StarSystem"": ""Diaguandri"",
-	""SystemAddress"": 670417429889,
-	""StarPos"": [-41.06250,
-	-62.15625,
-	-103.25000],
-	""SystemAllegiance"": ""Independent"",
-	""SystemEconomy"": ""$economy_HighTech;"",
-	""SystemEconomy_Localised"": ""HighTech"",
-	""SystemSecondEconomy"": ""$economy_Refinery;"",
-	""SystemSecondEconomy_Localised"": ""Refinery"",
-	""SystemGovernment"": ""$government_Democracy;"",
-	""SystemGovernment_Localised"": ""Democracy"",
-	""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
-	""SystemSecurity_Localised"": ""MediumSecurity"",
-	""Population"": 10303479,
-	""JumpDist"": 19.340,
-	""FuelUsed"": 2.218082,
-	""FuelLevel"": 23.899260,
-	""Factions"": [{
-		""Name"": ""DiaguandriInterstellar"",
-		""FactionState"": ""Boom"",
-		""Government"": ""Corporate"",
-		""Influence"": 0.100398,
-		""Allegiance"": ""Independent""
-	},
-	{
-		""Name"": ""People'sMET20Liberals"",
-		""FactionState"": ""Boom"",
-		""Government"": ""Democracy"",
-		""Influence"": 0.123260,
-		""Allegiance"": ""Federation""
-	},
-	{
-		""Name"": ""PilotsFederationLocalBranch"",
-		""FactionState"": ""None"",
-		""Government"": ""Democracy"",
-		""Influence"": 0.000000,
-		""Allegiance"": ""PilotsFederation""
-	},
-	{
-		""Name"": ""NaturalDiaguandriRegulatoryState"",
-		""FactionState"": ""None"",
-		""Government"": ""Dictatorship"",
-		""Influence"": 0.020875,
-		""Allegiance"": ""Independent"",
-		""RecoveringStates"": [{
-			""State"": ""CivilWar"",
-			""Trend"": 0
-		}]
-	},
-	{
-		""Name"": ""CartelofDiaguandri"",
-		""FactionState"": ""None"",
-		""Government"": ""Anarchy"",
-		""Influence"": 0.009940,
-		""Allegiance"": ""Independent"",
-		""PendingStates"": [{
-			""State"": ""Bust"",
-			""Trend"": 0
-		},
-		{
-			""State"": ""CivilUnrest"",
-			""Trend"": 1
-		}],
-		""RecoveringStates"": [{
-			""State"": ""CivilWar"",
-			""Trend"": 0
-		}]
-	},
-	{
-		""Name"": ""RevolutionaryPartyofDiaguandri"",
-		""FactionState"": ""None"",
-		""Government"": ""Democracy"",
-		""Influence"": 0.124254,
-		""Allegiance"": ""Federation"",
-		""PendingStates"": [{
-			""State"": ""Boom"",
-			""Trend"": 1
-		},
-		{
-			""State"": ""Bust"",
-			""Trend"": 1
-		}]
-	},
-	{
-		""Name"": ""TheBrotherhoodoftheDarkCircle"",
-		""FactionState"": ""None"",
-		""Government"": ""Corporate"",
-		""Influence"": 0.093439,
-		""Allegiance"": ""Independent"",
-		""RecoveringStates"": [{
-			""State"": ""CivilUnrest"",
-			""Trend"": 1
-		}]
-	},
-	{
-		""Name"": ""EXO"",
-		""FactionState"": ""Expansion"",
-		""Government"": ""Democracy"",
-		""Influence"": 0.527833,
-		""Allegiance"": ""Independent"",
-		""PendingStates"": [{
-			""State"": ""Boom"",
-			""Trend"": 1
-		}]
-	}],
-	""SystemFaction"": ""EXO"",
-	""FactionState"": ""Expansion""
-}";
+	        ""timestamp"": ""2018-08-08T06: 56: 20Z"",
+	        ""event"": ""FSDJump"",
+	        ""StarSystem"": ""Diaguandri"",
+        	""SystemAddress"": 670417429889,
+	        ""StarPos"": [-41.06250, -62.15625, -103.25000],
+	        ""SystemAllegiance"": ""Independent"",
+	        ""SystemEconomy"": ""$economy_HighTech;"",
+	        ""SystemEconomy_Localised"": ""HighTech"",
+	        ""SystemSecondEconomy"": ""$economy_Refinery;"",
+	        ""SystemSecondEconomy_Localised"": ""Refinery"",
+	        ""SystemGovernment"": ""$government_Democracy;"",
+	        ""SystemGovernment_Localised"": ""Democracy"",
+	        ""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
+	        ""SystemSecurity_Localised"": ""MediumSecurity"",
+	        ""Population"": 10303479,
+	        ""JumpDist"": 19.340,
+	        ""FuelUsed"": 2.218082,
+	        ""FuelLevel"": 23.899260,
+	        ""Factions"": [{
+		        ""Name"": ""DiaguandriInterstellar"",
+		        ""FactionState"": ""Boom"",
+		        ""Government"": ""Corporate"",
+		        ""Influence"": 0.100398,
+		        ""Allegiance"": ""Independent""
+	        },
+	        {
+		        ""Name"": ""People'sMET20Liberals"",
+		        ""FactionState"": ""Boom"",
+		        ""Government"": ""Democracy"",
+		        ""Influence"": 0.123260,
+		        ""Allegiance"": ""Federation""
+	        },
+	        {
+		        ""Name"": ""PilotsFederationLocalBranch"",
+		        ""FactionState"": ""None"",
+		        ""Government"": ""Democracy"",
+		        ""Influence"": 0.000000,
+		        ""Allegiance"": ""PilotsFederation""
+	        },
+	        {
+		        ""Name"": ""NaturalDiaguandriRegulatoryState"",
+		        ""FactionState"": ""None"",
+		        ""Government"": ""Dictatorship"",
+		        ""Influence"": 0.020875,
+		        ""Allegiance"": ""Independent"",
+		        ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
+	        },
+	        {
+		        ""Name"": ""CartelofDiaguandri"",
+		        ""FactionState"": ""None"",
+		        ""Government"": ""Anarchy"",
+		        ""Influence"": 0.009940,
+		        ""Allegiance"": ""Independent"",
+		        ""PendingStates"": [{""State"": ""Bust"", ""Trend"": 0}, {""State"": ""CivilUnrest"", ""Trend"": 1}],
+		        ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
+	        },
+	        {
+		        ""Name"": ""RevolutionaryPartyofDiaguandri"",
+		        ""FactionState"": ""None"",
+		        ""Government"": ""Democracy"",
+		        ""Influence"": 0.124254,
+		        ""Allegiance"": ""Federation"",
+		        ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}, {""State"": ""Bust"", ""Trend"": 1}]
+	        },
+	        {
+		        ""Name"": ""TheBrotherhoodoftheDarkCircle"",
+		        ""FactionState"": ""None"",
+		        ""Government"": ""Corporate"",
+		        ""Influence"": 0.093439,
+		        ""Allegiance"": ""Independent"",
+		        ""RecoveringStates"": [{""State"": ""CivilUnrest"", ""Trend"": 1}]
+            },
+            {
+		        ""Name"": ""EXO"",
+		        ""FactionState"": ""Expansion"",
+		        ""Government"": ""Democracy"",
+		        ""Influence"": 0.527833,
+		        ""Allegiance"": ""Independent"",
+		        ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}]
+	        }],
+	        ""SystemFaction"": ""EXO"",
+	        ""FactionState"": ""Expansion""
+            }";
+
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
             Assert.IsTrue(events.Count == 1);
             JumpedEvent jumpedEvent = (JumpedEvent)events[0];
@@ -508,6 +481,37 @@ namespace UnitTests
             Assert.AreEqual(23.899260M, jumpedEvent.fuelremaining);
             Assert.AreEqual("EXO", jumpedEvent.faction);
             Assert.AreEqual("Expansion", jumpedEvent.factionstate);
+        }
+
+        [TestMethod]
+        public void TestJournalJumpedEventFactionStateNull()
+        {
+            // Test for unpopulated system
+            string line = @"{
+                ""timestamp"": ""2018-10-17T00:40:45Z"",
+                ""event"": ""FSDJump"",
+                ""StarSystem"": ""Wredguia WD-K d8-65"",
+                ""SystemAddress"": 2243793258827,
+                ""StarPos"": [-319.15625,10.37500,-332.31250],
+                ""SystemAllegiance"": """",
+                ""SystemEconomy"": ""$economy_None;"",
+                ""SystemEconomy_Localised"": ""None"",
+                ""SystemSecondEconomy"": ""$economy_None;"",
+                ""SystemSecondEconomy_Localised"": ""None"",
+                ""SystemGovernment"": ""$government_None;"",
+                ""SystemGovernment_Localised"": ""None"",
+                ""SystemSecurity"": ""$GAlAXY_MAP_INFO_state_anarchy;"",
+                ""SystemSecurity_Localised"": ""Anarchy"",
+                ""Population"": 0,
+                ""JumpDist"": 24.230,
+                ""FuelUsed"": 4.271171,
+                ""FuelLevel"": 27.728828
+            }";
+
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            Assert.IsTrue(events.Count == 1);
+            JumpedEvent jumpedEvent = (JumpedEvent)events[0];
+            Assert.AreEqual("None", jumpedEvent.factionstate);
         }
 
         [TestMethod]

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -359,5 +359,27 @@ namespace UnitTests
             Assert.AreEqual("SRV", ship2.launchbays[0].type);
             Assert.AreEqual(2, ship2.launchbays[0].vehicles.Count());
         }
+
+        [TestMethod]
+        [DeploymentItem("shipMonitor.json")]
+        public void TestShipMonitorDeserializationDoesntMutateStatics()
+        {
+            // Read from our test item "shipMonitor.json"
+            ShipMonitorConfiguration configuration = new ShipMonitorConfiguration();
+            try
+            {
+                string data = System.IO.File.ReadAllText("shipMonitor.json");
+                if (data != null)
+                {
+                    configuration = JsonConvert.DeserializeObject<ShipMonitorConfiguration>(data);
+                }
+            }
+            catch (Exception)
+            {
+                Assert.Fail("Failed to read ship configuration");
+            }
+
+            Assert.AreEqual("Multipurpose", Role.MultiPurpose.edname);
+        }
     }
 }


### PR DESCRIPTION
The previous approach of setting the JsonProperty attribute on edname and basename was causing trouble because rather than create new objects, Json.NET would simply mutate those properties on an existing object. This would cause problems if the object was in the `AllOfThem` list or otherwise shared.

This new custom JsonConverter instead reads the edname from the JObject and uses it to call FromEDName(). 