### PR TITLE
Prevent nav beacon scan spamming in chapter 4 beta (compatible w/ chapter 3)

### DIFF
--- a/Events/BeltScannedEvent.cs
+++ b/Events/BeltScannedEvent.cs
@@ -20,8 +20,11 @@ namespace EddiEvents
 
         public decimal distancefromarrival { get; private set; }
 
-        public BeltScannedEvent(DateTime timestamp, string name, decimal distancefromarrival) : base(timestamp, NAME)
+        public string scantype { get; private set; } // One of Basic, Detailed, NavBeacon, NavBeaconDetail
+
+        public BeltScannedEvent(DateTime timestamp, string scantype, string name, decimal distancefromarrival) : base(timestamp, NAME)
         {
+            this.scantype = scantype;
             this.name = name;
             this.distancefromarrival = distancefromarrival;
         }

--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -117,7 +117,7 @@ namespace EddiEvents
 
         public string scantype { get; private set; } // One of Basic, Detailed, NavBeacon, NavBeaconDetail
 
-        public BodyScannedEvent(DateTime timestamp, string scantype, string name, PlanetClass planetClass, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? tidallylocked, bool? landable, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereComposition, List<SolidComposition> solidCompositions, Volcanism volcanism, decimal distancefromarrival_Ls, decimal orbitalperiodDays, decimal rotationperiodDays, decimal? semimajoraxisAU, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, List<Ring> rings, string reserves, List<MaterialPresence> materials, TerraformState terraformstate, decimal? axialtiltDegrees, bool dssEquipped) : base(timestamp, NAME)
+        public BodyScannedEvent(DateTime timestamp, string scantype, string name, PlanetClass planetClass, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? tidallylocked, bool? landable, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereComposition, List<SolidComposition> solidCompositions, Volcanism volcanism, decimal distancefromarrival_Ls, decimal orbitalperiodDays, decimal rotationperiodDays, decimal? semimajoraxisAU, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, List<Ring> rings, string reserves, List<MaterialPresence> materials, TerraformState terraformstate, decimal? axialtiltDegrees) : base(timestamp, NAME)
         {
             this.scantype = scantype;
             this.name = name;
@@ -145,7 +145,7 @@ namespace EddiEvents
             this.materials = materials;
             this.terraformState = terraformstate;
             this.axialtilt = axialtiltDegrees;
-            this.estimatedvalue = estimateValue(dssEquipped);
+            this.estimatedvalue = estimateValue(scantype == "Detailed" || scantype == "NavBeaconDetail");
         }
 
         private decimal sanitiseCP(decimal cp)
@@ -169,7 +169,7 @@ namespace EddiEvents
             }
         }
 
