### PR TITLE
Clarify that verbose logs are only placed on the desktop when the `Report an Issue` button is clicked.

### DIFF
--- a/EDDI/Properties/MainWindow.Designer.cs
+++ b/EDDI/Properties/MainWindow.Designer.cs
@@ -448,7 +448,7 @@ namespace Eddi.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If verbose logging is enabled, EDDI will prepare a version of your log (truncated if lengthy) and place it on your desktop. You may paste this log file into the Github Issue report. No private information is sent in the log..
+        ///   Looks up a localized string similar to If verbose logging is enabled when you click &quot;Report an Issue&quot;, EDDI will package your log and place a copy on your desktop. You may paste this copy into the Github Issue report. No private information is sent in the log..
         /// </summary>
         public static string verbose_logging_desc {
             get {

--- a/EDDI/Properties/MainWindow.Designer.cs
+++ b/EDDI/Properties/MainWindow.Designer.cs
@@ -448,7 +448,7 @@ namespace Eddi.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If verbose logging is enabled when you click &quot;Report an Issue&quot;, EDDI will package your log and place a copy on your desktop. You may paste this copy into the Github Issue report. No private information is sent in the log..
+        ///   Looks up a localized string similar to If verbose logging is enabled, this will create a zip archive of your log on your desktop, ready to be pasted into the issue report on GitHub. No personally-identifying information is included in the log..
         /// </summary>
         public static string verbose_logging_desc {
             get {

--- a/EDDI/Properties/MainWindow.resx
+++ b/EDDI/Properties/MainWindow.resx
@@ -149,7 +149,7 @@
     <value>Enable verbose logging (only if you have been requested to do so by EDDI developers)</value>
   </data>
   <data name="verbose_logging_desc" xml:space="preserve">
-    <value>If verbose logging is enabled, EDDI will prepare a version of your log (truncated if lengthy) and place it on your desktop. You may paste this log file into the Github Issue report. No private information is sent in the log.</value>
+    <value>If verbose logging is enabled when you click "Report an Issue", EDDI will package your log and place a copy on your desktop. You may paste this copy into the Github Issue report. No private information is sent in the log.</value>
   </data>
   <data name="version_hyperlink" xml:space="preserve">
     <value>Version:</value>

--- a/EDDI/Properties/MainWindow.resx
+++ b/EDDI/Properties/MainWindow.resx
@@ -149,7 +149,7 @@
     <value>Enable verbose logging (only if you have been requested to do so by EDDI developers)</value>
   </data>
   <data name="verbose_logging_desc" xml:space="preserve">
-    <value>If verbose logging is enabled when you click "Report an Issue", EDDI will package your log and place a copy on your desktop. You may paste this copy into the Github Issue report. No private information is sent in the log.</value>
+    <value>If verbose logging is enabled, this will create a zip archive of your log on your desktop, ready to be pasted into the issue report on GitHub. No personally-identifying information is included in the log.</value>
   </data>
   <data name="version_hyperlink" xml:space="preserve">
     <value>Version:</value>


### PR DESCRIPTION
Note: It looks like CrowdIn supports a version control feature that we may be able to use to hook Crowdin to this branch to request re-translation?