### PR TITLE
Locations Event factions Hotfix

### DIFF
--- a/DataDefinitions/FactionState.cs
+++ b/DataDefinitions/FactionState.cs
@@ -23,6 +23,8 @@
             var Famine = new FactionState("Famine");
             var Election = new FactionState("Election");
             var Investment = new FactionState("Investment");
+            var PirateAttack = new FactionState("PirateAttack");
+            var Incursion = new FactionState("Incursion");
         }
 
         public static readonly FactionState None = new FactionState("None");

--- a/DataDefinitions/Properties/FactionStates.Designer.cs
+++ b/DataDefinitions/Properties/FactionStates.Designer.cs
@@ -133,6 +133,15 @@ namespace EddiDataDefinitions.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Incursion.
+        /// </summary>
+        public static string Incursion {
+            get {
+                return ResourceManager.GetString("Incursion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Investment.
         /// </summary>
         public static string Investment {
@@ -165,6 +174,15 @@ namespace EddiDataDefinitions.Properties {
         public static string Outbreak {
             get {
                 return ResourceManager.GetString("Outbreak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pirate Attack.
+        /// </summary>
+        public static string PirateAttack {
+            get {
+                return ResourceManager.GetString("PirateAttack", resourceCulture);
             }
         }
         

--- a/DataDefinitions/Properties/FactionStates.resx
+++ b/DataDefinitions/Properties/FactionStates.resx
@@ -1,76 +1,96 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-		Microsoft ResX Schema
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -89,13 +109,13 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="None" xml:space="preserve">
     <value>None</value>
@@ -152,5 +172,13 @@
   <data name="CivilLiberty" xml:space="preserve">
     <value>Civil Liberty</value>
     <comment>Faction state CivilLiberty</comment>
+  </data>
+  <data name="Incursion" xml:space="preserve">
+    <value>Incursion</value>
+    <comment>Faction state Incursion</comment>
+  </data>
+  <data name="PirateAttack" xml:space="preserve">
+    <value>Pirate Attack</value>
+    <comment>Faction state PirateAttack</comment>
   </data>
 </root>

--- a/Events/DockedEvent.cs
+++ b/Events/DockedEvent.cs
@@ -43,21 +43,13 @@ namespace EddiEvents
 
         public string model => stationModel.localizedName;
 
-        public string allegiance => Allegiance.localizedName;
-
-        public string faction { get; private set; }
-
-        public string factionstate => factionState.localizedName;
-
         public string economy => economyShares.Count > 0 ? (economyShares[0]?.economy ?? Economy.None).localizedName : Economy.None.localizedName;
 
         public string secondeconomy => economyShares.Count > 1 ? (economyShares[1]?.economy ?? Economy.None).localizedName : Economy.None.localizedName;
 
-        public string government => Government.localizedName;
-
         public decimal? distancefromstar { get; private set; }
 
-        public List<string> stationservices 
+        public List<string> stationservices
         {
             get
             {
@@ -74,16 +66,22 @@ namespace EddiEvents
         public bool wanted { get; private set; }
         public bool activefine { get; private set; }
 
+        // Faction properties
+        public string faction => controllingfaction?.name;
+        public string factionstate => (controllingfaction?.FactionState ?? FactionState.None).localizedName;
+        public string allegiance => (controllingfaction?.Allegiance ?? Superpower.None).localizedName;
+        public string government => (controllingfaction?.Government ?? Government.None).localizedName;
+
         // These properties are not intended to be user facing
         public long systemAddress { get; private set; }
         public StationModel stationModel { get; private set; } = StationModel.None;
-        public Superpower Allegiance { get; private set; } = Superpower.None;
+        public Faction controllingfaction { get; private set; }
         public List<StationService> stationServices { get; private set; } = new List<StationService>();
         public FactionState factionState { get; private set; } = FactionState.None;
-        public Government Government { get; private set; } = Government.None;
+
         public List<EconomyShare> economyShares { get; private set; } = new List<EconomyShare>() { new EconomyShare(Economy.None, 0M), new EconomyShare(Economy.None, 0M) };
 
-        public DockedEvent(DateTime timestamp, string system, long systemAddress, long marketId, string station, string state, StationModel stationModel, Superpower Allegiance, string faction, FactionState factionState, List<EconomyShare> Economies, Government Government, decimal? distancefromstar, List<StationService> stationServices, bool cockpitBreach, bool wanted, bool activeFine) : base(timestamp, NAME)
+        public DockedEvent(DateTime timestamp, string system, long systemAddress, long marketId, string station, string state, StationModel stationModel, Faction controllingfaction, List<EconomyShare> Economies, decimal? distancefromstar, List<StationService> stationServices, bool cockpitBreach, bool wanted, bool activeFine) : base(timestamp, NAME)
         {
             this.system = system;
             this.systemAddress = systemAddress;
@@ -91,11 +89,8 @@ namespace EddiEvents
             this.station = station;
             this.state = state;
             this.stationModel = stationModel ?? StationModel.None;
-            this.Allegiance = Allegiance ?? Superpower.None;
-            this.faction = faction;
-            this.factionState = factionState ?? FactionState.None;
+            this.controllingfaction = controllingfaction;
             this.economyShares = Economies;
-            this.Government = Government ?? Government.None;
             this.distancefromstar = distancefromstar;
             this.stationServices = stationServices;
             this.cockpitbreach = cockpitBreach;

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -29,7 +29,8 @@ namespace EddiEvents
             VARIABLES.Add("government", "The government of the system to which the commander has jumped");
             VARIABLES.Add("security", "The security of the system to which the commander has jumped");
             VARIABLES.Add("population", "The population of the system to which the commander has jumped");
-            VARIABLES.Add("factions", "The factions in the system (this is a list of faction objects)");
+            VARIABLES.Add("destination", "The route destination system, if any");
+            VARIABLES.Add("destdistance", "The distance to the destination system)");
         }
 
         public string system { get; private set; }
@@ -50,17 +51,9 @@ namespace EddiEvents
 
         public int? boostused { get; private set; }
 
-        public string allegiance => (Allegiance ?? Superpower.None).localizedName;
-
-        public string faction { get; private set; }
-
-        public string factionstate => (factionState ?? FactionState.None).localizedName;
-
         public string economy => (Economy ?? Economy.None).localizedName;
 
         public string economy2 => (Economy2 ?? Economy.None).localizedName;
-
-        public string government => (Government ?? Government.None).localizedName;
 
         public string security => (securityLevel ?? SecurityLevel.None).localizedName;
 
@@ -68,16 +61,21 @@ namespace EddiEvents
 
         public List<Faction> factions { get; private set; }
 
+        // Faction properties
+        public string faction => controllingfaction?.name;
+        public string factionstate => (controllingfaction?.FactionState ?? FactionState.None).localizedName;
+        public string allegiance => (controllingfaction?.Allegiance ?? Superpower.None).localizedName;
+        public string government => (controllingfaction?.Government ?? Government.None).localizedName;
+
         // These properties are not intended to be user facing
         public long systemAddress { get; private set; }
         public Economy Economy { get; private set; } = Economy.None;
         public Economy Economy2 { get; private set; } = Economy.None;
-        public Superpower Allegiance { get; private set; } = Superpower.None;
-        public Government Government { get; private set; } = Government.None;
+        public Faction controllingfaction { get; private set; }
         public SecurityLevel securityLevel { get; private set; } = SecurityLevel.None;
         public FactionState factionState { get; private set; } = FactionState.None;
 
-        public JumpedEvent(DateTime timestamp, string system, long systemAddress, decimal x, decimal y, decimal z, string star, decimal distance, decimal fuelused, decimal fuelremaining, int? boostUsed, Superpower allegiance, string faction, FactionState factionstate, Economy economy, Economy economy2, Government government, SecurityLevel security, long? population, List<Faction> factions) : base(timestamp, NAME)
+        public JumpedEvent(DateTime timestamp, string system, long systemAddress, decimal x, decimal y, decimal z, string star, decimal distance, decimal fuelused, decimal fuelremaining, int? boostUsed, Faction controllingfaction, Economy economy, Economy economy2, SecurityLevel security, long? population, List<Faction> factions) : base(timestamp, NAME)
         {
             this.system = system;
             this.systemAddress = systemAddress;
@@ -89,12 +87,9 @@ namespace EddiEvents
             this.fuelused = fuelused;
             this.fuelremaining = fuelremaining;
             this.boostused = boostUsed;
-            this.Allegiance = (allegiance ?? Superpower.None);
-            this.faction = faction;
-            this.factionState = (factionstate ?? FactionState.None);
+            this.controllingfaction = controllingfaction;
             this.Economy = (economy ?? Economy.None);
             this.Economy2 = (economy2 ?? Economy.None);
-            this.Government = (government ?? Government.None);
             this.securityLevel = (security ?? SecurityLevel.None);
             this.population = population;
             this.factions = factions;

--- a/Events/LocationEvent.cs
+++ b/Events/LocationEvent.cs
@@ -24,17 +24,27 @@ namespace EddiEvents
             VARIABLES.Add("station", "The name of the station at which the commander is docked");
             VARIABLES.Add("marketId", "The market ID of the station at which the commander is docked");
             VARIABLES.Add("stationtype", "The type of the station at which the commander is docked");
-            VARIABLES.Add("allegiance", "The allegiance of the system in which the commander resides");
+
+            // Pre-3.3.03 faction variables
             VARIABLES.Add("faction", "The faction controlling the system in which the commander resides");
             VARIABLES.Add("factionstate", "The state of the faction controlling the system in which the commander resides");
+            VARIABLES.Add("government", "The government of the system in which the commander resides");
+            VARIABLES.Add("allegiance", "The allegiance of the system in which the commander resides");
+
+            // Post-3.3.03 faction variables
+            VARIABLES.Add("systemfaction", "The faction controlling the system in which the commander resides");
+            VARIABLES.Add("systemstate", "The state of the faction controlling the system in which the commander resides");
+            VARIABLES.Add("systemgovernment", "The government of the system in which the commander resides");
+            VARIABLES.Add("stationfaction", "The faction controlling the station, if the commander is docked");
+            VARIABLES.Add("stationstate", "The state of the faction controlling the station, if the commander is docked");
+            VARIABLES.Add("stationgovernment", "The government of the station, if the commander is docked");
+
             VARIABLES.Add("economy", "The economy of the system in which the commander resides");
             VARIABLES.Add("economy2", "The secondary economy of the system in which the commander resides, if any");
-            VARIABLES.Add("government", "The government of the system in which the commander resides");
             VARIABLES.Add("security", "The security of the system in which the commander resides");
             VARIABLES.Add("longitude", "The longitude of the commander (if on the ground)");
             VARIABLES.Add("latitude", "The latitude of the commander (if on the ground)");
             VARIABLES.Add("population", "The population of the system to which the commander has jumped");
-            VARIABLES.Add("factions", "The factions in the system (this is a list of faction objects)");
         }
 
         public string system { get; private set; }
@@ -55,17 +65,10 @@ namespace EddiEvents
 
         public string stationtype => (stationModel ?? StationModel.None).localizedName;
 
-        public string allegiance => (Allegiance ?? Superpower.None).localizedName;
-
-        public string faction { get; private set; }
-
-        public string factionstate => (factionState ?? FactionState.None).localizedName;
-
         public string economy => (Economy ?? Economy.None).localizedName;
 
         public string economy2 => (Economy2 ?? Economy.None).localizedName;
 
-        public string government => (Government ?? Government.None).localizedName;
 
         public string security => (securityLevel ?? SecurityLevel.None).localizedName;
 
@@ -75,21 +78,35 @@ namespace EddiEvents
 
         public decimal? latitude { get; private set; }
 
-        public List<Faction> factions { get; private set; }
+        // Pre-3.3.03 faction properties to maintain script/profile backwards compatability
+        public string faction => controllingsystemfaction?.name;
+        public string factionstate => (controllingsystemfaction?.FactionState ?? FactionState.None).localizedName;
+        public string government => (controllingsystemfaction?.Government ?? Government.None).localizedName;
+        public string allegiance => (controllingsystemfaction?.Allegiance ?? Superpower.None).localizedName;
+
+        // Post-3.3.03 faction properties
+        public string systemfaction => controllingsystemfaction?.name;
+        public string systemstate => (controllingsystemfaction?.FactionState ?? FactionState.None).localizedName;
+        public string systemgovernment => (controllingsystemfaction?.Government ?? Government.None).localizedName;
+        public string systemallegiance => (controllingsystemfaction?.Allegiance ?? Superpower.None).localizedName;
+        public string stationfaction => controllingstationfaction?.name;
+        public string stationstate => (controllingstationfaction?.FactionState ?? FactionState.None).localizedName;
+        public string stationgovernment => (controllingstationfaction?.Government ?? Government.None).localizedName;
+        public string stationallegiancet => (controllingstationfaction?.Allegiance ?? Superpower.None).localizedName;
 
         // These properties are not intended to be user facing
         public long? systemAddress { get; private set; }
         public long? marketId { get; private set; }
         public Economy Economy { get; private set; } = Economy.None;
         public Economy Economy2 { get; private set; } = Economy.None;
-        public Superpower Allegiance { get; private set; } = Superpower.None;
-        public Government Government { get; private set; } = Government.None;
+        public Faction controllingsystemfaction { get; private set; }
+        public Faction controllingstationfaction { get; private set; }
+        public List<Faction> factions { get; private set; }
         public SecurityLevel securityLevel { get; private set; } = SecurityLevel.None;
-        public FactionState factionState { get; private set; } = FactionState.None;
         public StationModel stationModel { get; private set; } = StationModel.None;
         public BodyType bodyType { get; private set; } = BodyType.None;
 
-        public LocationEvent(DateTime timestamp, string system, decimal x, decimal y, decimal z, long systemAddress, string body, BodyType bodytype, bool docked, string station, StationModel stationtype, long? marketId, Superpower allegiance, string faction, FactionState factionstate, Economy economy, Economy economy2, Government government, SecurityLevel security, long? population, decimal? longitude, decimal? latitude, List<Faction> factions) : base(timestamp, NAME)
+        public LocationEvent(DateTime timestamp, string system, decimal x, decimal y, decimal z, long systemAddress, string body, BodyType bodytype, bool docked, string station, StationModel stationtype, long? marketId, Faction systemFaction, Faction stationFaction, Economy economy, Economy economy2, SecurityLevel security, long? population, decimal? longitude, decimal? latitude, List<Faction> factions) : base(timestamp, NAME)
         {
             this.system = system;
             this.x = x;
@@ -102,11 +119,10 @@ namespace EddiEvents
             this.station = station;
             this.stationModel = stationtype;
             this.marketId = marketId;
-            this.Allegiance = allegiance;
-            this.faction = faction;
+            this.controllingsystemfaction = systemFaction;
+            this.controllingstationfaction = stationFaction;
             this.Economy = (economy ?? Economy.None);
             this.Economy2 = (economy2 ?? Economy.None);
-            this.Government = government;
             this.securityLevel = security;
             this.population = population;
             this.longitude = longitude;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -105,7 +105,7 @@ namespace EddiJournalMonitor
                                     string stationName = JsonParsing.getString(data, "StationName");
                                     string stationState = JsonParsing.getString(data, "StationState") ?? string.Empty;
                                     StationModel stationModel = StationModel.FromEDName(JsonParsing.getString(data, "StationType") ?? "None");
-                                    Faction controllingfaction = getFactionData(data, "Station");
+                                    Faction controllingfaction = getFaction(data, "Station");
                                     decimal? distancefromstar = JsonParsing.getOptionalDecimal(data, "DistFromStarLS");
 
                                     // Get station services data
@@ -197,7 +197,7 @@ namespace EddiJournalMonitor
                                     decimal fuelRemaining = JsonParsing.getDecimal(data, "FuelLevel");
                                     int? boostUsed = JsonParsing.getOptionalInt(data, "BoostUsed"); // 1-3 are synthesis, 4 is any supercharge (white dwarf or neutron star)
                                     decimal distance = JsonParsing.getDecimal(data, "JumpDist");
-                                    Faction controllingfaction = getFactionData(data, "System");
+                                    Faction controllingfaction = getFaction(data, "System");
                                     Economy economy = Economy.FromEDName(JsonParsing.getString(data, "SystemEconomy") ?? "$economy_None");
                                     Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy") ?? "$economy_None"); ;
                                     SecurityLevel security = SecurityLevel.FromEDName(JsonParsing.getString(data, "SystemSecurity") ?? "None");
@@ -235,8 +235,8 @@ namespace EddiJournalMonitor
                                     string body = JsonParsing.getString(data, "Body");
                                     BodyType bodyType = BodyType.FromEDName(JsonParsing.getString(data, "BodyType"));
                                     bool docked = JsonParsing.getBool(data, "Docked");
-                                    Faction systemfaction = getFactionData(data, "System");
-                                    Faction stationfaction = getFactionData(data, "Station");
+                                    Faction systemfaction = getFaction(data, "System");
+                                    Faction stationfaction = getFaction(data, "Station");
                                     Economy economy = Economy.FromEDName(JsonParsing.getString(data, "SystemEconomy"));
                                     Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy"));
                                     SecurityLevel security = SecurityLevel.FromEDName(JsonParsing.getString(data, "SystemSecurity"));
@@ -274,7 +274,7 @@ namespace EddiJournalMonitor
                                         target = ship.model;
                                     }
 
-                                    string victimFaction = getFaction(data, "VictimFaction");
+                                    string victimFaction = getFactionName(data, "VictimFaction");
 
                                     data.TryGetValue("SharedWithOthers", out object val);
                                     bool shared = false;
@@ -296,7 +296,7 @@ namespace EddiJournalMonitor
                                             // 0-credit reward; ignore
                                             break;
                                         }
-                                        string factionName = getFaction(data, "Faction");
+                                        string factionName = getFactionName(data, "Faction");
                                         rewards.Add(new Reward(factionName, reward));
                                     }
                                     else
@@ -315,7 +315,7 @@ namespace EddiJournalMonitor
                                         {
                                             foreach (Dictionary<string, object> rewardData in rewardsData)
                                             {
-                                                string factionName = getFaction(rewardData, "Faction");
+                                                string factionName = getFactionName(rewardData, "Faction");
                                                 rewardData.TryGetValue("Reward", out val);
                                                 long factionReward = (long)val;
 
@@ -334,16 +334,16 @@ namespace EddiJournalMonitor
                                 {
                                     data.TryGetValue("Reward", out object val);
                                     long reward = (long)val;
-                                    string victimFaction = getFaction(data, "VictimFaction");
+                                    string victimFaction = getFactionName(data, "VictimFaction");
 
                                     if (data.ContainsKey("AwardingFaction"))
                                     {
-                                        string awardingFaction = getFaction(data, "AwardingFaction");
+                                        string awardingFaction = getFactionName(data, "AwardingFaction");
                                         events.Add(new BondAwardedEvent(timestamp, awardingFaction, victimFaction, reward) { raw = line, fromLoad = fromLogLoad });
                                     }
                                     else if (data.ContainsKey("PayeeFaction"))
                                     {
-                                        string payeeFaction = getFaction(data, "PayeeFaction");
+                                        string payeeFaction = getFactionName(data, "PayeeFaction");
                                         events.Add(new DataVoucherAwardedEvent(timestamp, payeeFaction, victimFaction, reward) { raw = line, fromLoad = fromLogLoad });
                                     }
                                 }
@@ -353,7 +353,7 @@ namespace EddiJournalMonitor
                                 {
                                     object val;
                                     string crimetype = JsonParsing.getString(data, "CrimeType");
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     string victim = JsonParsing.getString(data, "Victim");
                                     // Might be a fine or a bounty
                                     if (data.ContainsKey("Fine"))
@@ -1450,7 +1450,7 @@ namespace EddiJournalMonitor
                                     bool iscommander = JsonParsing.getBool(data, "IsPlayer");
                                     data.TryGetValue("CombatRank", out object val);
                                     CombatRating rating = (val == null ? null : CombatRating.FromRank((int)val));
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     string power = JsonParsing.getString(data, "Power");
 
                                     events.Add(new ShipInterdictedEvent(timestamp, true, submitted, iscommander, interdictor, rating, faction, power) { raw = line, fromLoad = fromLogLoad });
@@ -1473,7 +1473,7 @@ namespace EddiJournalMonitor
                                     bool iscommander = JsonParsing.getBool(data, "IsPlayer");
                                     data.TryGetValue("CombatRank", out object val);
                                     CombatRating rating = (val == null ? null : CombatRating.FromRank((int)val));
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     string power = JsonParsing.getString(data, "Power");
 
                                     events.Add(new ShipInterdictionEvent(timestamp, success, iscommander, interdictee, rating, faction, power) { raw = line, fromLoad = fromLogLoad });
@@ -1884,7 +1884,7 @@ namespace EddiJournalMonitor
                             case "FSSSignalDiscovered":
                                 {
                                     SignalSource source = GetSignalSource(data);
-                                    string spawningFaction = getFaction(data, "SpawningFaction") ?? Superpower.None.localizedName; // the minor faction, if relevant
+                                    string spawningFaction = getFactionName(data, "SpawningFaction") ?? Superpower.None.localizedName; // the minor faction, if relevant
                                     decimal? secondsRemaining = JsonParsing.getOptionalDecimal(data, "TimeRemaining"); // remaining lifetime in seconds, if relevant
 
                                     string spawningstate = JsonParsing.getString(data, "SpawningState");
@@ -2146,7 +2146,7 @@ namespace EddiJournalMonitor
                             case "CrewHire":
                                 {
                                     string name = JsonParsing.getString(data, "Name");
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     long price = JsonParsing.getLong(data, "Cost");
                                     CombatRating rating = CombatRating.FromRank(JsonParsing.getInt(data, "CombatRank"));
                                     events.Add(new CrewHiredEvent(timestamp, name, faction, price, rating) { raw = line, fromLoad = fromLogLoad });
@@ -2354,7 +2354,7 @@ namespace EddiJournalMonitor
                                     data.TryGetValue("Amount", out object val);
                                     long amount = (long)val;
                                     decimal? brokerpercentage = JsonParsing.getOptionalDecimal(data, "BrokerPercentage");
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     data.TryGetValue("ShipID", out val);
                                     int shipId = (int)(long)val;
 
@@ -2368,7 +2368,7 @@ namespace EddiJournalMonitor
                                     long amount = (long)val;
                                     decimal? brokerpercentage = JsonParsing.getOptionalDecimal(data, "BrokerPercentage");
                                     bool allFines = JsonParsing.getBool(data, "AllFines");
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     data.TryGetValue("ShipID", out val);
                                     int shipId = (int)(long)val;
 
@@ -2459,7 +2459,7 @@ namespace EddiJournalMonitor
                                     {
                                         foreach (Dictionary<string, object> rewardData in factionsData)
                                         {
-                                            string factionName = getFaction(rewardData, "Faction");
+                                            string factionName = getFactionName(rewardData, "Faction");
                                             rewardData.TryGetValue("Amount", out val);
                                             long factionReward = (long)val;
 
@@ -2468,7 +2468,7 @@ namespace EddiJournalMonitor
                                     }
                                     else
                                     {
-                                        string factionName = getFaction(data, "Faction");
+                                        string factionName = getFactionName(data, "Faction");
                                         data.TryGetValue("Amount", out val);
                                         long factionReward = (long)val;
 
@@ -2688,7 +2688,7 @@ namespace EddiJournalMonitor
                                     DateTime? expiry = (val == null ? (DateTime?)null : (DateTime)val);
                                     string name = JsonParsing.getString(data, "Name");
                                     string localisedname = JsonParsing.getString(data, "LocalisedName");
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
                                     int? reward = JsonParsing.getOptionalInt(data, "Reward");
                                     bool wing = JsonParsing.getBool(data, "Wing");
 
@@ -2704,7 +2704,7 @@ namespace EddiJournalMonitor
                                     // Missions with targets
                                     string target = JsonParsing.getString(data, "Target");
                                     string targettype = JsonParsing.getString(data, "TargetType");
-                                    string targetfaction = getFaction(data, "TargetFaction");
+                                    string targetfaction = getFactionName(data, "TargetFaction");
                                     data.TryGetValue("KillCount", out val);
                                     if (val != null)
                                     {
@@ -2738,7 +2738,7 @@ namespace EddiJournalMonitor
                                     data.TryGetValue("Reward", out val);
                                     long reward = (val == null ? 0 : (long)val);
                                     long donation = JsonParsing.getOptionalLong(data, "Donated") ?? 0;
-                                    string faction = getFaction(data, "Faction");
+                                    string faction = getFactionName(data, "Faction");
 
                                     // Missions with commodities
                                     CommodityDefinition commodity = CommodityDefinition.FromEDName(JsonParsing.getString(data, "Commodity"));
@@ -3250,10 +3250,73 @@ namespace EddiJournalMonitor
             return source;
         }
 
+        private static Superpower getAllegiance(IDictionary<string, object> data, string key)
+        {
+            data.TryGetValue(key, out object val);
+            // FD sends "" rather than null; fix that here
+            if (((string)val) == "") { val = null; }
+            return Superpower.FromNameOrEdName((string)val);
+        }
+
+        private static string getFactionName(IDictionary<string, object> data, string key)
+        {
+            string faction = JsonParsing.getString(data, key);
+            // Might be a superpower...
+            Superpower superpowerFaction = Superpower.FromNameOrEdName(faction);
+            return superpowerFaction?.invariantName ?? faction;
+        }
+
+        private static Faction getFaction(IDictionary<string, object> data, string type)
+        {
+            Faction faction = new Faction();
+
+            // Get the faction name & state
+            if (data.TryGetValue(type + "Faction", out object val))
+            {
+                Dictionary<string, object> factionData = val as Dictionary<string, object>;
+                if (factionData != null) // 3.3.03 or later journal
+                {
+                    faction.name = JsonParsing.getString(factionData, "Name");
+                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(factionData, "FactionState") ?? "None");
+                }
+                else // per-3.3.03 journal
+                {
+                    faction.name = val as string;
+                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(data, "FactionState") ?? "None");
+                }
+            }
+
+            // Get the faction allegiance
+            if (data.TryGetValue(type + "Allegiance", out val))
+            {
+                faction.Allegiance = getAllegiance(data, type + "Allegiance");
+            }
+
+            // Station controlling faction government not discretely available in 'Location' event
+            else if (data.TryGetValue("Factions", out val))
+            {
+                var factionsList = val as List<object>;
+                foreach (IDictionary<string, object> factionDetail in factionsList)
+                {
+                    string fName = JsonParsing.getString(factionDetail, "Name");
+                    if (fName == faction.name)
+                    {
+                        faction.Allegiance = getAllegiance(factionDetail, "Allegiance");
+                        break;
+                    }
+                }
+            }
+
+            // Get the controlling faction (system or station) government
+            faction.Government = Government.FromEDName(JsonParsing.getString(data, type + "Government") ?? "None");
+
+            return faction;
+        }
+
         private static List<Faction> getFactions(object factionsVal)
         {
             List<Faction> factions = new List<Faction>();
-            var factionsList = (List<object>)factionsVal;
+            var factionsList = factionsVal as List<object>;
             foreach (IDictionary<string, object> factionDetail in factionsList)
             {
                 // Core data
@@ -3542,66 +3605,6 @@ namespace EddiJournalMonitor
         public IDictionary<string, object> GetVariables()
         {
             return null;
-        }
-
-        private static Superpower getAllegiance(IDictionary<string, object> data, string key)
-        {
-            data.TryGetValue(key, out object val);
-            // FD sends "" rather than null; fix that here
-            if (((string)val) == "") { val = null; }
-            return Superpower.FromNameOrEdName((string)val);
-        }
-
-        private static string getFaction(IDictionary<string, object> data, string key)
-        {
-            string faction = JsonParsing.getString(data, key);
-            // Might be a superpower...
-            Superpower superpowerFaction = Superpower.FromNameOrEdName(faction);
-            return superpowerFaction?.invariantName ?? faction;
-        }
-
-        private static Faction getFactionData(IDictionary<string, object> data, string type)
-        {
-            Faction faction = new Faction();
-
-            // Get the faction name & state
-            if (data.TryGetValue(type + "Faction", out object val))
-            {
-                Dictionary<string, object> factionData = val as Dictionary<string, object>;
-                if (factionData != null) // 3.3.03 or later journal
-                {
-                    faction.name = JsonParsing.getString(factionData, "Name");
-                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(factionData, "FactionState") ?? "None");
-                }
-                else // per-3.3.03 journal
-                {
-                    faction.name = val as string;
-                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(data, "FactionState") ?? "None");
-                }
-            }
-
-            // Get the faction government
-            faction.Government = Government.FromEDName(JsonParsing.getString(data, type + "Government") ?? "None");
-
-            // Get the faction allegiance
-            if (data.TryGetValue(type + "Allegiance", out val))
-            {
-                faction.Allegiance = getAllegiance(data, type + "Allegiance");
-            }
-            else if (data.TryGetValue("Factions", out val))
-            {
-                var factionsList = val as List<object>;
-                foreach (IDictionary<string, object> factionDetail in factionsList)
-                {
-                    string fName = JsonParsing.getString(factionDetail, "Name");
-                    if (fName == faction.name)
-                    {
-                        faction.Allegiance = getAllegiance(factionDetail, "Allegiance");
-                        break;
-                    }
-                }
-            }
-            return faction;
         }
 
         private static string getRole(IDictionary<string, object> data, string key)

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -105,9 +105,7 @@ namespace EddiJournalMonitor
                                     string stationName = JsonParsing.getString(data, "StationName");
                                     string stationState = JsonParsing.getString(data, "StationState") ?? string.Empty;
                                     StationModel stationModel = StationModel.FromEDName(JsonParsing.getString(data, "StationType") ?? "None");
-                                    Superpower allegiance = getAllegiance(data, "StationAllegiance") ?? Superpower.None;
-                                    Faction faction = getFactionData(data, "StationFaction");
-                                    Government government = Government.FromEDName(JsonParsing.getString(data, "StationGovernment" ?? "None"));
+                                    Faction controllingfaction = getFactionData(data, "Station");
                                     decimal? distancefromstar = JsonParsing.getOptionalDecimal(data, "DistFromStarLS");
 
                                     // Get station services data
@@ -138,7 +136,7 @@ namespace EddiJournalMonitor
                                     bool wanted = JsonParsing.getOptionalBool(data, "Wanted") ?? false;
                                     bool activeFine = JsonParsing.getOptionalBool(data, "ActiveFine") ?? false;
 
-                                    events.Add(new DockedEvent(timestamp, systemName, systemAddress, marketId, stationName, stationState, stationModel, allegiance, faction.name, faction.FactionState, Economies, government, distancefromstar, stationServices, cockpitBreach, wanted, activeFine) { raw = line, fromLoad = fromLogLoad });
+                                    events.Add(new DockedEvent(timestamp, systemName, systemAddress, marketId, stationName, stationState, stationModel, controllingfaction, Economies, distancefromstar, stationServices, cockpitBreach, wanted, activeFine) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;
                                 break;
@@ -199,11 +197,9 @@ namespace EddiJournalMonitor
                                     decimal fuelRemaining = JsonParsing.getDecimal(data, "FuelLevel");
                                     int? boostUsed = JsonParsing.getOptionalInt(data, "BoostUsed"); // 1-3 are synthesis, 4 is any supercharge (white dwarf or neutron star)
                                     decimal distance = JsonParsing.getDecimal(data, "JumpDist");
-                                    Superpower allegiance = getAllegiance(data, "SystemAllegiance");
-                                    Faction faction = getFactionData(data, "SystemFaction");
+                                    Faction controllingfaction = getFactionData(data, "System");
                                     Economy economy = Economy.FromEDName(JsonParsing.getString(data, "SystemEconomy") ?? "$economy_None");
-                                    Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy") ?? "$economy_None");
-                                    Government government = Government.FromEDName(JsonParsing.getString(data, "SystemGovernment") ?? "$government_None;");
+                                    Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy") ?? "$economy_None"); ;
                                     SecurityLevel security = SecurityLevel.FromEDName(JsonParsing.getString(data, "SystemSecurity") ?? "None");
                                     long? population = JsonParsing.getOptionalLong(data, "Population");
 
@@ -215,7 +211,7 @@ namespace EddiJournalMonitor
                                         factions = getFactions(factionsVal);
                                     }
 
-                                    events.Add(new JumpedEvent(timestamp, systemName, systemAddress, x, y, z, starName, distance, fuelUsed, fuelRemaining, boostUsed, allegiance, faction.name, faction.FactionState, economy, economy2, government, security, population, factions) { raw = line, fromLoad = fromLogLoad });
+                                    events.Add(new JumpedEvent(timestamp, systemName, systemAddress, x, y, z, starName, distance, fuelUsed, fuelRemaining, boostUsed, controllingfaction, economy, economy2, security, population, factions) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;
                                 break;
@@ -239,11 +235,10 @@ namespace EddiJournalMonitor
                                     string body = JsonParsing.getString(data, "Body");
                                     BodyType bodyType = BodyType.FromEDName(JsonParsing.getString(data, "BodyType"));
                                     bool docked = JsonParsing.getBool(data, "Docked");
-                                    Superpower allegiance = getAllegiance(data, "SystemAllegiance");
-                                    Faction faction = getFactionData(data, "SystemFaction");
+                                    Faction systemfaction = getFactionData(data, "System");
+                                    Faction stationfaction = getFactionData(data, "Station");
                                     Economy economy = Economy.FromEDName(JsonParsing.getString(data, "SystemEconomy"));
                                     Economy economy2 = Economy.FromEDName(JsonParsing.getString(data, "SystemSecondEconomy"));
-                                    Government government = Government.FromEDName(JsonParsing.getString(data, "SystemGovernment"));
                                     SecurityLevel security = SecurityLevel.FromEDName(JsonParsing.getString(data, "SystemSecurity"));
                                     long? population = JsonParsing.getOptionalLong(data, "Population");
 
@@ -264,7 +259,7 @@ namespace EddiJournalMonitor
                                         factions = getFactions(factionsVal);
                                     }
 
-                                    events.Add(new LocationEvent(timestamp, systemName, x, y, z, systemAddress, body, bodyType, docked, station, stationtype, marketId, allegiance, faction.name, faction.FactionState, economy, economy2, government, security, population, longitude, latitude, factions) { raw = line, fromLoad = fromLogLoad });
+                                    events.Add(new LocationEvent(timestamp, systemName, x, y, z, systemAddress, body, bodyType, docked, station, stationtype, marketId, systemfaction, stationfaction, economy, economy2, security, population, longitude, latitude, factions) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;
                                 break;
@@ -3266,6 +3261,7 @@ namespace EddiJournalMonitor
                 FactionState fState = FactionState.FromEDName(JsonParsing.getString(factionDetail, "FactionState") ?? "None");
                 Government fGov = Government.FromEDName(JsonParsing.getString(factionDetail, "SystemGovernment") ?? "$government_None;");
                 decimal influence = JsonParsing.getDecimal(factionDetail, "Influence");
+                Superpower fAllegiance = getAllegiance(factionDetail, "Allegiance");
                 Happiness happiness = Happiness.FromEDName(JsonParsing.getString(factionDetail, "Happiness") ?? string.Empty);
                 decimal myReputation = JsonParsing.getOptionalDecimal(factionDetail, "MyReputation") ?? 0;
                 Faction fFaction = new Faction()
@@ -3274,6 +3270,7 @@ namespace EddiJournalMonitor
                     FactionState = fState,
                     Government = fGov,
                     influence = influence,
+                    Allegiance = fAllegiance,
                     Happiness = happiness,
                     myreputation = myReputation
                 };
@@ -3563,29 +3560,47 @@ namespace EddiJournalMonitor
             return superpowerFaction?.invariantName ?? faction;
         }
 
-        private static Faction getFactionData(IDictionary<string, object> data, string key)
+        private static Faction getFactionData(IDictionary<string, object> data, string type)
         {
-            string name = null;
-            FactionState factionstate = FactionState.None;
             Faction faction = new Faction();
 
-            if (data.TryGetValue(key, out object val))
+            // Get the faction name & state
+            if (data.TryGetValue(type + "Faction", out object val))
             {
                 Dictionary<string, object> factionData = val as Dictionary<string, object>;
                 if (factionData != null) // 3.3.03 or later journal
                 {
-                    name = JsonParsing.getString(factionData, "Name");
-                    factionstate = FactionState.FromEDName(JsonParsing.getString(factionData, "FactionState") ?? "None");
+                    faction.name = JsonParsing.getString(factionData, "Name");
+                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(factionData, "FactionState") ?? "None");
                 }
-                else // pre-3.3.03 journal
+                else // per-3.3.03 journal
                 {
-                    name = val as string;
-                    factionstate = FactionState.FromEDName(JsonParsing.getString(data, "FactionState") ?? "None");
+                    faction.name = val as string;
+                    faction.FactionState = FactionState.FromEDName(JsonParsing.getString(data, "FactionState") ?? "None");
                 }
             }
-            faction.name = name;
-            faction.FactionState = factionstate;
 
+            // Get the faction government
+            faction.Government = Government.FromEDName(JsonParsing.getString(data, type + "Government") ?? "None");
+
+            // Get the faction allegiance
+            if (data.TryGetValue(type + "Allegiance", out val))
+            {
+                faction.Allegiance = getAllegiance(data, type + "Allegiance");
+            }
+            else if (data.TryGetValue("Factions", out val))
+            {
+                var factionsList = val as List<object>;
+                foreach (IDictionary<string, object> factionDetail in factionsList)
+                {
+                    string fName = JsonParsing.getString(factionDetail, "Name");
+                    if (fName == faction.name)
+                    {
+                        faction.Allegiance = getAllegiance(factionDetail, "Allegiance");
+                        break;
+                    }
+                }
+            }
             return faction;
         }
 

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -237,7 +237,7 @@ namespace UnitTests
         public void TestEDDNResponderDockedEvent()
         {
             string line = @"{
-	            ""timestamp"": ""2018-07-30T04:50:32Z"",
+                ""timestamp"": ""2018-07-30T04:50:32Z"",
 	            ""event"": ""FSDJump"",
 	            ""StarSystem"": ""Diaguandri"",
 	            ""SystemAddress"": 670417429889,
@@ -342,7 +342,7 @@ namespace UnitTests
             }";
 
             string line2 = @"{
-	            ""timestamp"": ""2018-07-30T06: 07: 47Z"",
+                ""timestamp"": ""2018-07-30T06: 07: 47Z"",
 	            ""event"": ""Docked"",
 	            ""StationName"": ""Ray Gateway"",
 	            ""StationType"": ""Coriolis"",
@@ -420,7 +420,7 @@ namespace UnitTests
         public void TestMyReputationDataStripping()
         {
             string line = @"{
-	            ""timestamp"": ""2018-11-19T01: 06: 17Z"",
+                ""timestamp"": ""2018-11-19T01: 06: 17Z"",
 	            ""event"": ""Location"",
 	            ""Docked"": false,
 	            ""StarSystem"": ""BD+48738"",
@@ -507,6 +507,7 @@ namespace UnitTests
 		            ""FactionState"": ""None""
 	            }
             }";
+
             IDictionary<string, object> data = Utilities.Deserializtion.DeserializeData(line);
 
             EDDNResponder.EDDNResponder responder = makeTestEDDNResponder();

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -65,53 +65,53 @@ namespace UnitTests
         public void TestJournalPlanetScan3()
         {
             string line = @"{
-        ""Atmosphere"": ""hot thick carbon dioxide atmosphere"",
-         ""AtmosphereComposition"": [
-            {
-                ""Name"": ""CarbonDioxide"",
-                 ""Percent"": 96.5
-            },
-             {
-                ""Name"": ""Nitrogen"",
-                 ""Percent"": 3.499999
-            }
-        ],
-         ""AtmosphereType"": ""CarbonDioxide"",
-         ""AxialTilt"": 3.094469,
-         ""BodyID"": 2,
-         ""BodyName"": ""Venus"",
-         ""Composition"": {
-            ""Ice"": 0.0,
-             ""Metal"": 0.3,
-             ""Rock"": 0.7
-        },
-         ""DistanceFromArrivalLS"": 360.959534,
-         ""Eccentricity"": 0.0067,
-         ""Landable"": false,
-         ""MassEM"": 0.815,
-         ""OrbitalInclination"": 3.395,
-         ""OrbitalPeriod"": 19414166.0,
-         ""Parents"": [
-            {
-                ""Star"": 0
-            }
-        ],
-         ""Periapsis"": 55.186001,
-         ""PlanetClass"": ""High metal content body"",
-         ""Radius"": 6051800.0,
-         ""RotationPeriod"": 20996798.0,
-         ""ScanType"": ""NavBeaconDetail"",
-         ""SemiMajorAxis"": 108207980544.0,
-         ""SurfaceGravity"": 8.869474,
-         ""SurfacePressure"": 9442427.0,
-         ""SurfaceTemperature"": 735.0,
-         ""SystemAddress"": 10477373803,
-         ""TerraformState"": """",
-         ""TidalLock"": true,
-         ""Volcanism"": ""minor rocky magma volcanism"",
-         ""event"": ""Scan"",
-         ""timestamp"": ""2018-09-03T19:07:54Z""
-    }";
+                ""Atmosphere"": ""hot thick carbon dioxide atmosphere"",
+                ""AtmosphereComposition"": [
+                    {
+                        ""Name"": ""CarbonDioxide"",
+                        ""Percent"": 96.5
+                    },
+                    {
+                        ""Name"": ""Nitrogen"",
+                        ""Percent"": 3.499999
+                    }
+                ],
+                ""AtmosphereType"": ""CarbonDioxide"",
+                ""AxialTilt"": 3.094469,
+                ""BodyID"": 2,
+                ""BodyName"": ""Venus"",
+                ""Composition"": {
+                    ""Ice"": 0.0,
+                    ""Metal"": 0.3,
+                    ""Rock"": 0.7
+                },
+                ""DistanceFromArrivalLS"": 360.959534,
+                ""Eccentricity"": 0.0067,
+                ""Landable"": false,
+                ""MassEM"": 0.815,
+                ""OrbitalInclination"": 3.395,
+                 ""OrbitalPeriod"": 19414166.0,
+                ""Parents"": [
+                    {
+                        ""Star"": 0
+                    }
+                ],
+                ""Periapsis"": 55.186001,
+                ""PlanetClass"": ""High metal content body"",
+                ""Radius"": 6051800.0,
+                ""RotationPeriod"": 20996798.0,
+                ""ScanType"": ""NavBeaconDetail"",
+                ""SemiMajorAxis"": 108207980544.0,
+                ""SurfaceGravity"": 8.869474,
+                ""SurfacePressure"": 9442427.0,
+                ""SurfaceTemperature"": 735.0,
+                ""SystemAddress"": 10477373803,
+                ""TerraformState"": """",
+                ""TidalLock"": true,
+                ""Volcanism"": ""minor rocky magma volcanism"",
+                ""event"": ""Scan"",
+                ""timestamp"": ""2018-09-03T19:07:54Z""
+            }";
 
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
             Assert.IsTrue(events.Count == 1);
@@ -227,9 +227,9 @@ namespace UnitTests
             Assert.AreEqual("Orbis", theEvent.stationModel.edname);
             Assert.AreEqual("Donaldson", theEvent.station);
             Assert.AreEqual("Alioth", theEvent.system);
-            Assert.AreEqual("Boom", theEvent.factionState.invariantName);
-            Assert.AreEqual("Democracy", theEvent.Government.invariantName);
-            Assert.AreEqual("Alliance", theEvent.Allegiance.invariantName);
+            Assert.AreEqual("Boom", theEvent.controllingfaction.FactionState.invariantName);
+            Assert.AreEqual("Democracy", theEvent.controllingfaction.Government.invariantName);
+            Assert.AreEqual("Alliance", theEvent.controllingfaction.Allegiance.invariantName);
             Assert.AreEqual(20, theEvent.stationservices.Count);
             Assert.AreEqual(1, theEvent.economyShares.Count);
             Assert.AreEqual("Service", theEvent.economyShares[0].economy.invariantName);
@@ -465,90 +465,90 @@ namespace UnitTests
         public void TestJournalJumpedEvent()
         {
             string line = @"{
-	        ""timestamp"": ""2018-08-08T06: 56: 20Z"",
-	        ""event"": ""FSDJump"",
-	        ""StarSystem"": ""Diaguandri"",
-        	""SystemAddress"": 670417429889,
-	        ""StarPos"": [-41.06250, -62.15625, -103.25000],
-	        ""SystemAllegiance"": ""Independent"",
-	        ""SystemEconomy"": ""$economy_HighTech;"",
-	        ""SystemEconomy_Localised"": ""HighTech"",
-	        ""SystemSecondEconomy"": ""$economy_Refinery;"",
-	        ""SystemSecondEconomy_Localised"": ""Refinery"",
-	        ""SystemGovernment"": ""$government_Democracy;"",
-	        ""SystemGovernment_Localised"": ""Democracy"",
-	        ""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
-	        ""SystemSecurity_Localised"": ""MediumSecurity"",
-	        ""Population"": 10303479,
-	        ""JumpDist"": 19.340,
-	        ""FuelUsed"": 2.218082,
-	        ""FuelLevel"": 23.899260,
-	        ""Factions"": [{
-		        ""Name"": ""DiaguandriInterstellar"",
-		        ""FactionState"": ""Boom"",
-		        ""Government"": ""Corporate"",
-		        ""Influence"": 0.100398,
-		        ""Allegiance"": ""Independent""
-	        },
-	        {
-		        ""Name"": ""People'sMET20Liberals"",
-		        ""FactionState"": ""Boom"",
-		        ""Government"": ""Democracy"",
-		        ""Influence"": 0.123260,
-		        ""Allegiance"": ""Federation""
-	        },
-	        {
-		        ""Name"": ""PilotsFederationLocalBranch"",
-		        ""FactionState"": ""None"",
-		        ""Government"": ""Democracy"",
-		        ""Influence"": 0.000000,
-		        ""Allegiance"": ""PilotsFederation""
-	        },
-	        {
-		        ""Name"": ""NaturalDiaguandriRegulatoryState"",
-		        ""FactionState"": ""None"",
-		        ""Government"": ""Dictatorship"",
-		        ""Influence"": 0.020875,
-		        ""Allegiance"": ""Independent"",
-		        ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
-	        },
-	        {
-		        ""Name"": ""CartelofDiaguandri"",
-		        ""FactionState"": ""None"",
-		        ""Government"": ""Anarchy"",
-		        ""Influence"": 0.009940,
-		        ""Allegiance"": ""Independent"",
-		        ""PendingStates"": [{""State"": ""Bust"", ""Trend"": 0}, {""State"": ""CivilUnrest"", ""Trend"": 1}],
-		        ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
-	        },
-	        {
-		        ""Name"": ""RevolutionaryPartyofDiaguandri"",
-		        ""FactionState"": ""None"",
-		        ""Government"": ""Democracy"",
-		        ""Influence"": 0.124254,
-		        ""Allegiance"": ""Federation"",
-		        ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}, {""State"": ""Bust"", ""Trend"": 1}]
-	        },
-	        {
-		        ""Name"": ""TheBrotherhoodoftheDarkCircle"",
-		        ""FactionState"": ""None"",
-		        ""Government"": ""Corporate"",
-		        ""Influence"": 0.093439,
-		        ""Allegiance"": ""Independent"",
-		        ""RecoveringStates"": [{""State"": ""CivilUnrest"", ""Trend"": 1}]
-            },
-            {
-		        ""Name"": ""EXO"",
-		        ""FactionState"": ""Expansion"",
-		        ""Government"": ""Democracy"",
-		        ""Influence"": 0.527833,
-		        ""Allegiance"": ""Independent"",
-		        ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}]
-	        }],
-	        ""SystemFaction"": {
-		        ""Name"": ""EXO"",
-		        ""FactionState"": ""Expansion""
-	        }
+            ""timestamp"": ""2018-08-08T06: 56: 20Z"",
+	            ""event"": ""FSDJump"",
+	            ""StarSystem"": ""Diaguandri"",
+        	    ""SystemAddress"": 670417429889,
+	            ""StarPos"": [-41.06250, -62.15625, -103.25000],
+	            ""SystemAllegiance"": ""Independent"",
+	            ""SystemEconomy"": ""$economy_HighTech;"",
+	            ""SystemEconomy_Localised"": ""HighTech"",
+	            ""SystemSecondEconomy"": ""$economy_Refinery;"",
+	            ""SystemSecondEconomy_Localised"": ""Refinery"",
+	            ""SystemGovernment"": ""$government_Democracy;"",
+	            ""SystemGovernment_Localised"": ""Democracy"",
+	            ""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
+	            ""SystemSecurity_Localised"": ""MediumSecurity"",
+	            ""Population"": 10303479,
+	            ""JumpDist"": 19.340,
+	            ""FuelUsed"": 2.218082,
+	            ""FuelLevel"": 23.899260,
+	            ""Factions"": [{
+		            ""Name"": ""DiaguandriInterstellar"",
+		            ""FactionState"": ""Boom"",
+		            ""Government"": ""Corporate"",
+		            ""Influence"": 0.100398,
+		            ""Allegiance"": ""Independent""
+	            },
+	            {
+		            ""Name"": ""People'sMET20Liberals"",
+		            ""FactionState"": ""Boom"",
+		            ""Government"": ""Democracy"",
+		            ""Influence"": 0.123260,
+		            ""Allegiance"": ""Federation""
+	            },
+	            {
+		            ""Name"": ""PilotsFederationLocalBranch"",
+		            ""FactionState"": ""None"",
+		            ""Government"": ""Democracy"",
+		            ""Influence"": 0.000000,
+		            ""Allegiance"": ""PilotsFederation""
+	            },
+	            {
+		            ""Name"": ""NaturalDiaguandriRegulatoryState"",
+		            ""FactionState"": ""None"",
+		            ""Government"": ""Dictatorship"",
+		            ""Influence"": 0.020875,
+		            ""Allegiance"": ""Independent"",
+		            ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
+	            },
+	            {
+		            ""Name"": ""CartelofDiaguandri"",
+		            ""FactionState"": ""None"",
+		            ""Government"": ""Anarchy"",
+		            ""Influence"": 0.009940,
+		            ""Allegiance"": ""Independent"",
+		            ""PendingStates"": [{""State"": ""Bust"", ""Trend"": 0}, {""State"": ""CivilUnrest"", ""Trend"": 1}],
+		            ""RecoveringStates"": [{""State"": ""CivilWar"", ""Trend"": 0}]
+	            },
+	            {
+		            ""Name"": ""RevolutionaryPartyofDiaguandri"",
+		            ""FactionState"": ""None"",
+		            ""Government"": ""Democracy"",
+		            ""Influence"": 0.124254,
+		            ""Allegiance"": ""Federation"",
+		            ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}, {""State"": ""Bust"", ""Trend"": 1}]
+	            },
+	            {
+		            ""Name"": ""TheBrotherhoodoftheDarkCircle"",
+		            ""FactionState"": ""None"",
+		            ""Government"": ""Corporate"",
+		            ""Influence"": 0.093439,
+		            ""Allegiance"": ""Independent"",
+		            ""RecoveringStates"": [{""State"": ""CivilUnrest"", ""Trend"": 1}]
+                },
+                {
+		            ""Name"": ""EXO"",
+		            ""FactionState"": ""Expansion"",
+		            ""Government"": ""Democracy"",
+		            ""Influence"": 0.527833,
+		            ""Allegiance"": ""Independent"",
+		            ""PendingStates"": [{""State"": ""Boom"", ""Trend"": 1}]
+	            }],
+                ""SystemFaction"": {
+		            ""Name"": ""EXO"",
+		            ""FactionState"": ""Expansion""
+	            }
             }";
 
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
@@ -559,7 +559,7 @@ namespace UnitTests
             Assert.AreEqual(-41.06250M, jumpedEvent.x);
             Assert.AreEqual(-62.15625M, jumpedEvent.y);
             Assert.AreEqual(-103.25000M, jumpedEvent.z);
-            Assert.AreEqual("Independent", jumpedEvent.Allegiance.invariantName);
+            Assert.AreEqual("Independent", jumpedEvent.controllingfaction.Allegiance.invariantName);
             Assert.AreEqual("High Tech", jumpedEvent.economy);
             Assert.AreEqual("Refinery", jumpedEvent.economy2);
             Assert.AreEqual("Democracy", jumpedEvent.government);
@@ -638,9 +638,9 @@ namespace UnitTests
         public void TestJournalLocationEvent()
         {
             string line = @"{
-	            ""timestamp"": ""2018-08-12T02: 52: 13Z"",
-	                ""event"": ""Location"",
-	        ""Docked"": true,
+                ""timestamp"": ""2018-08-12T02: 52: 13Z"",
+	            ""event"": ""Location"",
+	            ""Docked"": true,
 	            ""MarketID"": 3223343616,
 	            ""StationName"": ""RayGateway"",
 	            ""StationType"": ""Coriolis"",
@@ -656,6 +656,8 @@ namespace UnitTests
 	            ""SystemSecondEconomy_Localised"": ""Refinery"",
 	            ""SystemGovernment"": ""$government_Democracy;"",
 	            ""SystemGovernment_Localised"": ""Democracy"",
+	            ""StationGovernment"": ""$government_Democracy;"",
+	            ""StationGovernment_Localised"": ""Democracy"",
 	            ""SystemSecurity"": ""$SYSTEM_SECURITY_medium;"",
 	            ""SystemSecurity_Localised"": ""MediumSecurity"",
 	            ""Population"": 10303479,
@@ -741,6 +743,10 @@ namespace UnitTests
 	            ""SystemFaction"": {
 		            ""Name"": ""EXO"",
 		            ""FactionState"": ""None""
+	            },
+	            ""StationFaction"": {
+		            ""Name"": ""EXO"",
+		            ""FactionState"": ""None""
 	            }
             }";
 
@@ -748,14 +754,20 @@ namespace UnitTests
             Assert.IsTrue(events.Count == 1);
             LocationEvent @event = (LocationEvent)events[0];
 
-            Assert.AreEqual("Independent", @event.Allegiance.invariantName);
             Assert.AreEqual("RayGateway", @event.body);
             Assert.AreEqual("Station", @event.bodyType.invariantName);
             Assert.AreEqual(true, @event.docked);
             Assert.AreEqual("High Tech", @event.Economy.invariantName);
             Assert.AreEqual("Refinery", @event.Economy2.invariantName);
+
             Assert.AreEqual("EXO", @event.faction);
-            Assert.AreEqual("Democracy", @event.Government.invariantName);
+            Assert.AreEqual("EXO", @event.systemfaction);
+            Assert.AreEqual("Independent", @event.controllingsystemfaction.Allegiance.invariantName);
+            Assert.AreEqual("Democracy", @event.controllingsystemfaction.Government.invariantName);
+            Assert.AreEqual("EXO", @event.stationfaction);
+            Assert.AreEqual("Independent", @event.controllingstationfaction.Allegiance.invariantName);
+            Assert.AreEqual("Democracy", @event.controllingstationfaction.Government.invariantName);
+
             Assert.IsNull(@event.latitude);
             Assert.IsNull(@event.longitude);
             Assert.AreEqual(3223343616, @event.marketId);
@@ -834,7 +846,7 @@ namespace UnitTests
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
             JumpedEvent @event = (JumpedEvent)events[0];
 
-            Assert.AreEqual("Thargoid", @event.Allegiance.invariantName);
+            Assert.AreEqual("Thargoid", @event.controllingfaction.Allegiance.invariantName);
         }
 
         [TestMethod]
@@ -844,7 +856,7 @@ namespace UnitTests
             List<Event> events = JournalMonitor.ParseJournalEntry(line);
             JumpedEvent @event = (JumpedEvent)events[0];
 
-            Assert.AreEqual("Guardian", @event.Allegiance.invariantName);
+            Assert.AreEqual("Guardian", @event.controllingfaction.Allegiance.invariantName);
         }
 
         [TestMethod]
@@ -904,8 +916,8 @@ namespace UnitTests
             LocationEvent @event = (LocationEvent)events[0];
 
             Assert.IsNotNull(@event.raw);
-            Assert.AreEqual("None", @event.Allegiance?.invariantName);
-            Assert.AreEqual("$faction_None", @event.Allegiance?.edname);
+            Assert.AreEqual("None", @event.controllingsystemfaction.Allegiance?.invariantName);
+            Assert.AreEqual("$faction_None", @event.controllingsystemfaction.Allegiance?.edname);
         }
 
         [TestMethod]


### PR DESCRIPTION
* Location Event now handling added station controlling faction data, when docked
* `Docked`, `FSDJump`, and `Location` events now (more efficiently) pass Faction objects, localized state, government & allegiance properties are still derived for use in Cottle & VA.
* Retained `faction`, `factionstate`, `allegiance` and `government` properties (still pointing to system values) to not break existing scripts and profile commands in 'Location' event.
* Added system minor faction data updating to `CurrentStarSystem` in `Location` & `FSDJump` events.