-        private long? estimateValue(bool dssEquipped)
+        private long? estimateValue(bool detailedScan)
         {
             // Credit to MattG's thread at https://forums.frontier.co.uk/showthread.php/232000-Exploration-value-formulae for scan value formulas
             int baseTypeValue = 720;
@@ -239,7 +239,7 @@ namespace EddiEvents
             double terraBonusValue = terraValue + (scanMultiplier * terraValue * Math.Pow((double)earthmass, scanPower) / scanDivider);
             double value = baseValue + terraBonusValue;
 
-            if (dssEquipped == false)
+            if (detailedScan == false)
             {
                 value = value / dssDivider;
             }

--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -114,9 +114,12 @@ namespace EddiEvents
         public long? estimatedvalue { get; private set; }
 
         public PlanetClass planetClass { get; private set; }
-        
-        public BodyScannedEvent(DateTime timestamp, string name, PlanetClass planetClass, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? tidallylocked, bool? landable, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereComposition, List<SolidComposition> solidCompositions, Volcanism volcanism, decimal distancefromarrival_Ls, decimal orbitalperiodDays, decimal rotationperiodDays, decimal? semimajoraxisAU, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, List<Ring> rings, string reserves, List<MaterialPresence> materials, TerraformState terraformstate, decimal? axialtiltDegrees, bool dssEquipped) : base(timestamp, NAME)
+
+        public string scantype { get; private set; } // One of Basic, Detailed, NavBeacon, NavBeaconDetail
+
+        public BodyScannedEvent(DateTime timestamp, string scantype, string name, PlanetClass planetClass, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? tidallylocked, bool? landable, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereComposition, List<SolidComposition> solidCompositions, Volcanism volcanism, decimal distancefromarrival_Ls, decimal orbitalperiodDays, decimal rotationperiodDays, decimal? semimajoraxisAU, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, List<Ring> rings, string reserves, List<MaterialPresence> materials, TerraformState terraformstate, decimal? axialtiltDegrees, bool dssEquipped) : base(timestamp, NAME)
         {
+            this.scantype = scantype;
             this.name = name;
             this.distancefromarrival = distancefromarrival_Ls;
             this.planetClass = planetClass;

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -104,8 +104,11 @@ namespace EddiEvents
 
         public long? estimatedvalue { get; private set; }
 
-        public StarScannedEvent(DateTime timestamp, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings, bool dssEquipped) : base(timestamp, NAME)
+        public string scantype { get; private set; } // One of Basic, Detailed, NavBeacon, NavBeaconDetail
+
+        public StarScannedEvent(DateTime timestamp, string scantype, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings, bool dssEquipped) : base(timestamp, NAME)
         {
+            this.scantype = scantype;
             this.name = name;
             this.stellarclass = stellarclass;
             this.solarmass = solarmass;

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -106,7 +106,7 @@ namespace EddiEvents
 
         public string scantype { get; private set; } // One of Basic, Detailed, NavBeacon, NavBeaconDetail
 
-        public StarScannedEvent(DateTime timestamp, string scantype, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings, bool dssEquipped) : base(timestamp, NAME)
+        public StarScannedEvent(DateTime timestamp, string scantype, string name, string stellarclass, decimal solarmass, decimal radius, decimal absolutemagnitude, string luminosityclass, long age, decimal temperature, decimal distancefromarrival, decimal? orbitalperiod, decimal rotationperiod, decimal? semimajoraxis, decimal? eccentricity, decimal? orbitalinclination, decimal? periapsis, List<Ring> rings) : base(timestamp, NAME)
         {
             this.scantype = scantype;
             this.name = name;
@@ -146,10 +146,10 @@ namespace EddiEvents
                     this.estimatedhabzoneouter = estimatedhabzoneouter;
                 }
             }
-            this.estimatedvalue = estimateValue(dssEquipped);
+            this.estimatedvalue = estimateValue(scantype == "Detailed" || scantype == "NavBeaconDetail");
         }
 
-        private long? estimateValue(bool dssEquipped)
+        private long? estimateValue(bool detailedScan)
         {
             // Credit to MattG's thread at https://forums.frontier.co.uk/showthread.php/232000-Exploration-value-formulae for scan value formulas
             // 'bodyDataConstant' is a derived constant from MattG's thread for calculating scan values.
@@ -171,7 +171,7 @@ namespace EddiEvents
             // Calculate exploration scan values
             value = baseValue + ((double)solarmass * baseValue / scanDivider);
 
-            if (dssEquipped == false)
+            if (detailedScan == false)
             {
                 value = value / dssDivider;
             }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -663,20 +663,6 @@ namespace EddiJournalMonitor
                                 decimal? periapsisDegrees = JsonParsing.getOptionalDecimal(data, "Periapsis");
                                 decimal? axialTiltDegrees = JsonParsing.getOptionalDecimal(data, "AxialTilt");
 
-                                // Check whether we have a detailed discovery scanner on board the current ship
-                                bool dssEquipped = false;
-                                Ship ship = EDDI.Instance.CurrentShip;
-                                if (ship != null)
-                                {
-                                    foreach (Compartment compartment in ship.compartments)
-                                    {
-                                        if ((compartment.module.basename == "DetailedSurfaceScanner") && (compartment.module.enabled))
-                                        {
-                                            dssEquipped = true;
-                                        }
-                                    }
-                                }
-
                                 // Rings
                                 data.TryGetValue("Rings", out object val);
                                 List<object> ringsData = (List<object>)val;
@@ -706,7 +692,7 @@ namespace EddiJournalMonitor
                                     long ageMegaYears = (long)val;
                                     decimal temperatureKelvin = JsonParsing.getDecimal(data, "SurfaceTemperature");
 
-                                    events.Add(new StarScannedEvent(timestamp, scantype, name, starType, stellarMass, radiusKm, absoluteMagnitude, luminosityClass, ageMegaYears, temperatureKelvin, distancefromarrival, orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, dssEquipped) { raw = line });
+                                    events.Add(new StarScannedEvent(timestamp, scantype, name, starType, stellarMass, radiusKm, absoluteMagnitude, luminosityClass, ageMegaYears, temperatureKelvin, distancefromarrival, orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings) { raw = line });
                                     handled = true;
                                 }
                                 else
@@ -812,7 +798,7 @@ namespace EddiJournalMonitor
                                     TerraformState terraformState = TerraformState.FromEDName(JsonParsing.getString(data, "TerraformState")) ?? TerraformState.NotTerraformable;
                                     Volcanism volcanism = Volcanism.FromName(JsonParsing.getString(data, "Volcanism"));
 
-                                    events.Add(new BodyScannedEvent(timestamp, scantype, name, planetClass, earthMass, radiusKm, gravity, temperatureKelvin, pressure, tidallyLocked, landable, atmosphereClass, atmosphereCompositions, solidCompositions, volcanism, distancefromarrival, (decimal)orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, reserves, materials, terraformState, axialTiltDegrees, dssEquipped) { raw = line });
+                                    events.Add(new BodyScannedEvent(timestamp, scantype, name, planetClass, earthMass, radiusKm, gravity, temperatureKelvin, pressure, tidallyLocked, landable, atmosphereClass, atmosphereCompositions, solidCompositions, volcanism, distancefromarrival, (decimal)orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, reserves, materials, terraformState, axialTiltDegrees) { raw = line });
                                     handled = true;
                                 }
                             }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -637,13 +637,14 @@ namespace EddiJournalMonitor
                         case "Scan":
                             {
                                 string name = JsonParsing.getString(data, "BodyName");
+                                string scantype = JsonParsing.getString(data, "ScanType");
                                 decimal distancefromarrival = JsonParsing.getDecimal(data, "DistanceFromArrivalLS");
 
                                 // Belt
                                 if (name.Contains("Belt Cluster"))
                                 {
 
-                                    events.Add(new BeltScannedEvent(timestamp, name, distancefromarrival) { raw = line });
+                                    events.Add(new BeltScannedEvent(timestamp, scantype, name, distancefromarrival) { raw = line });
                                     handled = true;
                                     break;
                                 }
@@ -705,7 +706,7 @@ namespace EddiJournalMonitor
                                     long ageMegaYears = (long)val;
                                     decimal temperatureKelvin = JsonParsing.getDecimal(data, "SurfaceTemperature");
 
-                                    events.Add(new StarScannedEvent(timestamp, name, starType, stellarMass, radiusKm, absoluteMagnitude, luminosityClass, ageMegaYears, temperatureKelvin, distancefromarrival, orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, dssEquipped) { raw = line });
+                                    events.Add(new StarScannedEvent(timestamp, scantype, name, starType, stellarMass, radiusKm, absoluteMagnitude, luminosityClass, ageMegaYears, temperatureKelvin, distancefromarrival, orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, dssEquipped) { raw = line });
                                     handled = true;
                                 }
                                 else
