### PR TITLE
Sort dropdown menus appropriately

### DIFF
--- a/DataDefinitions/ShipDefinitions.cs
+++ b/DataDefinitions/ShipDefinitions.cs
@@ -46,10 +46,6 @@ namespace EddiDataDefinitions
             { 128816567, new Ship(128816567, "Krait_MkII", "Faulcon DeLacy", null, "Krait Mk. II", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Mk.", "mɑːk"), new Translation("II", "ˈtuː") }, "Medium", null, 0.63M) },
             { 128839281, new Ship(128839281, "krait_light", "Faulcon DeLacy", null, "Krait Phantom", new List<Translation>{new Translation("Krait", "ˈkreɪt")}, "Medium", null, 0.63M) },
             { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", null, "Mamba", null, "Medium", null, 0.5M) },
-
-            // Speculative future ships (replace '9999999xx' with Frontier ID once known)
-            { 999999902, new Ship(999999902, "Panther", "Zorgon Peterson", null, "Panther Clipper", null, "Large", null, 0M) },
-            { 999999903, new Ship(999999903, "AspMkII", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Asp Mk. II", null, "Medium", null, 0M) },
         };
 
         public static List<string> ShipModels = ShipsByEliteID.Select(kp => kp.Value.model).ToList();

--- a/DataDefinitions/ShipDefinitions.cs
+++ b/DataDefinitions/ShipDefinitions.cs
@@ -48,7 +48,7 @@ namespace EddiDataDefinitions
             { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", null, "Mamba", null, "Medium", null, 0.5M) },
         };
 
-        public static List<string> ShipModels = ShipsByEliteID.Select(kp => kp.Value.model).ToList();
+        public static readonly SortedSet<string> ShipModels = new SortedSet<string>(ShipsByEliteID.Select(kp => kp.Value.model));
 
         private static Dictionary<string, Ship> ShipsByModel = ShipsByEliteID.ToDictionary(kp => kp.Value.model.ToLowerInvariant(), kp => kp.Value);
         private static Dictionary<string, Ship> ShipsByEDModel = ShipsByEliteID.ToDictionary(kp => kp.Value.EDName.ToLowerInvariant().Replace(" ", "").Replace(".", "").Replace("_", ""), kp => kp.Value);

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -448,7 +448,7 @@ namespace Eddi
                         }
                     }
                 }
-
+                speechOptions.Sort();
                 ttsVoiceDropDown.ItemsSource = speechOptions;
                 ttsVoiceDropDown.Text = speechServiceConfiguration.StandardVoice ?? "Windows TTS default";
             }
@@ -542,6 +542,7 @@ namespace Eddi
                     }
                 }
             }
+            HomeStationOptions.Sort(1, HomeStationOptions.Count - 1, null);
             homeStationDropDown.ItemsSource = HomeStationOptions;
         }
 
@@ -779,6 +780,7 @@ namespace Eddi
                     }
                 }
             }
+            SquadronFactionOptions.Sort();
             squadronFactionDropDown.ItemsSource = SquadronFactionOptions;
         }
 
@@ -797,6 +799,7 @@ namespace Eddi
                     }
                 }
             }
+            SquadronPowerOptions.Sort();
             squadronPowerDropDown.ItemsSource = SquadronPowerOptions;
         }
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -223,9 +223,9 @@ namespace Eddi
             {
                 eddiSquadronSystemText.Text = string.Empty;
             }
-            squadronFactionDropDown.SelectedItem = eddiConfiguration.SquadronFaction == null ? "None" : eddiConfiguration.SquadronFaction;
+            squadronFactionDropDown.SelectedItem = eddiConfiguration.SquadronFaction ?? Power.None.localizedName;
             squadronPowerDropDown.SelectedItem = eddiConfiguration.SquadronPower == null
-                ? Power.FromEDName("None").localizedName : eddiConfiguration.SquadronPower.localizedName;
+                ? Power.None.localizedName : eddiConfiguration.SquadronPower.localizedName;
             ConfigureSquadronPowerOptions(eddiConfiguration);
 
             List<LanguageDef> langs = GetAvailableLangs(); // already correctly sorted
@@ -669,7 +669,7 @@ namespace Eddi
                     eddiConfiguration.SquadronPower = Power.None;
                     eddiConfiguration.ToFile();
 
-                    squadronFactionDropDown.SelectedItem = "None";
+                    squadronFactionDropDown.SelectedItem = Power.None.localizedName;
                     ConfigureSquadronFactionOptions(eddiConfiguration);
                     squadronPowerDropDown.SelectedItem = eddiConfiguration.SquadronPower.localizedName;
                     ConfigureSquadronPowerOptions(eddiConfiguration);

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -195,7 +195,7 @@ namespace Eddi
             {
                 eddiHomeSystemText.Text = string.Empty;
             }
-            homeStationDropDown.SelectedItem = eddiConfiguration.HomeStation == null ? "None" : eddiConfiguration.HomeStation;
+            homeStationDropDown.SelectedItem = eddiConfiguration.HomeStation ?? "";
             eddiVerboseLogging.IsChecked = eddiConfiguration.Debug;
             eddiBetaProgramme.IsChecked = eddiConfiguration.Beta;
             if (eddiConfiguration.Gender == "Female")
@@ -498,7 +498,7 @@ namespace Eddi
                 if (eddiConfiguration.HomeStation != null)
                 {
                     eddiConfiguration.HomeStation = null;
-                    homeStationDropDown.SelectedItem = "None";
+                    homeStationDropDown.SelectedItem = "";
                     ConfigureHomeStationOptions(null);
                 }
                 eddiConfiguration.ToFile();
