### PR TITLE
Fix SpeechService timeout exception

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -388,11 +388,11 @@ namespace EddiSpeechService
                             try
                             {
                                 Logging.Debug("Selecting voice " + voice);
-                                Task t = new Task(() => selectVoice(voice));
-                                t.Start();
+                                var timeout = new CancellationTokenSource();
+                                Task t = Task.Run(() => selectVoice(voice), timeout.Token);
                                 if (!t.Wait(TimeSpan.FromSeconds(2)))
                                 {
-                                    t.Dispose();
+                                    timeout.Cancel();
                                     Logging.Warn("Failed to select voice " + voice + " (timed out)");
                                 }
                             }


### PR DESCRIPTION
For exceptions like:
```
2018-11-04T19:09:04 [Warning] SpeechService:speak Failed to select voice IVONA 2 Amy OEM System.InvalidOperationException: A task may only be disposed if it is in a completion state (RanToCompletion, Faulted or Canceled).
   at System.Threading.Tasks.Task.Dispose(Boolean disposing)
   at System.Threading.Tasks.Task.Dispose()
   at EddiSpeechService.SpeechService.<>c__DisplayClass25_0.<speak>b__0() in EDDI\SpeechService\SpeechService.cs:line 395
```
(most likely to be seen by developers rather than end users)