### PR TITLE
Improve handling of module events when shipyard contains minimal or no ship definition.

### DIFF
--- a/ShipMonitor/ModulePurchasedEvent.cs
+++ b/ShipMonitor/ModulePurchasedEvent.cs
@@ -26,7 +26,7 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
 
         [JsonProperty("shipid")]
         public int? shipid { get; private set; }
@@ -51,10 +51,11 @@ namespace EddiShipMonitor
 
         // Admin
         public long marketId { get; private set; }
+        public Ship shipDefinition { get; private set; }
 
         public ModulePurchasedEvent(DateTime timestamp, string ship, int? shipid, string slot, Module buymodule, long buyprice, Module sellmodule, long? sellprice, Module storedmodule, long marketId) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipid;
             this.slot = slot;
             this.buymodule = buymodule;

--- a/ShipMonitor/ModuleRetrievedEvent.cs
+++ b/ShipMonitor/ModuleRetrievedEvent.cs
@@ -25,7 +25,7 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
 
         [JsonProperty("shipid")]
         public int? shipid { get; private set; }
@@ -47,10 +47,11 @@ namespace EddiShipMonitor
 
         // Admin
         public long marketId { get; private set; }
+        public Ship shipDefinition { get; private set; }
 
         public ModuleRetrievedEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long? cost, string engineermodifications, Module swapoutmodule, long marketId) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModuleSoldEvent.cs
+++ b/ShipMonitor/ModuleSoldEvent.cs
@@ -23,7 +23,7 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
 
         [JsonProperty("shipid")]
         public int? shipid { get; private set; }
@@ -39,10 +39,11 @@ namespace EddiShipMonitor
 
         // Admin
         public long marketId { get; private set; }
+        public Ship shipDefinition { get; private set; }
 
         public ModuleSoldEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long price, long marketId) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModuleStoredEvent.cs
+++ b/ShipMonitor/ModuleStoredEvent.cs
@@ -19,11 +19,11 @@ namespace EddiShipMonitor
             VARIABLES.Add("slot", "The outfitting slot");
             VARIABLES.Add("module", "The module (object) being stored");
             VARIABLES.Add("cost", "The cost of storage (if any)");
-            VARIABLES.Add("engineermodificaiotns", "The name of the modification blueprint");
+            VARIABLES.Add("engineermodifications", "The name of the modification blueprint");
             VARIABLES.Add("replacementmodule", "The module (object) replacement (if a core module)");
         }
 
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
         public int? shipid { get; private set; }
         public string slot { get; private set; }
         public Module module { get; private set; }
@@ -33,10 +33,11 @@ namespace EddiShipMonitor
 
         // Admin
         public long marketId { get; private set; }
+        public Ship shipDefinition { get; private set; }
 
         public ModuleStoredEvent(DateTime timestamp, string ship, int? shipid, string slot, Module module, long? cost, string engineermodifications, Module replacementmodule, long marketId) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipid;
             this.slot = slot;
             this.module = module;

--- a/ShipMonitor/ModulesStored.cs
+++ b/ShipMonitor/ModulesStored.cs
@@ -22,7 +22,7 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
 
         [JsonProperty("shipid")]
         public int? shipid { get; private set; }
@@ -35,10 +35,11 @@ namespace EddiShipMonitor
 
         // Admin
         public long marketId { get; private set; }
+        public Ship shipDefinition { get; private set; }
 
         public ModulesStoredEvent(DateTime timestamp, string ship, int? shipid, List<string> slots, List<Module> modules, long marketId ) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipid;
             this.slots = slots;
             this.modules = modules;


### PR DESCRIPTION
- Fixes #1106
- If the shipyard does not contain a ship with a local id matching the event, create a basic ship from the module event to receive the event data, pulling in ship definitions (like military compartment sizes).
- Revise `AddModule` and `RemoveModule` events to ensure any exception results in no change to the shipyard.
- Add an appropriate test.

Fixes issues like https://rollbar.com/EDCD/EDDI/items/11363/occurrences/64537533570/
 ```
{"ship":"Federal Corvette","shipid":119,"slot":"Military01","buymodule":{"edname":"Int_GuardianShieldReinforcement_Size5_Class2","class":5,"grade":"D","value":995328,"ShipId":null,"mount":null,"clipcapacity":null,"hoppercapacity":null,"ammoinclip":null,"ammoinhopper":null,"price":873402,"enabled":true,"priority":1,"position":0,"power":0.0,"health":100.0,"hot":false,"modified":false,"modificationEDName":"None","engineerlevel":0,"engineerquality":0.0,"EDID":128833974,"EDDBID":-1},"buyprice":873402,"sellmodule":null,"sellprice":null,"storedmodule":null,"marketId":128666762,"raw":"{ \"timestamp\":\"2018-12-25T22:55:11Z\", \"event\":\"ModuleBuy\", \"Slot\":\"Military01\", \"BuyItem\":\"$int_guardianshieldreinforcement_size5_class2_name;\", \"BuyItem_Localised\":\"Guardian Shield Reinforcement\", \"MarketID\":128666762, \"BuyPrice\":873402, \"Ship\":\"federation_corvette\", \"ShipID\":119 }","timestamp":"2018-12-25T22:55:11Z","type":"Module purchased","fromLoad":true}

System.InvalidOperationException: Nullable object must have a value.
at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
at EddiShipMonitor.ShipMonitor.AddModule(Int32 shipid, String slot, Module module)
at EddiShipMonitor.ShipMonitor.handleModulePurchasedEvent(ModulePurchasedEvent event)
at EddiShipMonitor.ShipMonitor.PreHandle(Event event)
at Eddi.EDDI.OnEvent(Event event)
```