### PR TITLE
Hotfix/EDDP crash

### DIFF
--- a/DataProviderService/LegacyEddpService.cs
+++ b/DataProviderService/LegacyEddpService.cs
@@ -24,9 +24,12 @@ namespace EddiDataProviderService
         public static StarSystem SetLegacyData(StarSystem system, bool setPowerplayData = true, bool setBodyData = true, bool setStationData = true)
         {
             JObject response = GetData(system.name);
-            SetStarSystemLegacyData(system, response, setPowerplayData);
-            if (setBodyData) { SetBodyLegacyData(system, response); }
-            if (setStationData) { SetStationLegacyData(system, response); }
+            if (response != null)
+            {
+                SetStarSystemLegacyData(system, response, setPowerplayData);
+                if (setBodyData) { SetBodyLegacyData(system, response); }
+                if (setStationData) { SetStationLegacyData(system, response); }
+            }
             return system;
         }
 
@@ -37,7 +40,7 @@ namespace EddiDataProviderService
                 string response = Net.DownloadString(BASE + "systems/" + Uri.EscapeDataString(system));
                 return JsonConvert.DeserializeObject<JObject>(response);
             }
-            catch (WebException)
+            catch (Exception)
             {
                 Logging.Debug("Failed to obtain data from " + BASE + "systems/" + Uri.EscapeDataString(system));
                 return null;


### PR DESCRIPTION
If you are at a system that is not in EDDP, EDDI crashes on startup with an uncaught exception as it tries to convert a null response to JObject.