@@ -811,7 +812,7 @@ namespace EddiJournalMonitor
                                     TerraformState terraformState = TerraformState.FromEDName(JsonParsing.getString(data, "TerraformState")) ?? TerraformState.NotTerraformable;
                                     Volcanism volcanism = Volcanism.FromName(JsonParsing.getString(data, "Volcanism"));
 
-                                    events.Add(new BodyScannedEvent(timestamp, name, planetClass, earthMass, radiusKm, gravity, temperatureKelvin, pressure, tidallyLocked, landable, atmosphereClass, atmosphereCompositions, solidCompositions, volcanism, distancefromarrival, (decimal)orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, reserves, materials, terraformState, axialTiltDegrees, dssEquipped) { raw = line });
+                                    events.Add(new BodyScannedEvent(timestamp, scantype, name, planetClass, earthMass, radiusKm, gravity, temperatureKelvin, pressure, tidallyLocked, landable, atmosphereClass, atmosphereCompositions, solidCompositions, volcanism, distancefromarrival, (decimal)orbitalPeriodDays, rotationPeriodDays, semimajoraxisLs, eccentricity, orbitalinclinationDegrees, periapsisDegrees, rings, reserves, materials, terraformState, axialTiltDegrees, dssEquipped) { raw = line });
                                     handled = true;
                                 }
                             }

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -146,14 +146,16 @@ namespace EddiSpeechResponder
             }
             else if (theEvent is BodyScannedEvent)
             {
-                if (((BodyScannedEvent)theEvent).scantype == "NavBeaconDetail")
+                string scantype = ((BodyScannedEvent)theEvent).scantype;
+                if (scantype == "NavBeacon" || scantype == "NavBeaconDetail")
                 {
                     return;
                 }
             }
             else if (theEvent is StarScannedEvent)
             {
-                if (((StarScannedEvent)theEvent).scantype == "NavBeaconDetail")
+                string scantype = ((StarScannedEvent)theEvent).scantype;
+                if (scantype == "NavBeacon" || scantype == "NavBeaconDetail")
                 {
                     return;
                 }

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -29,8 +29,6 @@ namespace EddiSpeechResponder
 
         private bool subtitlesOnly;
 
-        private int beaconScanCount = 0;
-
         public string ResponderName()
         {
             return "Speech responder";
@@ -141,22 +139,22 @@ namespace EddiSpeechResponder
                 }
             }
 
