### PR TITLE
Fix EDDI not running after a clean install.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,6 +4,10 @@ Full details of the variables available for each noted event, and VoiceAttack in
 
 ### Development
 
+### 3.1.1
+  * Core
+    * Fix crash to desktop when the folder `%APPDATA%\EDDI` does not exist.
+
 ### 3.1
   * Core
     * Fixed scan message spam upon scanning a Nav Beacon.

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -140,6 +140,10 @@ namespace Utilities
                     }
                 }
             }
+            else
+            {
+                Directory.CreateDirectory(Constants.DATA_DIR);
+            }
         }
 
         internal static void Report(ErrorLevel errorLevel, string message, object data = null, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -106,43 +106,42 @@ namespace Utilities
 
         public static void incrementLogs()
         {
-            // Obtain files, sorting by last write time to ensure that older files are incremented prior to newer files
+            // Ensure dir exists
             DirectoryInfo directoryInfo = new DirectoryInfo(Constants.DATA_DIR);
-            if (directoryInfo.Exists)
-            {
-                foreach (FileInfo file in directoryInfo.GetFiles().OrderBy(f => f.LastWriteTimeUtc).ToList())
-                {
-                    string filePath = file.FullName;
-                    if (filePath.EndsWith(".log"))
-                    {
-                        try
-                        {
-                            bool parsed = int.TryParse(filePath.Replace(Constants.DATA_DIR + @"\eddi", "").Replace(".log", ""), out int i);
-                            ++i; // Increment our index number
-
-                            if (i >= 10)
-                            {
-                                File.Delete(filePath);
-                            }
-                            else
-                            {
-                                // This might be our primary log file, so we lock it prior to doing anything with it
-                                lock (logLock)
-                                {
-                                    File.Move(filePath, Constants.DATA_DIR + @"\eddi" + i + ".log");
-                                }
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            // Someone may have had a log file open when this code executed? Nothing to do, we'll try again on the next run
-                        }
-                    }
-                }
-            }
-            else
+            if (!directoryInfo.Exists)
             {
                 Directory.CreateDirectory(Constants.DATA_DIR);
+            }
+
+            // Obtain files, sorting by last write time to ensure that older files are incremented prior to newer files
+            foreach (FileInfo file in directoryInfo.GetFiles().OrderBy(f => f.LastWriteTimeUtc).ToList())
+            {
+                string filePath = file.FullName;
+                if (filePath.EndsWith(".log"))
+                {
+                    try
+                    {
+                        bool parsed = int.TryParse(filePath.Replace(Constants.DATA_DIR + @"\eddi", "").Replace(".log", ""), out int i);
+                        ++i; // Increment our index number
+
+                        if (i >= 10)
+                        {
+                            File.Delete(filePath);
+                        }
+                        else
+                        {
+                            // This might be our primary log file, so we lock it prior to doing anything with it
+                            lock (logLock)
+                            {
+                                File.Move(filePath, Constants.DATA_DIR + @"\eddi" + i + ".log");
+                            }
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Someone may have had a log file open when this code executed? Nothing to do, we'll try again on the next run
+                    }
+                }
             }
         }
 

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -108,32 +108,35 @@ namespace Utilities
         {
             // Obtain files, sorting by last write time to ensure that older files are incremented prior to newer files
             DirectoryInfo directoryInfo = new DirectoryInfo(Constants.DATA_DIR);
-            foreach (FileInfo file in directoryInfo.GetFiles().OrderBy(f => f.LastWriteTimeUtc).ToList())
+            if (directoryInfo.Exists)
             {
-                string filePath = file.FullName;
-                if (filePath.EndsWith(".log"))
+                foreach (FileInfo file in directoryInfo.GetFiles().OrderBy(f => f.LastWriteTimeUtc).ToList())
                 {
-                    try
+                    string filePath = file.FullName;
+                    if (filePath.EndsWith(".log"))
                     {
-                        bool parsed = int.TryParse(filePath.Replace(Constants.DATA_DIR + @"\eddi", "").Replace(".log", ""), out int i);
-                        ++i; // Increment our index number
+                        try
+                        {
+                            bool parsed = int.TryParse(filePath.Replace(Constants.DATA_DIR + @"\eddi", "").Replace(".log", ""), out int i);
+                            ++i; // Increment our index number
 
-                        if (i >= 10)
-                        {
-                            File.Delete(filePath);
-                        }
-                        else
-                        {
-                            // This might be our primary log file, so we lock it prior to doing anything with it
-                            lock (logLock)
+                            if (i >= 10)
                             {
-                                File.Move(filePath, Constants.DATA_DIR + @"\eddi" + i + ".log");
+                                File.Delete(filePath);
+                            }
+                            else
+                            {
+                                // This might be our primary log file, so we lock it prior to doing anything with it
+                                lock (logLock)
+                                {
+                                    File.Move(filePath, Constants.DATA_DIR + @"\eddi" + i + ".log");
+                                }
                             }
                         }
-                    }
-                    catch (Exception)
-                    {
-                        // Someone may have had a log file open when this code executed? Nothing to do, we'll try again on the next run
+                        catch (Exception)
+                        {
+                            // Someone may have had a log file open when this code executed? Nothing to do, we'll try again on the next run
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix #950 by making sure our config directory exists before trying to increment the logs in said directory.