### PR TITLE
Revisions to prevent inaccurate star position data being reported to EDDN 

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.3.2
+  * Made revisions to prevent inaccurate star position data being reported to EDDN and refactored.
+  * The EDDN responder will now provide an audible warning if it detects that location data is in an invalid state.
+
 ### 3.3.1
   * EDDN responder
     * `CodexEntry` events are bugged and always return a SystemAddress of 1. These must be ignored by the EDDN responder to prevent sending bad data.

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -216,7 +216,7 @@ namespace EDDNResponder
                 invalidState = true;
                 if (sendToEddn)
                 {
-                    Logging.Warn("Invalid state in current star system information, unable to send messages to EDDN.", JsonConvert.SerializeObject(data));
+                    Logging.Warn("The EDDN responder is in an invalid state and is unable to send messages.", JsonConvert.SerializeObject(this) + " Event: " + JsonConvert.SerializeObject(data));
                     SpeechService.Instance.Say(null, EddiEddnResponder.Properties.EddnResources.errPosition, true);
                 }
             }

--- a/EDDNResponder/EddiEddnResponder.csproj
+++ b/EDDNResponder/EddiEddnResponder.csproj
@@ -104,6 +104,10 @@
       <Project>{2BB41C51-9BE0-49C9-91FD-C4E444994ECE}</Project>
       <Name>EddiEvents</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SpeechService\EddiSpeechService.csproj">
+      <Project>{19572a69-c13a-459d-ab72-2b0f034ac27f}</Project>
+      <Name>EddiSpeechService</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Utilities\Utilities.csproj">
       <Project>{CD71DD2A-86AC-44A8-959B-E1C3069966BD}</Project>
       <Name>Utilities</Name>

--- a/EDDNResponder/Properties/EddnResources.Designer.cs
+++ b/EDDNResponder/Properties/EddnResources.Designer.cs
@@ -70,6 +70,15 @@ namespace EddiEddnResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid state in current star system information, unable to send messages to EDDN. Please validate your position by either jumping out of the system and back in or by logging out and logging back in..
+        /// </summary>
+        public static string errPosition {
+            get {
+                return ResourceManager.GetString("errPosition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to EDDN Responder.
         /// </summary>
         public static string name {

--- a/EDDNResponder/Properties/EddnResources.Designer.cs
+++ b/EDDNResponder/Properties/EddnResources.Designer.cs
@@ -70,7 +70,7 @@ namespace EddiEddnResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid state in current star system information, unable to send messages to EDDN. Please validate your position by either jumping out of the system and back in or by logging out and logging back in..
+        ///   Looks up a localized string similar to The E D D N responder is in an invalid state and is unable to send messages. Please validate your position by either jumping out of the system and back in or by logging out and logging back in..
         /// </summary>
         public static string errPosition {
             get {

--- a/EDDNResponder/Properties/EddnResources.resx
+++ b/EDDNResponder/Properties/EddnResources.resx
@@ -123,4 +123,7 @@
   <data name="name" xml:space="preserve">
     <value>EDDN Responder</value>
   </data>
+  <data name="errPosition" xml:space="preserve">
+    <value>Invalid state in current star system information, unable to send messages to EDDN. Please validate your position by either jumping out of the system and back in or by logging out and logging back in.</value>
+  </data>
 </root>

--- a/EDDNResponder/Properties/EddnResources.resx
+++ b/EDDNResponder/Properties/EddnResources.resx
@@ -124,6 +124,6 @@
     <value>EDDN Responder</value>
   </data>
   <data name="errPosition" xml:space="preserve">
-    <value>Invalid state in current star system information, unable to send messages to EDDN. Please validate your position by either jumping out of the system and back in or by logging out and logging back in.</value>
+    <value>The E D D N responder is in an invalid state and is unable to send messages. Please validate your position by either jumping out of the system and back in or by logging out and logging back in.</value>
   </data>
 </root>

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -126,7 +126,7 @@ namespace UnitTests
         }
 
         [TestMethod()]
-        public void TestEDDNResponderBadMatchIsNull()
+        public void TestEDDNResponderBadStarPos()
         {
             EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();
             var privateObject = new PrivateObject(responder);
@@ -149,6 +149,28 @@ namespace UnitTests
         }
 
         [TestMethod()]
+        public void TestEDDNResponderBadSystemAddress()
+        {
+            EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();
+            var privateObject = new PrivateObject(responder);
+            // Intentionally place our EDDN responder in a state with incorrect SystemAddress (from Artemis).
+            privateObject.SetFieldOrProperty("systemName", "Sol");
+            privateObject.SetFieldOrProperty("systemAddress", 3107509474002);
+            privateObject.SetFieldOrProperty("systemX", 0.0M);
+            privateObject.SetFieldOrProperty("systemY", 0.0M);
+            privateObject.SetFieldOrProperty("systemZ", 0.0M);
+
+            bool confirmed = (bool)privateObject.Invoke("ConfirmAddressAndCoordinates", new object[] { "Sol" });
+
+            Assert.IsFalse(confirmed);
+            Assert.AreEqual("Sol", responder.systemName);
+            Assert.IsNull(responder.systemAddress);
+            Assert.AreEqual(0.0M, responder.systemX);
+            Assert.AreEqual(0.0M, responder.systemY);
+            Assert.AreEqual(0.0M, responder.systemZ);
+        }
+
+        [TestMethod()]
         public void TestEDDNResponderUnverifiableData()
         {
             EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();
@@ -160,6 +182,28 @@ namespace UnitTests
             privateObject.SetFieldOrProperty("systemZ", 0.0M);
 
             bool confirmed = (bool)privateObject.Invoke("ConfirmAddressAndCoordinates", new object[] { "Not in this galaxy" });
+
+            Assert.IsFalse(confirmed);
+            Assert.IsNull(responder.systemName);
+            Assert.IsNull(responder.systemAddress);
+            Assert.IsNull(responder.systemX);
+            Assert.IsNull(responder.systemY);
+            Assert.IsNull(responder.systemZ);
+        }
+
+        [TestMethod()]
+        public void TestEDDNResponderBadName()
+        {
+            // Tests that procedurally generated body names match the procedurally generated system name
+            EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();
+            var privateObject = new PrivateObject(responder);
+            privateObject.SetFieldOrProperty("systemName", "Pleiades Sector HR-W d1-79");
+            privateObject.SetFieldOrProperty("systemAddress", 2724879894859);
+            privateObject.SetFieldOrProperty("systemX", -80.62500M);
+            privateObject.SetFieldOrProperty("systemY", -146.65625M);
+            privateObject.SetFieldOrProperty("systemZ", -343.25000M);
+
+            bool confirmed = (bool)privateObject.Invoke("ConfirmScan", new object[] { "Hyades Sector DL-X b1-2" });
 
             Assert.IsFalse(confirmed);
             Assert.IsNull(responder.systemName);


### PR DESCRIPTION
Refactored.
The EDDN responder will now provide an audible warning if it detects that location data is in an invalid state.
Revised tests.