### PR TITLE
Don't try to find a "Paint" module when performing repairs.

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2615,7 +2615,7 @@ namespace EddiJournalMonitor
                                 {
                                     item = EddiDataDefinitions.Properties.Modules.ShipIntegrity;
                                 }
-                                else if (item != "All")
+                                else if (item != "All" && item != "Paint")
                                 {
                                     // Item might be a module
                                     Module module = Module.FromEDName(item);


### PR DESCRIPTION
Fix log entries like `2018-10-27T23:07:51 [Info] ResourceBasedLocalizedEDName:FromEDName Unknown ED name paint in resource EddiDataDefinitions.Properties.Modules`