### PR TITLE
EDSM station data: Fix null reference exception from missing faction info

### DIFF
--- a/StarMapService/EdsmStationData.cs
+++ b/StarMapService/EdsmStationData.cs
@@ -67,7 +67,7 @@ namespace EddiStarMapService
                 distancefromstar = (decimal?)station["distanceToArrival"], // Light seconds
             };
 
-            var faction = station["controllingFaction"]?.ToObject<IDictionary<string, object>>();
+            var faction = station["controllingFaction"]?.ToObject<Dictionary<string, object>>();
             Station.Faction = new Faction()
             {
                 name = faction != null ? (string)faction["name"] : string.Empty,

--- a/StarMapService/EdsmStationData.cs
+++ b/StarMapService/EdsmStationData.cs
@@ -70,8 +70,8 @@ namespace EddiStarMapService
             var faction = station["controllingFaction"]?.ToObject<Dictionary<string, object>>();
             Station.Faction = new Faction()
             {
-                name = faction != null ? (string)faction["name"] : string.Empty,
-                EDSMID = faction != null ? (long?)faction["id"] : null,
+                name = (string)faction?["name"] ?? string.Empty,
+                EDSMID = (long?)faction?["id"],
                 Allegiance = Superpower.FromName((string)station["allegiance"]) ?? Superpower.None,
                 Government = Government.FromName((string)station["government"]) ?? Government.None,
             };

--- a/StarMapService/EdsmStationData.cs
+++ b/StarMapService/EdsmStationData.cs
@@ -67,11 +67,11 @@ namespace EddiStarMapService
                 distancefromstar = (decimal?)station["distanceToArrival"], // Light seconds
             };
 
-            var faction = station["controllingFaction"]?.ToObject<Dictionary<string, object>>();
-            Station.Faction = new Faction() 
+            var faction = station["controllingFaction"]?.ToObject<IDictionary<string, object>>();
+            Station.Faction = new Faction()
             {
-                name = (string)faction["name"],
-                EDSMID = (long?)faction["id"],
+                name = faction != null ? (string)faction["name"] : string.Empty,
+                EDSMID = faction != null ? (long?)faction["id"] : null,
                 Allegiance = Superpower.FromName((string)station["allegiance"]) ?? Superpower.None,
                 Government = Government.FromName((string)station["government"]) ?? Government.None,
             };


### PR DESCRIPTION
When parsing a station without a "controllingFaction" key.