### PR TITLE
Revised ship FSD charging status

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,7 +5,11 @@ Full details of the variables available for each noted event, and VoiceAttack in
 ### Development
   * Speech responder
     * Fixed an error converting a string, such as a ship ID, to the ICAO alphabet that was empty or all symbols (an empty string should result).
-
+  * Status monitor
+    * Recalibrated the `ShipFSD` event 
+      * `charging complete` now triggers at a more appropriate time.
+      * Added new FSD status - `charging canceled`.
+    
 ### 3.1.0-b3
   * Core
     * Fixed a bug in our JSON deserialization code that led to variables changing which were expected to remain constant. This manifested in various ways, including:

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -8,7 +8,7 @@ Full details of the variables available for each noted event, and VoiceAttack in
   * Status monitor
     * Recalibrated the `ShipFSD` event 
       * `charging complete` now triggers at a more appropriate time.
-      * Added new FSD status - `charging canceled`.
+      * Added new FSD status - `charging cancelled`.
     
 ### 3.1.0-b3
   * Core

--- a/ShipMonitor/ShipFsdEvent.cs
+++ b/ShipMonitor/ShipFsdEvent.cs
@@ -14,7 +14,7 @@ namespace EddiShipMonitor
 
         static ShipFsdEvent()
         {
-            VARIABLES.Add("fsd_status", "The status of your ship's fsd ('cooldown', 'cooldown complete', 'charging', 'charging canceled', 'charging complete', 'masslock', or 'masslock cleared')");
+            VARIABLES.Add("fsd_status", "The status of your ship's fsd ('cooldown', 'cooldown complete', 'charging', 'charging cancelled', 'charging complete', 'masslock', or 'masslock cleared')");
         }
 
         [JsonProperty("fsd_status")]

--- a/ShipMonitor/ShipFsdEvent.cs
+++ b/ShipMonitor/ShipFsdEvent.cs
@@ -14,7 +14,7 @@ namespace EddiShipMonitor
 
         static ShipFsdEvent()
         {
-            VARIABLES.Add("fsd_status", "The status of your ship's fsd ('cooldown', 'cooldown complete', 'charging', 'charging complete', 'masslock', or 'masslock cleared')");
+            VARIABLES.Add("fsd_status", "The status of your ship's fsd ('cooldown', 'cooldown complete', 'charging', 'charging canceled', 'charging complete', 'masslock', or 'masslock cleared')");
         }
 
         [JsonProperty("fsd_status")]

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -308,7 +308,7 @@ namespace EddiStatusMonitor
                             case "charging":
                                 if (!jumping && thisStatus.supercruise == lastStatus.supercruise)
                                 {
-                                    EDDI.Instance.eventHandler(new ShipFsdEvent(thisStatus.timestamp, "charging canceled"));
+                                    EDDI.Instance.eventHandler(new ShipFsdEvent(thisStatus.timestamp, "charging cancelled"));
                                 }
                                 jumping = false;
                                 break;

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -24,7 +24,8 @@ namespace EddiStatusMonitor
         private string Directory = GetSavedGamesDir();
         public static Status currentStatus { get; set; } = new Status();
         public static Status lastStatus { get; set; } = new Status();
-        private static bool gliding; 
+        private static bool gliding;
+        private static bool jumping;
 
         // Keep track of status
         private bool running;
@@ -305,7 +306,11 @@ namespace EddiStatusMonitor
                         switch(lastStatus.fsd_status)
                         {
                             case "charging":
-                                EDDI.Instance.eventHandler(new ShipFsdEvent(thisStatus.timestamp, "charging complete"));
+                                if (!jumping && thisStatus.supercruise == lastStatus.supercruise)
+                                {
+                                    EDDI.Instance.eventHandler(new ShipFsdEvent(thisStatus.timestamp, "charging canceled"));
+                                }
+                                jumping = false;
                                 break;
                             case "cooldown":
                                 EDDI.Instance.eventHandler(new ShipFsdEvent(thisStatus.timestamp, "cooldown complete"));
@@ -376,6 +381,10 @@ namespace EddiStatusMonitor
             {
                 handleEnteredNormalSpaceEvent(@event);
             }
+            else if (@event is FSDEngagedEvent)
+            {
+                handleFSDEngagedEvent(@event);
+            }
         }
 
         private void handleEnteredNormalSpaceEvent(Event @event)
@@ -385,8 +394,17 @@ namespace EddiStatusMonitor
             {
                 gliding = true;
                 EnteredNormalSpaceEvent theEvent = (EnteredNormalSpaceEvent)@event;
-                EDDI.Instance.eventHandler(new GlideEvent(currentStatus.timestamp, gliding, theEvent.system, theEvent.systemAddress, theEvent.body, theEvent.bodytype));
+                EDDI.Instance.eventHandler(new GlideEvent(DateTime.UtcNow, gliding, theEvent.system, theEvent.systemAddress, theEvent.body, theEvent.bodytype));
             }
+        }
+
+        private void handleFSDEngagedEvent(Event @event)
+        {
+            if (((FSDEngagedEvent)@event).target == "Hyperspace")
+            {
+                jumping = true;
+            }
+            EDDI.Instance.eventHandler(new ShipFsdEvent(DateTime.UtcNow, "charging complete"));
         }
 
         public void PostHandle(Event @event)

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -193,7 +193,7 @@ namespace EddiVoiceAttackResponder
 
                     if (MessageBoxResult.Cancel == result)
                     {
-                        throw new Exception("EDDI initialization canceled by user.");
+                        throw new Exception("EDDI initialization cancelled by user.");
                     }
                 }
             }


### PR DESCRIPTION
- `charging complete` now triggers at a more appropriate time.
- Added new FSD status - `charging canceled`.

Fixes #886.