### PR TITLE
Tighten up EDSM credentials management

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -99,11 +99,7 @@ namespace Eddi
         private static readonly object responderLock = new object();
 
         // Information obtained from the companion app service
-        public Commander Cmdr { get; private set; }
         public DateTime ApiTimeStamp { get; private set; }
-
-        // Services made available from EDDI
-        public StarMapService starMapService { get; private set; }
 
         // Information obtained from the configuration
         public StarSystem HomeStarSystem { get; private set; }
@@ -111,6 +107,7 @@ namespace Eddi
         public StarSystem SquadronStarSystem { get; private set; }
 
         // Information obtained from the player journal
+        public Commander Cmdr { get; private set; } // Also includes information from the configuration and companion app service
         public string Environment { get; private set; }
         public StarSystem CurrentStarSystem { get; private set; }
         public StarSystem LastStarSystem { get; private set; }
@@ -190,22 +187,21 @@ namespace Eddi
                     Cmdr.squadronallegiance = configuration.SquadronAllegiance;
                     Cmdr.squadronpower = configuration.SquadronPower;
                     Cmdr.squadronfaction = configuration.SquadronFaction;
-                    if (Cmdr.name != null)
+                    if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.Authorized)
                     {
                         Logging.Info("EDDI access to the companion app is enabled");
                     }
                     else
                     {
-                        // If InvokeUpdatePlugin failed then it will have have left an error message, but this once we ignore it
                         Logging.Info("EDDI access to the companion app is disabled");
                     }
 
-                    // Pass our commander name to the StarMapService (if it has been set via the Frontier API) and initialize the StarMapService
-                    if (Cmdr != null && Cmdr.name != null)
+                    // Pass our commander's Elite name to the StarMapService (if it has been set via the Frontier API or an event) and initialize the StarMapService
+                    // (the Elite name may differ from the EDSM name)
+                    if (Cmdr?.name != null)
                     {
-                        StarMapService.commanderName = Cmdr.name;
+                        StarMapService.commanderEliteName = Cmdr.name;
                     }
