### PR TITLE
Fix body system metadata sometimes being not set.

### DIFF
--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -40,7 +40,13 @@ namespace EddiDataProviderService
                 if (showBodies)
                 {
                     List<Body> bodies = StarMapService.GetStarMapBodies(starSystem.name);
-                    starSystem.bodies = bodies;
+                    foreach (Body body in bodies)
+                    {
+                        body.systemname = starSystem.name;
+                        body.systemAddress = starSystem.systemAddress;
+                        body.systemEDDBID = starSystem.EDDBID;
+                        starSystem.bodies.Add(body);
+                    }
                 }
 
                 if (starSystem?.population > 0)

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1682,7 +1682,8 @@ namespace Eddi
                         EDDBID = -1,
                         Type = BodyType.FromEDName("Star"),
                         name = theEvent.name,
-                        systemname = CurrentStarSystem?.name
+                        systemname = CurrentStarSystem?.name,
+                        systemAddress = CurrentStarSystem?.systemAddress
                     };
                     CurrentStarSystem.bodies?.Add(star);
                 }
@@ -1723,7 +1724,8 @@ namespace Eddi
                         EDDBID = -1,
                         Type = BodyType.FromEDName("Planet"),
                         name = theEvent.name,
-                        systemname = CurrentStarSystem.name
+                        systemname = CurrentStarSystem.name,
+                        systemAddress = CurrentStarSystem?.systemAddress
                     };
                     CurrentStarSystem.bodies.Add(body);
                 }


### PR DESCRIPTION
Make sure that system metadata is populated for each body looked up from the server or scanned.