### PR TITLE
EDDN responder restructured to use journal event raws

### DIFF
--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -161,9 +161,9 @@ namespace EDDNResponder
                 if (starpos != null)
                 {
                     List<object> starPos = (List<object>)starpos;
-                    systemX = Math.Round(JsonParsing.getDecimal("X", starPos[0]) * 32) / (decimal)32.0;
-                    systemY = Math.Round(JsonParsing.getDecimal("Y", starPos[1]) * 32) / (decimal)32.0;
-                    systemZ = Math.Round(JsonParsing.getDecimal("Z", starPos[2]) * 32) / (decimal)32.0;
+                    systemX = Math.Round(JsonParsing.getDecimal("X", starPos[0]) * 32M) / 32M;
+                    systemY = Math.Round(JsonParsing.getDecimal("Y", starPos[1]) * 32M) / 32M;
+                    systemZ = Math.Round(JsonParsing.getDecimal("Z", starPos[2]) * 32M) / 32M;
                 }
                 marketId = JsonParsing.getOptionalLong(data, "MarketID");
                 stationName = JsonParsing.getString(data, "StationName");

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -177,12 +177,23 @@ namespace EDDNResponder
         private IDictionary<string, object> StripPersonalData(IDictionary<string, object> data)
         {
             // Need to strip a number of entries
+            data.Remove("ActiveFine");
             data.Remove("CockpitBreach");
             data.Remove("BoostUsed");
             data.Remove("FuelLevel");
             data.Remove("FuelUsed");
             data.Remove("JumpDist");
             data.Remove("Wanted");
+
+            data.TryGetValue("Factions", out object factionsVal);
+            if (factionsVal != null)
+            {
+                var factions = (List<object>)factionsVal;
+                foreach (object faction in factions)
+                {
+                    ((IDictionary<string, object>)faction).Remove("MyReputation");
+                }
+            }
 
             // Need to remove any keys ending with _Localised
             data = data.Where(x => !x.Key.EndsWith("_Localised")).ToDictionary(x => x.Key, x => x.Value);

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2973,6 +2973,7 @@ namespace EddiJournalMonitor
                     }
                     catch (Exception ex)
                     {
+                        // Something went wrong, but an unhandled event will still be passed to the responders.
                         Logging.Warn("Failed to parse line details: " + ex.ToString());
                         Logging.Error("Exception whilst parsing journal line details", "Raw event: " + line + ". Exception: " + ex.Message + ". " + ex.StackTrace);
                     }

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -333,6 +333,117 @@ namespace UnitTests
             Assert.AreEqual(-62.15625M, responder.systemY);
             Assert.AreEqual(-103.25000M, responder.systemZ);
         }