@@ -553,7 +553,7 @@ namespace Eddi
             string homeStationName = homeStationDropDown.SelectedItem.ToString();
             if (eddiConfiguration.HomeStation != homeStationName)
             {
-                eddiConfiguration.HomeStation = homeStationName == "None" ? null : homeStationName;
+                eddiConfiguration.HomeStation = String.IsNullOrEmpty(homeStationName) ? null : homeStationName;
                 eddiConfiguration = EDDI.Instance.updateHomeStation(eddiConfiguration);
                 eddiConfiguration.ToFile();
             }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -210,8 +210,8 @@ namespace Eddi
             {
                 eddiGenderNeither.IsChecked = true;
             }
-            eddiSquadronNameText.Text = eddiConfiguration.SquadronName == null ? string.Empty : eddiConfiguration.SquadronName;
-            eddiSquadronIDText.Text = eddiConfiguration.SquadronID == null ? string.Empty : eddiConfiguration.SquadronID;
+            eddiSquadronNameText.Text = eddiConfiguration.SquadronName ?? string.Empty;
+            eddiSquadronIDText.Text = eddiConfiguration.SquadronID ?? string.Empty;
             squadronRankDropDown.SelectedItem = (eddiConfiguration.SquadronRank ?? SquadronRank.None).localizedName;
             ConfigureSquadronRankOptions(eddiConfiguration);
             if (eddiConfiguration.validSquadronSystem)
@@ -789,9 +789,10 @@ namespace Eddi
 
         private void ConfigureSquadronPowerOptions(EDDIConfiguration configuration)
         {
-            List<string> SquadronPowerOptions = new List<string>();
-
-            SquadronPowerOptions.Add(Power.None.localizedName);
+            List<string> SquadronPowerOptions = new List<string>
+            {
+                Power.None.localizedName
+            };
             if (configuration.SquadronAllegiance != Superpower.None)
             {
                 foreach (Power power in Power.AllOfThem)

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -228,7 +228,7 @@ namespace Eddi
                 ? Power.FromEDName("None").localizedName : eddiConfiguration.SquadronPower.localizedName;
             ConfigureSquadronPowerOptions(eddiConfiguration);
 
-            List<LanguageDef> langs = GetAvailableLangs();
+            List<LanguageDef> langs = GetAvailableLangs(); // already correctly sorted
             chooseLanguageDropDown.ItemsSource = langs;
             chooseLanguageDropDown.DisplayMemberPath = "displayName";
             chooseLanguageDropDown.SelectedItem = langs.Find(l => l.ci.Name == Eddi.Properties.Settings.Default.OverrideCulture);
@@ -463,7 +463,7 @@ namespace Eddi
             disableSsmlCheckbox.IsChecked = speechServiceConfiguration.DisableSsml;
             enableIcaoCheckbox.IsChecked = speechServiceConfiguration.EnableIcao;
 
-            ttsTestShipDropDown.ItemsSource = ShipDefinitions.ShipModels;
+            ttsTestShipDropDown.ItemsSource = ShipDefinitions.ShipModels; // already sorted
             ttsTestShipDropDown.Text = "Adder";
         }
 
@@ -528,7 +528,7 @@ namespace Eddi
         {
             List<string> HomeStationOptions = new List<string>
                 {
-                    "None"
+                    "" // use empty string rather than "None" -- more accurate and doesnt need translating
                 };
 
             if (system != null)
@@ -542,6 +542,7 @@ namespace Eddi
                     }
                 }
             }
+            // sort but leave "" at the top
             HomeStationOptions.Sort(1, HomeStationOptions.Count - 1, null);
             homeStationDropDown.ItemsSource = HomeStationOptions;
         }
@@ -759,6 +760,7 @@ namespace Eddi
                 }
                 SquadronRankOptions.Add(squadronrank.localizedName);
             }
+            // don't sort
             squadronRankDropDown.ItemsSource = SquadronRankOptions;
         }
 
@@ -780,7 +782,8 @@ namespace Eddi
                     }
                 }
             }
-            SquadronFactionOptions.Sort();
+            // sort but leave "None" at the top
+            SquadronFactionOptions.Sort(1, SquadronFactionOptions.Count - 1, null);
             squadronFactionDropDown.ItemsSource = SquadronFactionOptions;
         }
 
@@ -799,7 +802,8 @@ namespace Eddi
                     }
                 }
             }
-            SquadronPowerOptions.Sort();
+            // sort but leave "None" at the top
+            SquadronPowerOptions.Sort(1, SquadronPowerOptions.Count - 1, null);
             squadronPowerDropDown.ItemsSource = SquadronPowerOptions;
         }
 

--- a/EDDPMonitor/ConfigurationWindow.xaml.cs
+++ b/EDDPMonitor/ConfigurationWindow.xaml.cs
@@ -40,7 +40,7 @@ namespace EddiEddpMonitor
             // Make a list of states plus a (anything) state that maps to NULL
             StatesPlusNone = new List<KeyValuePair<string, FactionState>>();
             StatesPlusNone.Add(new KeyValuePair<string, FactionState>(Properties.EddpResources.anything, null));
-            StatesPlusNone.AddRange(FactionState.AllOfThem.Select(x => new KeyValuePair<string, FactionState>(x.localizedName, x)));
+            StatesPlusNone.AddRange(FactionState.AllOfThem.OrderBy(x => x.localizedName).Select(x => new KeyValuePair<string, FactionState>(x.localizedName, x)));
 
             configurationFromFile();
 


### PR DESCRIPTION
Went thru each dropdown menu in the UI and took a decision on how it should be sorted, commenting where necessary.
There the menu has a "None" option I left it at the top.
I did not sort squadron ranks as they are (or should be) enumerated in order of seniority.
Sorted the ship names and removed the speculative entries.

Fixes #961 