-                    starMapService = StarMapService.Instance;
                 }
                 else
                 {

--- a/EDSMResponder/ConfigurationWindow.xaml.cs
+++ b/EDSMResponder/ConfigurationWindow.xaml.cs
@@ -94,20 +94,19 @@ namespace EddiEdsmResponder
             edsmFetchLogsButton.Content = Properties.EDSMResources.log_button_fetching;
 
             var progress = new Progress<string>(s => edsmFetchLogsButton.Content = s);
-            await Task.Factory.StartNew(() => obtainEdsmLogs(starMapConfiguration, commanderName, progress),
+            await Task.Factory.StartNew(() => obtainEdsmLogs(progress),
                                             TaskCreationOptions.LongRunning);
 
             starMapConfiguration.lastSync = DateTime.UtcNow;
             starMapConfiguration.ToFile();
         }
 
-        public static void obtainEdsmLogs(StarMapConfiguration starMapConfiguration, string commanderName, IProgress<string> progress)
+        public static void obtainEdsmLogs(IProgress<string> progress)
         {
-            StarMapService starMapService = new StarMapService(starMapConfiguration.apiKey, commanderName);
             try
             {
-                Dictionary<string, StarMapLogInfo> systems = starMapService.getStarMapLog();
-                Dictionary<string, string> comments = starMapService.getStarMapComments();
+                Dictionary<string, StarMapLogInfo> systems = StarMapService.Instance.getStarMapLog();
+                Dictionary<string, string> comments = StarMapService.Instance.getStarMapComments();
                 int total = systems.Count;
                 int i = 0;
 

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -13,7 +13,6 @@ namespace EddiEdsmResponder
 {
     public class EDSMResponder : EDDIResponder
     {
-        private StarMapService starMapService;
         private Thread updateThread;
         private List<string> ignoredEvents = new List<string>();
 
@@ -46,26 +45,24 @@ namespace EddiEdsmResponder
         {
             Reload();
 
-            return starMapService != null;
+            return StarMapService.Instance != null;
         }
 
         public void Stop()
         {
             updateThread?.Abort();
             updateThread = null;
-            starMapService = null;
         }
 
         public void Reload()
         {
             // Set up the star map service
-            starMapService = StarMapService.Instance;
             if (ignoredEvents == null)
             {
-                ignoredEvents = starMapService?.getIgnoredEvents();
+                ignoredEvents = StarMapService.Instance?.getIgnoredEvents();
             }
 
-            if (starMapService != null && updateThread == null)
+            if (StarMapService.Instance != null && updateThread == null)
             {
                 // Spin off a thread to download & sync flight logs & system comments from EDSM in the background 
                 updateThread = new Thread(() => DataProviderService.syncFromStarMapService(StarMapConfiguration.FromFile()?.lastSync))
@@ -97,7 +94,7 @@ namespace EddiEdsmResponder
                 return;
             }
 
-            if (starMapService != null)
+            if (StarMapService.Instance != null)
             {
                 /// Retrieve applicable transient game state info (metadata) 
                 /// for the event and send the event with transient info to EDSM
@@ -112,7 +109,7 @@ namespace EddiEdsmResponder
                 }
                 if (eventData != null && !EDDI.Instance.ShouldUseTestEndpoints())
                 {
-                    starMapService.sendEvent(eventData);
+                    StarMapService.Instance.sendEvent(eventData);
                 }
             }
         }

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -17,40 +17,18 @@ namespace EddiStarMapService
         // Set the maximum batch size we will use for syncing before we write systems to our sql database
         public const int syncBatchSize = 50;
 
-        public static string commanderName { get; set; }
-        private static string apiKey { get; set; }
-        private static string baseUrl = "https://www.edsm.net/";
+        public static string commanderEliteName { get; set; }
 
-        public StarMapService()
-        {
-            // Set up the star map service
-            StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
-            if (starMapCredentials != null && starMapCredentials.apiKey != null)
-            {
-                // Commander name might come from star map credentials or the companion app's profile
-                string commanderName = null;
-                if (starMapCredentials.commanderName != null)
-                {
-                    commanderName = starMapCredentials.commanderName;
-                }
-                if (commanderName != null)
-                {
-                    instance = new StarMapService(starMapCredentials.apiKey, commanderName);
-                    Logging.Info("EDDI access to EDSM is enabled");
-                }
-            }
-            if (instance == null)
-            {
-                Logging.Info("EDDI access to EDSM is disabled");
-            }
-        }
+        private string commanderName { get; set; }
+        private string apiKey { get; set; }
+        private static string baseUrl = "https://www.edsm.net/";
 
         // For normal use, the EDSM API base URL is https://www.edsm.net/.
         // If you need to do some testing on EDSM's API, please use the https://beta.edsm.net/ endpoint for sending data.
         public StarMapService(string apikey, string commandername, string baseURL = "https://www.edsm.net/")
         {
-            apiKey = apikey;
-            commanderName = commandername;
+            apiKey = apikey?.Trim();
+            commanderName = commandername?.Trim();
             baseUrl = baseURL;
         }
 
@@ -67,7 +45,23 @@ namespace EddiStarMapService
                         if (instance == null)
                         {
                             Logging.Debug("No StarMapService instance: creating one");
-                            instance = new StarMapService();
+
+                            // Set up the star map service
+                            StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
+                            if (!string.IsNullOrEmpty(starMapCredentials?.apiKey))
+                            {
+                                string commanderName = starMapCredentials?.commanderName ?? commanderEliteName;
+                                if (!string.IsNullOrEmpty(commanderName))
+                                {
+                                    // Commander name might come from EDSM credentials or from the game and companion app
+                                    instance = new StarMapService(starMapCredentials.apiKey, commanderName);
+                                    Logging.Info("Configuring EDDI access to EDSM profile data");
+                                }
+                            }
+                            if (instance == null)
+                            {
+                                Logging.Info("EDDI access to EDSM profile data could not be configured");
+                            }
                         }
                     }
                 }

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -50,10 +50,10 @@ namespace EddiStarMapService
                             StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
                             if (!string.IsNullOrEmpty(starMapCredentials?.apiKey))
                             {
+                                // Commander name might come from EDSM credentials or from the game and companion app
                                 string commanderName = starMapCredentials?.commanderName ?? commanderEliteName;
                                 if (!string.IsNullOrEmpty(commanderName))
                                 {
-                                    // Commander name might come from EDSM credentials or from the game and companion app
                                     instance = new StarMapService(starMapCredentials.apiKey, commanderName);
                                     Logging.Info("Configuring EDDI access to EDSM profile data");
                                 }

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
 using Utilities;
+using EddiStarMapService;
 
 namespace EddiVoiceAttackResponder
 {
@@ -853,18 +854,15 @@ namespace EddiVoiceAttackResponder
                     return;
                 }
 
-                if (EDDI.Instance.Cmdr != null && EDDI.Instance.CurrentStarSystem != null && EDDI.Instance.starMapService != null)
+                if (EDDI.Instance.CurrentStarSystem != null)
                 {
                     // Store locally
                     StarSystem here = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(EDDI.Instance.CurrentStarSystem.name);
                     here.comment = comment == "" ? null : comment;
                     StarSystemSqLiteRepository.Instance.SaveStarSystem(here);
 
-                    if (EDDI.Instance.starMapService != null)
-                    {
-                        // Store in EDSM
-                        EDDI.Instance.starMapService.sendStarMapComment(EDDI.Instance.CurrentStarSystem.name, comment);
-                    }
+                    // Store in EDSM
+                    StarMapService.Instance?.sendStarMapComment(EDDI.Instance.CurrentStarSystem.name, comment);
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Prevents issues like `2019-02-08T22:17:23 [Warning] StarMapService:sendEvent EDSM responded with Missing commander name` by verifying that StarMapService.Instance can only be initialized with credentials and is not null prior to attempting to send data, and by managing access through a single instance.
Ref. https://forums.frontier.co.uk/showthread.php/387955-EDDI-3-3-Bring-your-cockpit-to-life?p=7410330&viewfull=1#post7410330