### PR TITLE
Increment logs only once per EDDI instance, being sensitive as to whether we are starting from VA.

### DIFF
--- a/EDDI/App.xaml.cs
+++ b/EDDI/App.xaml.cs
@@ -17,6 +17,7 @@ namespace Eddi
         static void Main()
         {
             // Start the application
+            Logging.incrementLogs(); // Increment to a new log file.
             StartRollbar(); // do immediately to initialize error reporting
             ApplyAnyOverrideCulture(); // this must be done before any UI is generated
 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -122,9 +122,6 @@ namespace Eddi
         {
             try
             {
-                // Increment to a new log file.
-                Logging.incrementLogs();
-
                 Logging.Info(Constants.EDDI_NAME + " " + Constants.EDDI_VERSION + " starting");
 
                 // Start by fetching information from the update server, and handling appropriately

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -165,9 +165,6 @@ namespace Eddi
 
             this.fromVA = fromVA;
 
-            // Increment to a new log file.
-            if (!fromVA) { Logging.incrementLogs(); }
-
             // Start the EDDI instance
             EDDI.FromVA = fromVA;
             EDDI.Instance.Start();

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -165,6 +165,9 @@ namespace Eddi
 
             this.fromVA = fromVA;
 
+            // Increment to a new log file.
+            if (!fromVA) { Logging.incrementLogs(); }
+
             // Start the EDDI instance
             EDDI.FromVA = fromVA;
             EDDI.Instance.Start();

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -53,6 +53,7 @@ namespace EddiVoiceAttackResponder
             try
             {
                 GetEddiInstance(ref vaProxy);
+                Logging.incrementLogs(); 
                 App.StartRollbar();
                 App.ApplyAnyOverrideCulture();
                 EDDI.Instance.Start();


### PR DESCRIPTION
Fix #879.