### PR TITLE
Convert station model pronunciation fixups to use `P()` function, rather than editing the invariant name.

### DIFF
--- a/DataDefinitions/Properties/StationModels.Designer.cs
+++ b/DataDefinitions/Properties/StationModels.Designer.cs
@@ -88,7 +88,7 @@ namespace EddiDataDefinitions.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Mega-ship.
+        ///   Looks up a localized string similar to Megaship.
         /// </summary>
         public static string Megaship {
             get {
@@ -106,7 +106,7 @@ namespace EddiDataDefinitions.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Or-bis Starport.
+        ///   Looks up a localized string similar to Orbis Starport.
         /// </summary>
         public static string Orbis {
             get {

--- a/DataDefinitions/Properties/StationModels.resx
+++ b/DataDefinitions/Properties/StationModels.resx
@@ -130,11 +130,11 @@
     <comment>A Coriolis Starport</comment>
   </data>
   <data name="Megaship" xml:space="preserve">
-    <value>Mega-ship</value>
+    <value>Megaship</value>
     <comment>A Megaship</comment>
   </data>
   <data name="Orbis" xml:space="preserve">
-    <value>Or-bis Starport</value>
+    <value>Orbis Starport</value>
     <comment>An Orbis Starport</comment>
   </data>
   <data name="Outpost" xml:space="preserve">

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,7 +5,8 @@ Full details of the variables available for each noted event, and VoiceAttack in
 ### Development
   * Localization
     * Material locations have been moved from the update server to the app and are now a translatable resource.
-
+  * Tweaked pronunciations of "Megaship" and "Orbis" in English. Tweaked pronuncations are available via the `P()` function.
+  
 ### 3.1.1
   * Core
     * Fixed crash to desktop when the folder `%APPDATA%\EDDI` does not exist.

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -176,6 +176,10 @@ namespace EddiSpeechResponder
                 }
                 if (translation == val)
                 {
+                    translation = Translations.Station(val);
+                }
+                if (translation == val)
+                {
                     translation = Translations.Faction(val);
                 }
                 if (translation == val)

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -52,6 +52,13 @@ namespace EddiSpeechService
             { "VESPER-M4", "Vesper M 4" } // Stop Vesper being treated as a sector
         };
 
+        // Fixes to avoid issues with pronunciation of station model names
+        private static Dictionary<string, string> STATION_MODEL_FIXES = new Dictionary<string, string>()
+        {
+            { "Orbis Starport", "Or-bis Starport" }, // Stop "Or-bis" from sometimes being pronounced as "Or-bise"
+            { "Megaship", "Mega-ship" } // Stop "Mega-Ship" from sometimes being pronounced as "Meg-AH-ship"
+        };
+
         // Fixes to avoid issues with some of the more strangely-named factions
         private static Dictionary<string, string> FACTION_FIXES = new Dictionary<string, string>()
         {
@@ -420,6 +427,17 @@ namespace EddiSpeechService
             starSystem = UPPERCASE.Replace(starSystem, match => useICAO ? ICAO(match.Value, true) : string.Join<char>(" ", match.Value));
 
             return Regex.Replace(starSystem, @"\s+", " ");
+        }
+
+        /// <summary>Fix up station related pronunciations </summary>
+        public static string Station(string station)
+        {
+            // Specific fixing of station model pronunciations
+            if (STATION_MODEL_FIXES.ContainsKey(station))
+            {
+                station = STATION_MODEL_FIXES[station];
+            }
+            return station;
         }
 
         private static string replaceWithPronunciation(string sourcePhrase, string[] pronunciation)

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -224,7 +224,7 @@ namespace UnitTests
             Station station = stations.Find(s => s.name == "Jameson Memorial");
             Assert.AreEqual(65, station.EDSMID);
             Assert.AreEqual(128666762, station.marketId);
-            Assert.AreEqual("Or-bis Starport", station.Model.invariantName);
+            Assert.AreEqual("Orbis Starport", station.Model.invariantName);
             Assert.AreEqual(324.925354M, station.distancefromstar);
             Assert.AreEqual("Pilots Federation", station.Faction.Allegiance.invariantName);
             Assert.AreEqual("Democracy", station.Faction.Government.invariantName);

--- a/Tests/TranslationTests.cs
+++ b/Tests/TranslationTests.cs
@@ -171,5 +171,12 @@ namespace UnitTests
             Assert.AreEqual(@"B D plus 18 7 1 1", Translations.StarSystem("BD+18 711", false));
             Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> plus 18 <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.StarSystem("BD+18 711", true));
         }
+
+        [TestMethod]
+        public void TestTranslateStation()
+        {
+            Assert.AreEqual("Or-bis Starport", Translations.Station("Orbis Starport"));
+            Assert.AreEqual("Mega-ship", Translations.Station("Megaship"));
+        }
     }
 }


### PR DESCRIPTION
Invariant names may be used by end user scripts. And are often used to parse EDSM data.
This PR implements the same fix as a pronunciation fix-up accessible via the `P()` function while restoring the original invariant name.