+
+        [TestMethod()]
+        public void TestMyReputationDataStripping()
+        {
+            string line = @"{
+	""timestamp"": ""2018-11-19T01: 06: 17Z"",
+	""event"": ""Location"",
+	""Docked"": false,
+	""StarSystem"": ""BD+48738"",
+	""SystemAddress"": 908352033466,
+	""StarPos"": [-93.53125,
+	-24.46875,
+	-114.71875],
+	""SystemAllegiance"": ""Independent"",
+	""SystemEconomy"": ""$economy_Extraction;"",
+	""SystemEconomy_Localised"": ""Extraction"",
+	""SystemSecondEconomy"": ""$economy_Industrial;"",
+	""SystemSecondEconomy_Localised"": ""Industrial"",
+	""SystemGovernment"": ""$government_Cooperative;"",
+	""SystemGovernment_Localised"": ""Cooperative"",
+	""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
+	""SystemSecurity_Localised"": ""MediumSecurity"",
+	""Population"": 2530147,
+	""Body"": ""LinnaeusEnterprise"",
+	""BodyID"": 28,
+	""BodyType"": ""Station"",
+	""Factions"": [{
+		""Name"": ""IndependentBD+48738Liberals"",
+		""FactionState"": ""None"",
+		""Government"": ""Democracy"",
+		""Influence"": 0.037000,
+		""Allegiance"": ""Federation"",
+		""Happiness"": ""$Faction_HappinessBand2;"",
+		""Happiness_Localised"": ""Happy"",
+		""MyReputation"": 0.000000
+	},
+	{
+		""Name"": ""PilotsFederationLocalBranch"",
+		""FactionState"": ""None"",
+		""Government"": ""Democracy"",
+		""Influence"": 0.000000,
+		""Allegiance"": ""PilotsFederation"",
+		""Happiness"": """",
+		""MyReputation"": 100.000000
+	},
+	{
+		""Name"": ""NewBD+48738Focus"",
+		""FactionState"": ""None"",
+		""Government"": ""Dictatorship"",
+		""Influence"": 0.046000,
+		""Allegiance"": ""Independent"",
+		""Happiness"": ""$Faction_HappinessBand2;"",
+		""Happiness_Localised"": ""Happy"",
+		""MyReputation"": 0.000000
+	},
+	{
+		""Name"": ""BD+48738CrimsonTravelCo"",
+		""FactionState"": ""None"",
+		""Government"": ""Corporate"",
+		""Influence"": 0.032000,
+		""Allegiance"": ""Independent"",
+		""Happiness"": ""$Faction_HappinessBand2;"",
+		""Happiness_Localised"": ""Happy"",
+		""MyReputation"": 0.000000
+	},
+	{
+		""Name"": ""BD+48738CrimsonPosse"",
+		""FactionState"": ""None"",
+		""Government"": ""Anarchy"",
+		""Influence"": 0.010000,
+		""Allegiance"": ""Independent"",
+		""Happiness"": ""$Faction_HappinessBand2;"",
+		""Happiness_Localised"": ""Happy"",
+		""MyReputation"": 0.000000
+	},
+	{
+		""Name"": ""Laniakea"",
+		""FactionState"": ""None"",
+		""Government"": ""Cooperative"",
+		""Influence"": 0.875000,
+		""Allegiance"": ""Independent"",
+		""Happiness"": ""$Faction_HappinessBand2;"",
+		""Happiness_Localised"": ""Happy"",
+		""MyReputation"": 0.000000,
+		""PendingStates"": [{
+			""State"": ""Expansion"",
+			""Trend"": 0
+		}]
+	}],
+	""SystemFaction"": ""Laniakea""
+}";
+            IDictionary<string, object> data = Utilities.Deserializtion.DeserializeData(line);
+
+            EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();
+            var privateObject = new PrivateObject(responder);
+            data = (IDictionary<string, object>)privateObject.Invoke("StripPersonalData", new object[] { data });
+
+            data.TryGetValue("Factions", out object factionsVal);
+            if (factionsVal != null)
+            {
+                var factions = (List<object>)factionsVal;
+                foreach (object faction in factions)
+                {
+                    Assert.IsFalse(((IDictionary<string, object>)faction).ContainsKey("MyReputation"));
+                }
+            }
+            else
+            {
+                Assert.Fail();
+            }
+        }
     }
 }
 

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -127,8 +127,8 @@ namespace UnitTests
             bool matched = responder.eventConfirmCoordinates("Artemis", 3107509474002);
 
             Assert.IsFalse(matched);
-            Assert.AreEqual("Artemis", responder.systemName);
-            Assert.AreEqual(3107509474002, responder.systemAddress);
+            Assert.IsNull(responder.systemName);
+            Assert.IsNull(responder.systemAddress);
             Assert.IsNull(responder.systemX);
             Assert.IsNull(responder.systemY);
             Assert.IsNull(responder.systemZ);

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -847,5 +847,17 @@ namespace UnitTests
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
             Assert.AreEqual(0, events.Count);
         }
+
+        [TestMethod]
+        public void TestUnhandledEvent()
+        {
+            string line = @"{ ""timestamp"":""2018 - 10 - 30T20: 45:07Z"", ""event"":""AnyUnhandledEvent""}";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            Assert.AreEqual(1, events.Count);
+            UnhandledEvent @event = (UnhandledEvent)events[0];
+
+            Assert.AreEqual("AnyUnhandledEvent", @event.edType);
+            Assert.IsNotNull(@event.raw);
+        }
     }
 }


### PR DESCRIPTION
Fix #941 by ensuring that the EDDN responder is not affected by any failure to parse event details.
Instead, the EDDN responder will parse from raw event data. 

Advantages of this approach:
- Changes to the journal monitor's parsing of event details is less likely to disrupt / cause missing messages for the EDDN responder
- More events are taken into account when tracking location data (especially market ID)
- More complete data is sent to EDDN