### PR TITLE
Incorporate Galnet regex tweak

### DIFF
--- a/GalnetMonitor/Properties/GalnetMonitor.Designer.cs
+++ b/GalnetMonitor/Properties/GalnetMonitor.Designer.cs
@@ -106,7 +106,7 @@ namespace EddiGalnetMonitor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &gt;@&quot;(has promised to reward pilots)|(The campaign.+will run for one week)|(The two organisations have set out week-long operations)|(Pilots.+can now collect their rewards)|(If the final target is met earlier than planned, the campaign will end immediately)&quot;.
+        ///   Looks up a localized string similar to &gt;@&quot;(promised to reward pilots)|(campaign.+will run for one week)|(organisations have set out week-long operations)|(collect.+rewards)|(If.+final target is met earlier than planned, the campaign will end immediately)&quot;.
         /// </summary>
         public static string contentFilterCgRegex {
             get {

--- a/GalnetMonitor/Properties/GalnetMonitor.resx
+++ b/GalnetMonitor/Properties/GalnetMonitor.resx
@@ -154,7 +154,7 @@
     <comment>The URL the Galnet monitor should access for obtaining new news feed items. Though adding new languages to the Galnet monitor is not yet supported, this helps lay the groundwork for Galnet in more languages in the future.</comment>
   </data>
   <data name="contentFilterCgRegex" xml:space="preserve">
-    <value>&gt;@"(has promised to reward pilots)|(The campaign.+will run for one week)|(The two organisations have set out week-long operations)|(Pilots.+can now collect their rewards)|(If the final target is met earlier than planned, the campaign will end immediately)"</value>
+    <value>&gt;@"(promised to reward pilots)|(campaign.+will run for one week)|(organisations have set out week-long operations)|(collect.+rewards)|(If.+final target is met earlier than planned, the campaign will end immediately)"</value>
     <comment>Regex filter for determining whether an item's contents match a Community Goal related item.</comment>
   </data>
   <data name="categoryArticle" xml:space="preserve">


### PR DESCRIPTION
Ref. #1090
Recommendation: Restore translated language regex filters after incorporation.