### PR TITLE
Suppress an unnecessary `Message received` event when entering a new system and connecting to a new system-wide chat channel.

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1385,6 +1385,13 @@ namespace EddiJournalMonitor
                                 string message = JsonParsing.getString(data, "Message");
                                 string source = "";
 
+                                if (from == string.Empty && channel == "npc" && message.StartsWith("Entered Channel: "))
+                                {
+                                    // We can safely ignore messages that simply announce that we entered a channel - no event is needed. 
+                                    handled = true;
+                                    break;
+                                }
+
                                 if (
                                     channel == "player" ||
                                     channel == "wing" ||

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -733,5 +733,12 @@ namespace UnitTests
             Assert.AreEqual("Thargoid", @event.victimfaction);
         }
 
+        [TestMethod]
+        public void TestMessageReceivedEnteredChannel()
+        {
+            string line = @"{ ""timestamp"":""2018 - 10 - 30T20: 45:07Z"", ""event"":""ReceiveText"", ""From"":"""", ""Message"":""Entered Channel: Shinrarta Dezhra"", ""Channel"":""npc"" }";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            Assert.AreEqual(0, events.Count);
+        }
     }
 }


### PR DESCRIPTION
Fix #897.