### PR TITLE
Protection from mission & haulage duplicates

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -27,6 +27,7 @@ namespace EddiCargoMonitor
         public ObservableCollection<Cargo> inventory { get; private set; }
         public int cargoCarried;
         private bool checkHaulage = false;
+        private DateTime updateDat;
 
         private static readonly object inventoryLock = new object();
         public event EventHandler InventoryUpdatedEvent;
@@ -213,9 +214,13 @@ namespace EddiCargoMonitor
 
         private void handleCargoEvent(CargoEvent @event)
         {
-            if(_handleCargoEvent(@event))
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCargoEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -289,9 +294,13 @@ namespace EddiCargoMonitor
 
         private void handleCommodityCollectedEvent(CommodityCollectedEvent @event)
         {
-            if (_handleCommodityCollectedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCommodityCollectedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -342,9 +351,13 @@ namespace EddiCargoMonitor
 
         private void handleCommodityEjectedEvent(CommodityEjectedEvent @event)
         {
-            if(_handleCommodityEjectedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCommodityEjectedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -395,9 +408,13 @@ namespace EddiCargoMonitor
 
         private void handleCommodityPurchasedEvent(CommodityPurchasedEvent @event)
         {
-            if(_handleCommodityPurchasedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCommodityPurchasedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -422,9 +439,13 @@ namespace EddiCargoMonitor
 
         private void handleCommodityRefinedEvent(CommodityRefinedEvent @event)
         {
-            if(_handleCommodityRefinedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCommodityRefinedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -449,9 +470,13 @@ namespace EddiCargoMonitor
 
         private void handleCommoditySoldEvent(CommoditySoldEvent @event)
         {
-            if(_handleCommoditySoldEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleCommoditySoldEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -469,9 +494,10 @@ namespace EddiCargoMonitor
 
         private void handleCargoDepotEvent(CargoDepotEvent @event)
         {
-            _handleCargoDepotEvent(@event);
-            if(!@event.fromLoad)
+            if(@event.timestamp > updateDat)
             {
+                _handleCargoDepotEvent(@event);
+                updateDat = @event.timestamp;
                 writeInventory();
             }
         }
@@ -639,9 +665,13 @@ namespace EddiCargoMonitor
 
         private void handleMissionsEvent(MissionsEvent @event)
         {
-            if (_handleMissionsEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleMissionsEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -666,9 +696,13 @@ namespace EddiCargoMonitor
 
         private void handleMissionAbandonedEvent(MissionAbandonedEvent @event)
         {
-            if(_handleMissionAbandonedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleMissionAbandonedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -691,10 +725,11 @@ namespace EddiCargoMonitor
 
         private void handleMissionAcceptedEvent(MissionAcceptedEvent @event)
         {
-            if (@event.commodityDefinition != null)
+            if (@event.timestamp > updateDat && @event.commodityDefinition != null)
             {
-                if (_handleMissionAcceptedEvent(@event) && !@event.fromLoad)
+                if (_handleMissionAcceptedEvent(@event))
                 {
+                    updateDat = @event.timestamp;
                     writeInventory();
                 }
             }
@@ -772,9 +807,13 @@ namespace EddiCargoMonitor
         {
             if (@event.commodityDefinition != null || @event.commodityrewards != null)
             {
-                if(_handleMissionCompletedEvent(@event) && !@event.fromLoad)
+                if (@event.timestamp > updateDat)
                 {
-                    writeInventory();
+                    if (_handleMissionCompletedEvent(@event))
+                    {
+                        updateDat = @event.timestamp;
+                        writeInventory();
+                    }
                 }
             }
         }
@@ -798,9 +837,13 @@ namespace EddiCargoMonitor
 
         private void handleMissionExpiredEvent(MissionExpiredEvent @event)
         {
-            if(_handleMissionExpiredEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleMissionExpiredEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -818,9 +861,13 @@ namespace EddiCargoMonitor
 
         private void handleMissionFailedEvent(MissionFailedEvent @event)
         {
-            if(_handleMissionFailedEvent(@event) && !@event.fromLoad)
+            if (@event.timestamp > updateDat)
             {
-                writeInventory();
+                if (_handleMissionFailedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
             }
         }
 
@@ -849,6 +896,19 @@ namespace EddiCargoMonitor
 
         private void handleEngineerContributedEvent(EngineerContributedEvent @event)
         {
+            if (@event.timestamp > updateDat)
+            {
+                if (_handleEngineerContributedEvent(@event))
+                {
+                    updateDat = @event.timestamp;
+                    writeInventory();
+                }
+            }
+        }
+
+        private bool _handleEngineerContributedEvent(EngineerContributedEvent @event)
+        {
+            bool update = false;
             if (@event.commodityAmount != null)
             {
                 Cargo cargo = GetCargoWithEDName(@event.commodityAmount.edname);
@@ -856,8 +916,10 @@ namespace EddiCargoMonitor
                 {
                     cargo.owned -= Math.Min(cargo.owned, @event.commodityAmount.amount);
                     RemoveCargo(cargo);
+                    update = true;
                 }
             }
+            return update;
         }
 
         public IDictionary<string, object> GetVariables()
@@ -875,10 +937,12 @@ namespace EddiCargoMonitor
             lock (inventoryLock)
             {
                 // Write cargo configuration with current inventory
-                CargoMonitorConfiguration configuration = new CargoMonitorConfiguration();
-
-                configuration.cargo = inventory;
-                configuration.cargocarried = cargoCarried;
+                CargoMonitorConfiguration configuration = new CargoMonitorConfiguration()
+                {
+                    updatedat = updateDat,
+                    cargo = inventory,
+                    cargocarried = cargoCarried
+                };
                 configuration.ToFile();
             }
             // Make sure the UI is up to date
@@ -892,6 +956,7 @@ namespace EddiCargoMonitor
                 // Obtain current cargo inventory from configuration
                 configuration = configuration ?? CargoMonitorConfiguration.FromFile();
                 cargoCarried = configuration.cargocarried;
+                updateDat = configuration.updatedat;
 
                 // Build a new inventory
                 List<Cargo> newInventory = new List<Cargo>();

--- a/CargoMonitor/CargoMonitorConfiguration.cs
+++ b/CargoMonitor/CargoMonitorConfiguration.cs
@@ -14,6 +14,8 @@ namespace EddiCargoMonitor
 
         public int cargocarried { get; set; }
 
+        public DateTime updatedat { get; set; }
+
         [JsonIgnore]
         private string dataPath;
 

--- a/MissionMonitor/MissionMonitor.cs
+++ b/MissionMonitor/MissionMonitor.cs
@@ -295,7 +295,7 @@ namespace EddiMissionMonitor
 
         private void handleMissionsEvent(MissionsEvent @event)
         {
-            if(_handleMissionsEvent(@event))
+            if(_handleMissionsEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }
@@ -391,7 +391,10 @@ namespace EddiMissionMonitor
         private void handlePassengersEvent(PassengersEvent @event)
         {
             _handlePassengersEvent(@event);
-            writeMissions();
+            if (!@event.fromLoad)
+            {
+                writeMissions();
+            }
         }
 
         public void _handlePassengersEvent(PassengersEvent @event)
@@ -427,7 +430,10 @@ namespace EddiMissionMonitor
         private void handleCommunityGoalEvent(CommunityGoalEvent @event)
         {
             _handleCommunityGoalEvent(@event);
-            writeMissions();
+            if(!@event.fromLoad)
+            {
+                writeMissions();
+            }
         }
 
         public void _handleCommunityGoalEvent(CommunityGoalEvent @event)
@@ -460,7 +466,10 @@ namespace EddiMissionMonitor
         private void handleCargoDepotEvent(CargoDepotEvent @event)
         {
             _handleCargoDepotEvent(@event);
-            writeMissions();
+            if (!@event.fromLoad)
+            {
+                writeMissions();
+            }
         }
 
         public void _handleCargoDepotEvent(CargoDepotEvent @event)
@@ -556,7 +565,7 @@ namespace EddiMissionMonitor
 
         private void handleMissionAbandonedEvent(MissionAbandonedEvent @event)
         {
-            if(_handleMissionAbandonedEvent(@event))
+            if(_handleMissionAbandonedEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }
@@ -579,20 +588,19 @@ namespace EddiMissionMonitor
 
         private void handleMissionAcceptedEvent(MissionAcceptedEvent @event)
         {
-            // Protect against duplicates
-            if (!missions.Any(m => m.missionid == @event.missionid))
+            if (_handleMissionAcceptedEvent(@event) && !@event.fromLoad)
             {
-                if (_handleMissionAcceptedEvent(@event))
-                {
-                    writeMissions();
-                }
+                writeMissions();
             }
         }
 
         public bool _handleMissionAcceptedEvent(MissionAcceptedEvent @event)
         {
             bool update = false;
-            if (!string.IsNullOrEmpty(@event.name))
+
+            // Protect against duplicates and empty strings
+            bool exists = missions.Any(m => m.missionid == @event.missionid);
+            if (!exists && !string.IsNullOrEmpty(@event.name))
             {
                 MissionStatus status = MissionStatus.FromEDName("Active");
                 Mission mission = new Mission(@event.missionid ?? 0, @event.name, @event.expiry, status)
@@ -727,7 +735,7 @@ namespace EddiMissionMonitor
         private void handleMissionCompletedEvent(MissionCompletedEvent @event)
         {
 
-            if(_handleMissionCompletedEvent(@event))
+            if(_handleMissionCompletedEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }
@@ -750,7 +758,7 @@ namespace EddiMissionMonitor
 
         private void handleMissionExpiredEvent(MissionExpiredEvent @event)
         {
-            if(_handleMissionExpiredEvent(@event))
+            if(_handleMissionExpiredEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }
@@ -773,7 +781,7 @@ namespace EddiMissionMonitor
 
         private void handleMissionFailedEvent(MissionFailedEvent @event)
         {
-            if(_handleMissionFailedEvent(@event))
+            if(_handleMissionFailedEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }
@@ -796,7 +804,7 @@ namespace EddiMissionMonitor
 
         private void handleMissionRedirectedEvent(MissionRedirectedEvent @event)
         {
-            if(_handleMissionRedirectedEvent(@event))
+            if(_handleMissionRedirectedEvent(@event) && !@event.fromLoad)
             {
                 writeMissions();
             }

--- a/MissionMonitor/MissionMonitorConfiguration.cs
+++ b/MissionMonitor/MissionMonitorConfiguration.cs
@@ -12,6 +12,7 @@ namespace EddiMissionMonitor
     {
         public ObservableCollection<Mission> missions { get; set; }
 
+        public DateTime updatedat { get; set; }
         public int missionsCount { get; set; }
         public int? missionWarning { get; set; }
         public string missionsRouteList { get; set; }

--- a/Tests/MissionMonitorTests.cs
+++ b/Tests/MissionMonitorTests.cs
@@ -221,6 +221,13 @@ namespace UnitTests
             Assert.IsTrue(mission.legal);
             Assert.IsFalse(mission.wing);
 
+            // Verify duplication protection
+            events = JournalMonitor.ParseJournalEntry(line);
+            Assert.IsTrue(events.Count == 1);
+            missionMonitor._handleMissionAcceptedEvent((MissionAcceptedEvent)events[0]);
+            Assert.AreEqual(1, missionMonitor.missions.ToList().Where(m => m.missionid == 413748324).Count());
+            Assert.AreEqual(4, missionMonitor.missions.Count);
+
             //CargoDepotEvent - 'Collect'
             line = @"{ ""timestamp"":""2018-08-26T02:55:10Z"", ""event"":""CargoDepot"", ""MissionID"":413748324, ""UpdateType"":""Deliver"", ""CargoType"":""Tantalum"", ""Count"":54, ""StartMarketID"":0, ""EndMarketID"":3224777216, ""ItemsCollected"":0, ""ItemsDelivered"":54, ""TotalItemsToDeliver"":54, ""Progress"":0.000000 }";
             events = JournalMonitor.ParseJournalEntry(line);


### PR DESCRIPTION
* Added protection against mission and haulage entries being duplicated during EDDI 'Log Load' startup.
* Improved 'Log Load' parsing efficiency for mission and haulage related events by skipping those already updated in respective monitor json files.