### PR TITLE
Fix BodyDetails() errors

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### Development
+  * Speech responder
+    * Fixed a bug that could prevent proper lookup of bodies using the `BodyDetails()` function.
+
 ### 3.3.4-rc3
   * Frontier API
     * Fixed missing client ID in 3.3.4-rc2.

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -120,9 +120,6 @@ namespace Eddi
         public string Vehicle { get; private set; } = Constants.VEHICLE_SHIP;
         public Ship CurrentShip { get; set; }
 
-        // Information from the last jump we initiated (for reference)
-        public FSDEngagedEvent LastFSDEngagedEvent { get; private set; }
-
         // Our main window, made accessible via the applicable EDDI Instance
         public MainWindow MainWindow { get; internal set; }
 
@@ -1280,9 +1277,6 @@ namespace Eddi
             // Set the destination system as the current star system
             updateCurrentSystem(@event.system);
 
-            // Save a copy of this event for reference
-            LastFSDEngagedEvent = @event;
-
             return true;
         }
 
@@ -1326,7 +1320,7 @@ namespace Eddi
             CurrentStarSystem.y = theEvent.y;
             CurrentStarSystem.z = theEvent.z;
             CurrentStarSystem.Faction = theEvent.controllingfaction;
-            CurrentStellarBody = CurrentStarSystem.bodies.FirstOrDefault(b => b.name == theEvent.star);
+            CurrentStellarBody = CurrentStarSystem.bodies.FirstOrDefault(b => b.distance == 0);
 
             // Update system faction data if available
             if (theEvent.factions != null)
@@ -1373,20 +1367,6 @@ namespace Eddi
 
             // After jump has completed we are always in supercruise
             Environment = Constants.ENVIRONMENT_SUPERCRUISE;
-
-            // If we don't have any information about bodies in the system yet, create a basic main star from current and saved event data
-            if (CurrentStellarBody == null)
-            {
-                CurrentStellarBody = new Body()
-                {
-                    name = theEvent.star,
-                    Type = BodyType.FromEDName("Star"),
-                    stellarclass = LastFSDEngagedEvent?.stellarclass,
-                    mainstar = true,
-                    distance = 0, 
-                };
-                CurrentStarSystem.bodies.Add(CurrentStellarBody);
-            }
 
             return passEvent;
         }
@@ -1779,7 +1759,6 @@ namespace Eddi
                         systemname = CurrentStarSystem?.name,
                         systemAddress = CurrentStarSystem?.systemAddress
                     };
-                    CurrentStarSystem.bodies?.Add(belt);
                 }
 
                 // Update with the information we have

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -17,7 +17,6 @@ namespace EddiEvents
             VARIABLES.Add("x", "The X co-ordinate of the system to which the commander has jumped");
             VARIABLES.Add("y", "The Y co-ordinate of the system to which the commander has jumped");
             VARIABLES.Add("z", "The Z co-ordinate of the system to which the commander has jumped");
-            VARIABLES.Add("star", "The name of the star at which you've arrived");
             VARIABLES.Add("distance", "The distance the commander has jumped, in light years");
             VARIABLES.Add("fuelused", "The amount of fuel used in this jump");
             VARIABLES.Add("fuelremaining", "The amount of fuel remaining after this jump");
@@ -41,6 +40,7 @@ namespace EddiEvents
 
         public decimal z { get; private set; }
 
+        /// <summary> Documented by the journal, but apparently never written. We can't rely on this being set. </summary>
         public string star { get; private set; }
 
         public decimal distance { get; private set; }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -192,7 +192,7 @@ namespace EddiJournalMonitor
                                     decimal x = Math.Round(JsonParsing.getDecimal("X", starPos[0]) * 32) / (decimal)32.0;
                                     decimal y = Math.Round(JsonParsing.getDecimal("Y", starPos[1]) * 32) / (decimal)32.0;
                                     decimal z = Math.Round(JsonParsing.getDecimal("Z", starPos[2]) * 32) / (decimal)32.0;
-                                    string starName = JsonParsing.getString(data, "Body");
+                                    string starName = JsonParsing.getString(data, "Body"); // Documented by the journal, but apparently never written. We can't rely on this being set.
                                     decimal fuelUsed = JsonParsing.getDecimal(data, "FuelUsed");
                                     decimal fuelRemaining = JsonParsing.getDecimal(data, "FuelLevel");
                                     int? boostUsed = JsonParsing.getOptionalInt(data, "BoostUsed"); // 1-3 are synthesis, 4 is any supercharge (white dwarf or neutron star)

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -627,7 +627,7 @@ namespace EddiSpeechResponder
                     // Named system
                     system = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(values[1].AsString, true);
                 }
-                Body result = system != null && system.bodies != null ? system.bodies.FirstOrDefault(v => v.name.ToLowerInvariant() == values[0].AsString.ToLowerInvariant()) : null;
+                Body result = system?.bodies?.Find(v => v.name?.ToLowerInvariant() == values[0].AsString?.ToLowerInvariant());
                 if (result != null && result.Type.invariantName == "Star" && result.chromaticity == null)
                 {
                     // Need to set our internal extras for the star


### PR DESCRIPTION
Trying to generate a synthetic main star to reference immediately after jumping was generating a star with a null name, since FDev aren't writing the name of the main star to the journal like they say they will do in the journal manual. Since lookups are performed by body name, null names are not acceptable. 
This change rolls back #1063.

