### PR TITLE
Fix missing events reported in Frontier Forums and observed from the EDDN responder output.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -5,6 +5,8 @@ Full details of the variables available for each noted event, and VoiceAttack in
 ### Development
   * Core
     * EDDI will now sync to the most current journal on startup (dramatically improving the accuracy of data available after startup)
+  * VoiceAttack plugin
+    * EDDI will no longer lose track of position data when you pass through a system where your squadron minor faction has influence.
 
 ### 3.3.3-b1
   * Core

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -116,6 +116,9 @@ namespace Eddi
         // Information from the last jump we initiated (for reference)
         public FSDEngagedEvent LastFSDEngagedEvent { get; private set; }
 
+        // Our main window, made accessible via the applicable EDDI Instance
+        public MainWindow MainWindow { get; internal set; }
+
         public ObservableConcurrentDictionary<string, object> State = new ObservableConcurrentDictionary<string, object>();
 
         /// <summary>
@@ -1474,16 +1477,12 @@ namespace Eddi
                         configuration.SquadronRank = rank;
 
                         // Update the squadron UI data
-                        if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                        Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                         {
-                            Application.Current.Dispatcher.Invoke(new Action(() =>
-                            {
-                                MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                                mw.eddiSquadronNameText.Text = theEvent.name;
-                                mw.squadronRankDropDown.SelectedItem = rank.localizedName;
-                                configuration = mw.resetSquadronRank(configuration);
-                            }));
-                        }
+                            Instance.MainWindow.eddiSquadronNameText.Text = theEvent.name;
+                            Instance.MainWindow.squadronRankDropDown.SelectedItem = rank.localizedName;
+                            configuration = Instance.MainWindow.resetSquadronRank(configuration);
+                        }));
 
                         // Update the commander object, if it exists
                         if (Cmdr != null)
@@ -1499,14 +1498,10 @@ namespace Eddi
                         configuration.SquadronName = theEvent.name;
 
                         // Update the squadron UI data
-                        if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                        Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                         {
-                            Application.Current.Dispatcher.Invoke(new Action(() =>
-                            {
-                                MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                                mw.eddiSquadronNameText.Text = theEvent.name;
-                            }));
-                        }
+                            Instance.MainWindow.eddiSquadronNameText.Text = theEvent.name;
+                        }));
 
                         // Update the commander object, if it exists
                         if (Cmdr != null)
@@ -1524,16 +1519,12 @@ namespace Eddi
                         configuration.SquadronID = null;
 
                         // Update the squadron UI data
-                        if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                        Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                         {
-                            Application.Current.Dispatcher.Invoke(new Action(() =>
-                            {
-                                MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                                mw.eddiSquadronNameText.Text = string.Empty;
-                                mw.eddiSquadronIDText.Text = string.Empty;
-                                configuration = mw.resetSquadronRank(configuration);
-                            }));
-                        }
+                            Instance.MainWindow.eddiSquadronNameText.Text = string.Empty;
+                            Instance.MainWindow.eddiSquadronIDText.Text = string.Empty;
+                            configuration = Instance.MainWindow.resetSquadronRank(configuration);
+                        }));
 
                         // Update the commander object, if it exists
                         if (Cmdr != null)
@@ -1558,15 +1549,11 @@ namespace Eddi
             configuration.ToFile();
 
             // Update the squadron UI data
-            if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+            Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
             {
-                Application.Current.Dispatcher.Invoke(new Action(() =>
-                {
-                    MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                    mw.eddiSquadronNameText.Text = theEvent.name;
-                    mw.squadronRankDropDown.SelectedItem = rank.localizedName;
-                }));
-            }
+                Instance.MainWindow.eddiSquadronNameText.Text = theEvent.name;
+                Instance.MainWindow.squadronRankDropDown.SelectedItem = rank.localizedName;
+            }));
 
             // Update the commander object, if it exists
             if (Cmdr != null)
@@ -2303,14 +2290,10 @@ namespace Eddi
                 {
                     configuration.SquadronFaction = faction.name;
 
-                    if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                    Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                     {
-                        Application.Current.Dispatcher.Invoke(new Action(() =>
-                        {
-                            MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                            mw.squadronFactionDropDown.SelectedItem = faction.name;
-                        }));
-                    }
+                        Instance.MainWindow.squadronFactionDropDown.SelectedItem = faction.name;
+                    }));
 
                     Cmdr.squadronfaction = faction.name;
                 }
@@ -2324,15 +2307,11 @@ namespace Eddi
                     {
                         configuration.SquadronSystem = system;
 
-                        if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                        Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                         {
-                            Application.Current.Dispatcher.Invoke(new Action(() =>
-                            {
-                                MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                                mw.eddiSquadronSystemText.Text = system;
-                                mw.ConfigureSquadronFactionOptions(configuration);
-                            }));
-                        }
+                            Instance.MainWindow.eddiSquadronSystemText.Text = system;
+                            Instance.MainWindow.ConfigureSquadronFactionOptions(configuration);
+                        }));
 
                         configuration = updateSquadronSystem(configuration, true);
                     }
@@ -2360,15 +2339,11 @@ namespace Eddi
                         {
                             configuration.SquadronPower = power;
 
-                            if (Application.Current != null) // We need to make sure our WPF and UI are initialized
+                            Instance.MainWindow?.Dispatcher?.Invoke(new Action(() =>
                             {
-                                Application.Current.Dispatcher.Invoke(new Action(() =>
-                                {
-                                    MainWindow mw = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                                    mw.squadronPowerDropDown.SelectedItem = power.localizedName;
-                                    mw.ConfigureSquadronPowerOptions(configuration);
-                                }));
-                            }
+                                Instance.MainWindow.squadronPowerDropDown.SelectedItem = power.localizedName;
+                                Instance.MainWindow.ConfigureSquadronPowerOptions(configuration);
+                            }));
                         }
                     }
                 }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -273,6 +273,7 @@ namespace Eddi
             LoadAndSortTabs(eddiConfiguration);
 
             RestoreWindowState();
+            EDDI.Instance.MainWindow = this;
             EDDI.Instance.Start();
         }
 


### PR DESCRIPTION
Makes MainWindow accessible via the EDDI instance.
Continuation of #1048.
- `Application.Current` is null if EDDI is started from VoiceAttack (since it is running in its plugin configuration).
- Attempts to invoke `Application.Current` from a machine running VoiceAttack are caught by EDDI's log and recorded as unhandled event errors.
- If EDDI's UI hasn't been invoked through VoiceAttack, we still won't have a MainWindow so we use a nullable invokation.