### PR TITLE
Add 'set' & 'cancel' to route plotting functions

### DIFF
--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -59,6 +59,10 @@ namespace EddiEvents
 
         public long? population { get; private set; }
 
+        public string destination { get; private set; }
+
+        public decimal destdistance { get; private set; }
+
         public List<Faction> factions { get; private set; }
 
         // Faction properties
@@ -75,7 +79,7 @@ namespace EddiEvents
         public SecurityLevel securityLevel { get; private set; } = SecurityLevel.None;
         public FactionState factionState { get; private set; } = FactionState.None;
 
-        public JumpedEvent(DateTime timestamp, string system, long systemAddress, decimal x, decimal y, decimal z, string star, decimal distance, decimal fuelused, decimal fuelremaining, int? boostUsed, Faction controllingfaction, Economy economy, Economy economy2, SecurityLevel security, long? population, List<Faction> factions) : base(timestamp, NAME)
+        public JumpedEvent(DateTime timestamp, string system, long systemAddress, decimal x, decimal y, decimal z, string star, decimal distance, decimal fuelused, decimal fuelremaining, int? boostUsed, Faction controllingfaction, List<Faction> factions, Economy economy, Economy economy2, SecurityLevel security, long? population, string destination, decimal destdistance) : base(timestamp, NAME)
         {
             this.system = system;
             this.systemAddress = systemAddress;
@@ -88,11 +92,13 @@ namespace EddiEvents
             this.fuelremaining = fuelremaining;
             this.boostused = boostUsed;
             this.controllingfaction = controllingfaction;
+            this.factions = factions;
             this.Economy = (economy ?? Economy.None);
             this.Economy2 = (economy2 ?? Economy.None);
             this.securityLevel = (security ?? SecurityLevel.None);
             this.population = population;
-            this.factions = factions;
+            this.destination = destination;
+            this.destdistance = destdistance;
         }
     }
 }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -211,7 +211,15 @@ namespace EddiJournalMonitor
                                         factions = getFactions(factionsVal);
                                     }
 
-                                    events.Add(new JumpedEvent(timestamp, systemName, systemAddress, x, y, z, starName, distance, fuelUsed, fuelRemaining, boostUsed, controllingfaction, economy, economy2, security, population, factions) { raw = line, fromLoad = fromLogLoad });
+                                    // Calculate remaining distance to route destination (if it exists)
+                                    decimal destDistance = 0;
+                                    string destination = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).GetNextSystem();
+                                    if (!string.IsNullOrEmpty(destination))
+                                    {
+                                        destDistance = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).CalculateDistance(systemName, destination);
+                                    }
+
+                                    events.Add(new JumpedEvent(timestamp, systemName, systemAddress, x, y, z, starName, distance, fuelUsed, fuelRemaining, boostUsed, controllingfaction, factions, economy, economy2, security, population, destination, destDistance) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;
                                 break;

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -655,6 +655,11 @@ namespace EddiSpeechResponder
                 }
                 switch (value)
                 {
+                    case "cancel":
+                        {
+                            ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).CancelRoute();
+                        }
+                        break;
                     case "expiring":
                         {
                             result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).GetExpiringRoute();
@@ -685,6 +690,11 @@ namespace EddiSpeechResponder
                             {
                                 result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).GetMissionsRoute();
                             }
+                        }
+                        break;
+                    case "set":
+                        {
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).SetRoute(values[1].AsString);
                         }
                         break;
                     case "source":

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -316,6 +316,7 @@ namespace EddiVoiceAttackResponder
                         InvokeTransmit(ref vaProxy);
                         break;
                     case "missionsroute":
+                    case "route":
                         InvokeMissionsRoute(ref vaProxy);
                         break;
                 }
@@ -880,6 +881,11 @@ namespace EddiVoiceAttackResponder
                 string system = vaProxy.GetText("System variable");
                 switch (type)
                 {
+                    case "cancel":
+                        {
+                            ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).CancelRoute();
+                        }
+                        break;
                     case "expiring":
                         {
                             ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).GetExpiringRoute();
@@ -910,6 +916,11 @@ namespace EddiVoiceAttackResponder
                             {
                                 ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).GetMissionsRoute(system);
                             }
+                        }
+                        break;
+                    case "set":
+                        {
+                            ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor")).SetRoute(system);
                         }
                         break;
                     case "source":


### PR DESCRIPTION
* Added ability to set route to individual systems in Cottle `RouteDetails()` and VA external plugin function, `missionsroute`.
* Added ability to cancel route(s) in Cottle `RouteDetails()` and VA external plugin function, `missionsroute`.
* Added ``destination` and `destdistance` properties to the `Jumped` event to allow tracking of progress to route destination.