-            if (theEvent is NavBeaconScanEvent)
+            if (theEvent is BeltScannedEvent)
             {
-                beaconScanCount = ((NavBeaconScanEvent)theEvent).numbodies;
-                Logging.Debug($"beaconScanCount = {beaconScanCount}");
+                // We ignore belt clusters
+                return;
             }
-            else if (theEvent is StarScannedEvent || theEvent is BodyScannedEvent || theEvent is BeltScannedEvent)
+            else if (theEvent is BodyScannedEvent)
             {
-                if (beaconScanCount > 0)
+                if (((BodyScannedEvent)theEvent).scantype == "NavBeaconDetail")
                 {
-                    beaconScanCount--;
-                    Logging.Debug("beaconScanCount = " + beaconScanCount.ToString());
                     return;
                 }
-                if (theEvent is BeltScannedEvent)
+            }
+            else if (theEvent is StarScannedEvent)
+            {
+                if (((StarScannedEvent)theEvent).scantype == "NavBeaconDetail")
                 {
-                    // We ignore belt clusters
                     return;
                 }
             }


### PR DESCRIPTION
Implements the `scantype` property from the `Scan` event.
Use it to distinguish and suppress extra nav beacon scans.
Use it to determine whether scans are detailed or not for estimating scan values.

Note: Nav beacon scanning is a result of [this FDev bug](https://forums.frontier.co.uk/showthread.php/455841-NavBeaconScan-writes-two-entries-per-body-to-journal?highlight=scantype).