### PR TITLE
Fix VA variables (partially reverts PR #1172)

### DIFF
--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -40,28 +40,6 @@ namespace EddiCargoMonitor
             {"rescuethewares", "salvage"}
         };
 
-        private static CargoMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static CargoMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No cargo monitor instance: creating one");
-                            instance = new CargoMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         public string MonitorName()
         {
             return "Cargo monitor";
@@ -413,7 +391,8 @@ namespace EddiCargoMonitor
                         case "smuggle":
                             {
                                 haulage.status = "Failed";
-                                Mission mission = MissionMonitor.Instance.GetMissionWithMissionId(@event.missionid ?? 0);
+                                Mission mission = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?
+                                    .GetMissionWithMissionId(@event.missionid ?? 0);
                                 if (mission != null)
                                 {
                                     mission.statusDef = MissionStatus.FromEDName("Failed");
@@ -525,7 +504,8 @@ namespace EddiCargoMonitor
 
         private void _handleCargoDepotEvent(CargoDepotEvent @event)
         {
-            Mission mission = MissionMonitor.Instance.GetMissionWithMissionId(@event.missionid ?? 0);
+            Mission mission = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?
+                .GetMissionWithMissionId(@event.missionid ?? 0);
             Cargo cargo = new Cargo();
             Haulage haulage = new Haulage();
             int amountRemaining = @event.totaltodeliver - @event.delivered;
@@ -1097,7 +1077,8 @@ namespace EddiCargoMonitor
 
             foreach (CargoInfo info in infoList.Where(i => i.missionid != null).ToList())
             {
-                Mission mission = MissionMonitor.Instance.GetMissionWithMissionId(info.missionid ?? 0);
+                Mission mission = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?
+                    .GetMissionWithMissionId(info.missionid ?? 0);
 
                 Haulage cargoHaulage = cargo.haulageData.FirstOrDefault(h => h.missionid == info.missionid);
                 if (cargoHaulage != null)

--- a/CargoMonitor/ConfigurationWindow.xaml.cs
+++ b/CargoMonitor/ConfigurationWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Controls;
+﻿using Eddi;
+using System.Windows.Controls;
 using System.Windows.Data;
 
 namespace EddiCargoMonitor
@@ -8,16 +9,21 @@ namespace EddiCargoMonitor
     /// </summary>
     public partial class ConfigurationWindow : UserControl
     {
+        private CargoMonitor cargoMonitor()
+        {
+            return (CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor");
+        }
+
         public ConfigurationWindow()
         {
             InitializeComponent();
-            cargoData.ItemsSource = CargoMonitor.Instance.inventory;
+            cargoData.ItemsSource = cargoMonitor()?.inventory;
         }
 
         private void cargoUpdated(object sender, DataTransferEventArgs e)
         {
             // Update the cargo monitor's information
-            CargoMonitor.Instance.writeInventory();
+            cargoMonitor()?.writeInventory();
         }
     }
 }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -108,11 +108,11 @@ namespace Eddi
         // Information obtained from the player journal
         public Commander Cmdr { get; private set; } // Also includes information from the configuration and companion app service
         public string Environment { get; set; }
-        public StarSystem CurrentStarSystem { get; private set; } = new StarSystem();
-        public StarSystem LastStarSystem { get; private set; } = new StarSystem();
-        public StarSystem NextStarSystem { get; private set; } = new StarSystem();
-        public Station CurrentStation { get; private set; } = new Station();
-        public Body CurrentStellarBody { get; private set; } = new Body();
+        public StarSystem CurrentStarSystem { get; private set; }
+        public StarSystem LastStarSystem { get; private set; }
+        public StarSystem NextStarSystem { get; private set; }
+        public Station CurrentStation { get; private set; }
+        public Body CurrentStellarBody { get; private set; }
         public DateTime JournalTimeStamp { get; set; } = DateTime.MinValue;
 
         // Current vehicle of player

--- a/EDDPMonitor/EddpMonitor.cs
+++ b/EDDPMonitor/EddpMonitor.cs
@@ -23,28 +23,6 @@ namespace EddiEddpMonitor
 
         private EddpConfiguration configuration;
 
-        private static EddpMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static EddpMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No EDDP monitor instance: creating one");
-                            instance = new EddpMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         /// <summary>
         /// The name of the monitor; shows up in EDDI's configuration window
         /// </summary>

--- a/GalnetMonitor/ConfigurationWindow.xaml.cs
+++ b/GalnetMonitor/ConfigurationWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Eddi;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -9,12 +10,17 @@ namespace GalnetMonitor
     /// </summary>
     public partial class ConfigurationWindow : UserControl
     {
+        private GalnetMonitor galnetMonitor()
+        {
+            return (GalnetMonitor)EDDI.Instance.ObtainMonitor("Galnet monitor");
+        }
+
         public ConfigurationWindow()
         {
             InitializeComponent();
 
             GalnetConfiguration configuration = GalnetConfiguration.FromFile();
-            Dictionary<string, string> langs = GalnetMonitor.Instance.GetGalnetLocales();
+            Dictionary<string, string> langs = galnetMonitor()?.GetGalnetLocales();
             languageComboBox.ItemsSource = langs.Keys;
             languageComboBox.SelectedValue = configuration.language;
             galnetAlwaysOn.IsChecked = configuration.galnetAlwaysOn;
@@ -31,7 +37,7 @@ namespace GalnetMonitor
                 configuration.lastuuid = null;
                 configuration.language = language;
                 configuration.ToFile();
-                GalnetMonitor.Instance?.Reload();
+                galnetMonitor()?.Reload();
             }
         }
 
@@ -40,7 +46,7 @@ namespace GalnetMonitor
             GalnetConfiguration configuration = GalnetConfiguration.FromFile();
             configuration.galnetAlwaysOn = galnetAlwaysOn.IsChecked.Value;
             configuration.ToFile();
-            GalnetMonitor.Instance.Reload();
+            galnetMonitor()?.Reload();
         }
 
         private void galnetAlwaysOnUnchecked(object sender, RoutedEventArgs e)
@@ -48,7 +54,7 @@ namespace GalnetMonitor
             GalnetConfiguration configuration = GalnetConfiguration.FromFile();
             configuration.galnetAlwaysOn = galnetAlwaysOn.IsChecked.Value;
             configuration.ToFile();
-            GalnetMonitor.Instance.Reload();
+            galnetMonitor()?.Reload();
         }
     }
 }

--- a/GalnetMonitor/GalnetMonitor.cs
+++ b/GalnetMonitor/GalnetMonitor.cs
@@ -44,28 +44,6 @@ namespace GalnetMonitor
             configuration = GalnetConfiguration.FromFile();
         }
 
-        private static GalnetMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static GalnetMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No Galnet monitor instance: creating one");
-                            instance = new GalnetMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         /// <summary>
         /// The name of the monitor; shows up in EDDI's configuration window
         /// </summary>

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -213,10 +213,11 @@ namespace EddiJournalMonitor
 
                                     // Calculate remaining distance to route destination (if it exists)
                                     decimal destDistance = 0;
-                                    string destination = MissionMonitor.Instance.GetNextSystem();
+                                    MissionMonitor missionMonitor = (MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor");
+                                    string destination = missionMonitor?.GetNextSystem();
                                     if (!string.IsNullOrEmpty(destination))
                                     {
-                                        destDistance = MissionMonitor.Instance.CalculateDistance(systemName, destination);
+                                        destDistance = missionMonitor.CalculateDistance(systemName, destination);
                                     }
 
                                     events.Add(new JumpedEvent(timestamp, systemName, systemAddress, x, y, z, starName, distance, fuelUsed, fuelRemaining, boostUsed, controllingfaction, factions, economy, economy2, security, population, destination, destDistance) { raw = line, fromLoad = fromLogLoad });
@@ -2044,7 +2045,7 @@ namespace EddiJournalMonitor
                                     decimal? quality = JsonParsing.getOptionalDecimal(data, "Quality"); //
                                     string experimentalEffect = JsonParsing.getString(data, "ApplyExperimentalEffect"); //
 
-                                    string ship = ShipMonitor.Instance.GetCurrentShip().model;
+                                    string ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip().model;
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
 
@@ -3550,28 +3551,6 @@ namespace EddiJournalMonitor
         private static decimal sensibleHealth(decimal health)
         {
             return (health < 10 ? Math.Round(health, 1) : Math.Round(health));
-        }
-
-        private static JournalMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static JournalMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No journal monitor instance: creating one");
-                            instance = new JournalMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
         }
 
         public string MonitorName()

--- a/MaterialMonitor/ConfigurationWindow.xaml.cs
+++ b/MaterialMonitor/ConfigurationWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Controls;
+﻿using Eddi;
+using System.Windows.Controls;
 using System.Windows.Data;
 
 namespace EddiMaterialMonitor
@@ -8,16 +9,21 @@ namespace EddiMaterialMonitor
     /// </summary>
     public partial class ConfigurationWindow : UserControl
     {
+        private MaterialMonitor materialMonitor()
+        {
+            return (MaterialMonitor)EDDI.Instance.ObtainMonitor("Material monitor");
+        }
+
         public ConfigurationWindow()
         {
             InitializeComponent();
-            materialsData.ItemsSource = MaterialMonitor.Instance.inventory;
+            materialsData.ItemsSource = materialMonitor()?.inventory;
         }
 
         private void materialsUpdated(object sender, DataTransferEventArgs e)
         {
             // Update the material monitor's information
-            MaterialMonitor.Instance.writeMaterials();
+            materialMonitor()?.writeMaterials();
         }
     }
 }

--- a/MaterialMonitor/MaterialMonitor.cs
+++ b/MaterialMonitor/MaterialMonitor.cs
@@ -32,28 +32,6 @@ namespace EddiMaterialMonitor
         // they are fired at the correct time
         private ConcurrentQueue<Event> pendingEvents = new ConcurrentQueue<Event>();
 
-        private static MaterialMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static MaterialMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No material monitor instance: creating one");
-                            instance = new MaterialMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         public string MonitorName()
         {
             return "Material monitor";

--- a/MissionMonitor/ConfigurationWindow.xaml.cs
+++ b/MissionMonitor/ConfigurationWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Eddi;
+using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
@@ -12,11 +13,16 @@ namespace EddiMissionMonitor
     /// </summary>
     public partial class ConfigurationWindow : UserControl
     {
+        private MissionMonitor missionMonitor()
+        {
+            return (MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor");
+        }
+
         public ConfigurationWindow()
         {
             InitializeComponent();
 
-            missionsData.ItemsSource = MissionMonitor.Instance.missions;
+            missionsData.ItemsSource = missionMonitor()?.missions;
 
             MissionMonitorConfiguration configuration = MissionMonitorConfiguration.FromFile();
             missionWarningInt.Text = configuration.missionWarning?.ToString(CultureInfo.InvariantCulture);
@@ -25,7 +31,7 @@ namespace EddiMissionMonitor
         private void missionsUpdated(object sender, DataTransferEventArgs e)
         {
             // Update the mission monitor's information
-            MissionMonitor.Instance.writeMissions();
+            missionMonitor()?.writeMissions();
         }
 
         private void warningChanged(object sender, TextChangedEventArgs e)
@@ -34,7 +40,7 @@ namespace EddiMissionMonitor
             try
             {
                 int? warning = string.IsNullOrWhiteSpace(missionWarningInt.Text) ? 60 : Convert.ToInt32(missionWarningInt.Text, CultureInfo.InvariantCulture);
-                MissionMonitor.Instance.missionWarning = warning;
+                missionMonitor().missionWarning = warning;
                 configuration.missionWarning = warning;
                 configuration.ToFile();
             }

--- a/MissionMonitor/MissionMonitor.cs
+++ b/MissionMonitor/MissionMonitor.cs
@@ -37,28 +37,6 @@ namespace EddiMissionMonitor
         private static readonly object missionsLock = new object();
         public event EventHandler MissionUpdatedEvent;
 
-        private static MissionMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static MissionMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No mission monitor instance: creating one");
-                            instance = new MissionMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         public string MonitorName()
         {
             return "Mission monitor";

--- a/ShipMonitor/ConfigurationWindow.xaml.cs
+++ b/ShipMonitor/ConfigurationWindow.xaml.cs
@@ -17,10 +17,15 @@ namespace EddiShipMonitor
     /// </summary>
     public partial class ConfigurationWindow : UserControl
     {
+        private ShipMonitor shipMonitor()
+        {
+            return (ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor");
+        }
+
         public ConfigurationWindow()
         {
             InitializeComponent();
-            shipData.ItemsSource = ShipMonitor.Instance.shipyard;
+            shipData.ItemsSource = shipMonitor().shipyard;
 
             EDDIConfiguration eddiConfiguration = EDDIConfiguration.FromFile();
             string exporttarget = eddiConfiguration.exporttarget;
@@ -106,13 +111,13 @@ namespace EddiShipMonitor
         private void shipsUpdated(object sender, DataTransferEventArgs e)
         {
             // Update the ship monitor's information
-            ShipMonitor.Instance.Save();
+            shipMonitor()?.Save();
         }
 
         private void shipsUpdated(object sender, SelectionChangedEventArgs e)
         {
             // Update the ship monitor's information
-            ShipMonitor.Instance.Save();
+            shipMonitor()?.Save();
         }
     }
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -34,28 +34,6 @@ namespace EddiShipMonitor
         private static readonly object shipyardLock = new object();
         public event EventHandler ShipyardUpdatedEvent;
 
-        private static ShipMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static ShipMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No ship monitor instance: creating one");
-                            instance = new ShipMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
-
         public string MonitorName()
         {
             return Properties.ShipMonitor.ResourceManager.GetString("name", CultureInfo.InvariantCulture);

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -139,7 +139,7 @@ namespace EddiSpeechResponder
             }
             foreach (Event sampleEvent in sampleEvents)
             {
-                responder.Say(scriptResolver, ShipMonitor.Instance.GetCurrentShip(), script.Name, sampleEvent, null, null, false);
+                responder.Say(scriptResolver, ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip(), script.Name, sampleEvent, null, null, false);
             }
         }
 

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using EddiEvents;
+﻿using Eddi;
+using EddiEvents;
 using EddiJournalMonitor;
 using EddiShipMonitor;
 using System.Collections.Generic;
@@ -173,7 +174,7 @@ namespace EddiSpeechResponder
             }
             foreach (Event sampleEvent in sampleEvents)
             {
-                responder.Say(scriptResolver, ShipMonitor.Instance.GetCurrentShip(), ScriptName, sampleEvent, 3, null, false);
+                responder.Say(scriptResolver, ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip(), ScriptName, sampleEvent, 3, null, false);
             }
         }
 

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -638,7 +638,7 @@ namespace EddiSpeechResponder
             store["MissionDetails"] = new NativeFunction((values) =>
             {
                 List<Mission> missions = new List<Mission>();
-                missions = MissionMonitor.Instance.missions.ToList();
+                missions = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.missions.ToList();
 
                 Mission result = missions?.FirstOrDefault(v => v.missionid == values[0].AsNumber);
                 return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
@@ -656,55 +656,55 @@ namespace EddiSpeechResponder
                 {
                     case "cancel":
                         {
-                            MissionMonitor.Instance.CancelRoute();
+                            ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.CancelRoute();
                         }
                         break;
                     case "expiring":
                         {
-                            result = MissionMonitor.Instance.GetExpiringRoute();
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetExpiringRoute();
                         }
                         break;
                     case "farthest":
                         {
-                            result = MissionMonitor.Instance.GetFarthestRoute();
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetFarthestRoute();
                         }
                         break;
                     case "most":
                         {
-                            result = MissionMonitor.Instance.GetMostRoute();
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetMostRoute();
                         }
                         break;
                     case "nearest":
                         {
-                            result = MissionMonitor.Instance.GetNearestRoute();
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetNearestRoute();
                         }
                         break;
                     case "route":
                         {
                             if (values.Count == 2)
                             {
-                                result = MissionMonitor.Instance.GetMissionsRoute(values[1].AsString);
+                                result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetMissionsRoute(values[1].AsString);
                             }
                             else
                             {
-                                result = MissionMonitor.Instance.GetMissionsRoute();
+                                result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.GetMissionsRoute();
                             }
                         }
                         break;
                     case "set":
                         {
-                            result = MissionMonitor.Instance.SetRoute(values[1].AsString);
+                            result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.SetRoute(values[1].AsString);
                         }
                         break;
                     case "source":
                         {
                             if (values.Count == 2)
                             {
-                                result = CargoMonitor.Instance.GetSourceRoute(values[1].AsString);
+                                result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"))?.GetSourceRoute(values[1].AsString);
                             }
                             else
                             {
-                                result = CargoMonitor.Instance.GetSourceRoute();
+                                result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"))?.GetSourceRoute();
                             }
                         }
                         break;
@@ -712,11 +712,11 @@ namespace EddiSpeechResponder
                         {
                             if (values.Count == 2)
                             {
-                                result = MissionMonitor.Instance.UpdateMissionsRoute(values[1].AsString);
+                                result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.UpdateMissionsRoute(values[1].AsString);
                             }
                             else
                             {
-                                result = MissionMonitor.Instance.UpdateMissionsRoute();
+                                result = ((MissionMonitor)EDDI.Instance.ObtainMonitor("Mission monitor"))?.UpdateMissionsRoute();
                             }
                         }
                         break;
@@ -866,11 +866,11 @@ namespace EddiSpeechResponder
                 if (value.Type == Cottle.ValueContent.String)
                 {
                     edname = CommodityDefinition.FromNameOrEDName(value.AsString).edname;
-                    result = CargoMonitor.Instance.GetCargoWithEDName(edname);
+                    result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"))?.GetCargoWithEDName(edname);
                 }
                 else if (value.Type == Cottle.ValueContent.Number)
                 {
-                    result = CargoMonitor.Instance.GetCargoWithMissionId((long)value.AsNumber);
+                    result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"))?.GetCargoWithMissionId((long)value.AsNumber);
                 }
                 return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
             }, 1);
@@ -878,7 +878,7 @@ namespace EddiSpeechResponder
             store["HaulageDetails"] = new NativeFunction((values) =>
             {
                 Haulage result = null;
-                result = CargoMonitor.Instance.GetHaulageWithMissionId((long)values[0].AsNumber);
+                result = ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"))?.GetHaulageWithMissionId((long)values[0].AsNumber);
                 return (result == null ? new ReflectionValue(new object()) : new ReflectionValue(result));
             }, 1);
 
@@ -1045,16 +1045,17 @@ namespace EddiSpeechResponder
 
         private static Ship findShip(int? localId, string model)
         {
+            ShipMonitor shipMonitor = (ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor");
             Ship ship = null;
             if (localId == null)
             {
                 // No local ID so take the current ship
-                ship = ShipMonitor.Instance.GetCurrentShip();
+                ship = shipMonitor?.GetCurrentShip();
             }
             else
             {
                 // Find the ship with the given local ID
-                ship = ShipMonitor.Instance.GetShip(localId);
+                ship = shipMonitor?.GetShip(localId);
             }
 
             if (ship == null)

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -142,6 +142,7 @@ namespace EddiSpeechResponder
             }
 
             Logging.Debug("Received event " + JsonConvert.SerializeObject(@event));
+            StatusMonitor statusMonitor = (StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor");
 
             if (@event is BeltScannedEvent)
             {
@@ -184,20 +185,21 @@ namespace EddiSpeechResponder
                 TakeTypeFromEventQueue<StarScannedEvent>();
                 enqueueStarScan = true;
             }
-            else if (@event is SignalDetectedEvent)
-            {
-                if (!(StatusMonitor.Instance.currentStatus.gui_focus == "fss mode" || StatusMonitor.Instance.currentStatus.gui_focus == "saa mode"))
-                {
-                    return;
-                }
-            }
             else if (@event is CommunityGoalEvent)
             {
                 // Disable speech from the community goal event for the time being.
                 return;
             }
+            else if (@event is SignalDetectedEvent)
+            {
+                if (!(statusMonitor?.currentStatus.gui_focus == "fss mode" || statusMonitor?.currentStatus.gui_focus == "saa mode"))
+                {
+                    return;
+                }
+            }
 
-            if (StatusMonitor.Instance.currentStatus.gui_focus == "fss mode" && StatusMonitor.Instance.lastStatus.gui_focus != "fss mode")
+
+            if (statusMonitor?.currentStatus.gui_focus == "fss mode" && statusMonitor?.lastStatus.gui_focus != "fss mode")
             {
                 // Beginning with Elite Dangerous v. 3.3, the primary star scan is delivered via a Scan with 
                 // scantype `AutoScan` when you jump into the system. Secondary stars may be delivered in a burst 
@@ -217,7 +219,7 @@ namespace EddiSpeechResponder
 
         private void Say(Event @event)
         {
-            Say(scriptResolver, ShipMonitor.Instance.GetCurrentShip(), @event.type, @event, null, null, null, SayOutLoud());
+            Say(scriptResolver, ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip(), @event.type, @event, null, null, null, SayOutLoud());
         }
 
         private static bool SayOutLoud()
@@ -314,9 +316,9 @@ namespace EddiSpeechResponder
                 dict["body"] = new ReflectionValue(EDDI.Instance.CurrentStellarBody);
             }
 
-            if (StatusMonitor.Instance.currentStatus != null)
+            if (((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus != null)
             {
-                dict["status"] = new ReflectionValue(StatusMonitor.Instance.currentStatus);
+                dict["status"] = new ReflectionValue(((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus);
             }
 
             if (theEvent != null)

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -32,7 +32,7 @@ namespace EddiSpeechService
         public static SpeechSynthesizer synth { get; private set; }
 
         private static bool _eddiSpeaking;
-        public static bool eddiSpeaking
+        public bool eddiSpeaking
         {
             get
             {

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -31,6 +31,8 @@ namespace EddiStatusMonitor
         // Keep track of status monitor 
         private bool running;
 
+        public event EventHandler StatusUpdatedEvent;
+
         public StatusMonitor()
         {
             Logging.Info("Initialised " + MonitorName() + " " + MonitorVersion());
@@ -403,7 +405,15 @@ namespace EddiStatusMonitor
                 {
                     fuelLog = null;
                 }
+
+                // Pass the change in status to all subscribed processes
+                OnStatus(StatusUpdatedEvent, currentStatus);
             }
+        }
+
+        private void OnStatus(EventHandler statusUpdatedEvent, Status currentStatus)
+        {
+            statusUpdatedEvent?.Invoke(currentStatus, EventArgs.Empty);
         }
 
         private static string GetSavedGamesDir()

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -21,8 +21,8 @@ namespace EddiStatusMonitor
         // What we are monitoring and what to do with it
         private static readonly Regex JsonRegex = new Regex(@"^{.*}$");
         private string Directory = GetSavedGamesDir();
-        public Status currentStatus { get; set; } = new Status();
-        public Status lastStatus { get; set; } = new Status();
+        public Status currentStatus { get; private set; } = new Status();
+        public Status lastStatus { get; private set; } = new Status();
 
         // Miscellaneous tracking
         private bool gliding;
@@ -30,28 +30,6 @@ namespace EddiStatusMonitor
 
         // Keep track of status monitor 
         private bool running;
-
-        private static StatusMonitor instance;
-
-        private static readonly object instanceLock = new object();
-        public static StatusMonitor Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                        {
-                            Logging.Debug("No status monitor instance: creating one");
-                            instance = new StatusMonitor();
-                        }
-                    }
-                }
-                return instance;
-            }
-        }
 
         public StatusMonitor()
         {
@@ -490,12 +468,10 @@ namespace EddiStatusMonitor
 
         public IDictionary<string, object> GetVariables()
         {
-            return null;
-        }
-
-        public Status GetStatus()
-        {
-            return currentStatus;
+            Dictionary<string, object> variables = new Dictionary<string, object>();
+            variables.Add("currentStatus", currentStatus);
+            variables.Add("lastStatus", lastStatus);
+            return variables;
         }
 
         private void SetFuelExtras(Status status)
@@ -542,7 +518,7 @@ namespace EddiStatusMonitor
 
             if (currentStatus.vehicle == Constants.VEHICLE_SHIP)
             {
-                Ship ship = ShipMonitor.Instance.GetCurrentShip();
+                Ship ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip();
                 if (ship?.fueltanktotalcapacity != null && fuelRemaining != null)
                 {
                     // Fuel recorded in Status.json includes the fuel carried in the Active Fuel Reservoir

--- a/Tests/StatusMonitorTests.cs
+++ b/Tests/StatusMonitorTests.cs
@@ -1,4 +1,5 @@
-﻿using EddiDataDefinitions;
+﻿using Eddi;
+using EddiDataDefinitions;
 using EddiStatusMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rollbar;
@@ -20,7 +21,7 @@ namespace UnitTests
         public void TestParseStatusFlagsDocked()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16842765, \"Pips\":[5,2,5], \"FireGroup\":0, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             // Variables set from status flags (when not signed in, flags are set to '0')
             DateTime expectedTimestamp = new DateTime(2018, 3, 25, 0, 39, 48, DateTimeKind.Utc);
@@ -55,7 +56,7 @@ namespace UnitTests
         public void TestParseStatusFlagsNormalSpace()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16777320, \"Pips\":[7,1,4], \"FireGroup\":0, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             // Variables set from status flags (when not signed in, flags are set to '0')
             Assert.AreEqual(status.flags, (Status.Flags)16777320);
@@ -88,7 +89,7 @@ namespace UnitTests
         public void TestParseStatusFlagsSrv()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":69255432, \"Pips\":[2,8,2], \"FireGroup\":0, \"GuiFocus\":0, \"Latitude\":-5.683115, \"Longitude\":-10.957623, \"Heading\":249, \"Altitude\":0}";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             // Variables set from status flags (when not signed in, flags are set to '0')
             Assert.AreEqual(status.flags, (Status.Flags)69255432);
@@ -121,7 +122,7 @@ namespace UnitTests
         public void TestParseStatusFlagsSupercruise()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16777240, \"Pips\":[7,1,4], \"FireGroup\":0, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             // Variables set from status flags (when not signed in, flags are set to '0')
             Assert.AreEqual(status.flags, (Status.Flags)16777240);
@@ -133,7 +134,7 @@ namespace UnitTests
         public void TestParseStatusPips()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16842765, \"Pips\":[5,2,5], \"FireGroup\":0, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(status.pips_sys, (decimal)2.5);
             Assert.AreEqual(status.pips_eng, (decimal)1);
@@ -144,7 +145,7 @@ namespace UnitTests
         public void TestParseStatusFiregroup()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16842765, \"Pips\":[5,2,5], \"FireGroup\":1, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(status.firegroup, 1);
         }
@@ -153,7 +154,7 @@ namespace UnitTests
         public void TestParseStatusGuiFocus()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16842765, \"Pips\":[5,2,5], \"FireGroup\":1, \"GuiFocus\":5 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(status.gui_focus, "station services");
         }
@@ -162,7 +163,7 @@ namespace UnitTests
         public void TestParseStatusGps1()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":16842765, \"Pips\":[5,2,5], \"FireGroup\":1, \"GuiFocus\":0 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.IsNull(status.latitude);
             Assert.IsNull(status.longitude);
@@ -174,7 +175,7 @@ namespace UnitTests
         public void TestParseStatusGps2()
         {
             string line = "{ \"timestamp\":\"2018-03-25T00:39:48Z\", \"event\":\"Status\", \"Flags\":69255432, \"Pips\":[2,8,2], \"FireGroup\":0, \"GuiFocus\":0, \"Latitude\":-5.683115, \"Longitude\":-10.957623, \"Heading\":249, \"Altitude\":0}";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(status.latitude, (decimal)-5.683115);
             Assert.AreEqual(status.longitude, (decimal)-10.957623);
@@ -186,7 +187,7 @@ namespace UnitTests
         public void TestParseStatusFlagsAnalysisFssMode()
         {
             string line = "{ \"timestamp\":\"2018 - 11 - 15T04: 41:06Z\", \"event\":\"Status\", \"Flags\":151519320, \"Pips\":[4,4,4], \"FireGroup\":2, \"GuiFocus\":9, \"Fuel\":{ \"FuelMain\":15.260000, \"FuelReservoir\":0.444812 }, \"Cargo\":39.000000 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(true, status.analysis_mode);
             Assert.AreEqual("fss mode", status.gui_focus);
@@ -196,7 +197,7 @@ namespace UnitTests
         public void TestParseStatusFlagsAnalysisSaaMode()
         {
             string line = "{ \"timestamp\":\"2018 - 11 - 15T04: 47:51Z\", \"event\":\"Status\", \"Flags\":150995032, \"Pips\":[4,4,4], \"FireGroup\":2, \"GuiFocus\":10, \"Fuel\":{ \"FuelMain\":15.260000, \"FuelReservoir\":0.444812 }, \"Cargo\":39.000000 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(true, status.analysis_mode);
             Assert.AreEqual("saa mode", status.gui_focus);
@@ -206,7 +207,7 @@ namespace UnitTests
         public void TestParseStatusFlagsNightMode()
         {
             string line = "{ \"timestamp\":\"2018 - 11 - 15T04: 58:37Z\", \"event\":\"Status\", \"Flags\":422117640, \"Pips\":[4,4,4], \"FireGroup\":2, \"GuiFocus\":0, \"Fuel\":{ \"FuelMain\":29.0, \"FuelReservoir\":0.564209 }, \"Cargo\":39.000000, \"Latitude\":88.365417, \"Longitude\":99.356514, \"Heading\":29, \"Altitude\":36 }";
-            Status status = StatusMonitor.Instance.ParseStatusEntry(line);
+            Status status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).ParseStatusEntry(line);
 
             Assert.AreEqual(true, status.night_vision);
             Assert.AreEqual(true, status.lights_on);

--- a/VoiceAttackResponder/EDDI.vap
+++ b/VoiceAttackResponder/EDDI.vap
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <HasMB>false</HasMB>
-  <Id>18fe23bc-cb3f-4342-8a85-4d8b7caa5f18</Id>
+  <Id>3f035203-30ee-44ed-968f-f57b6bdb4bd5</Id>
   <Name>EDDI</Name>
   <Commands>
     <Command>
@@ -19,7 +19,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>c1021f79-1691-43c2-8b58-70472eca5f56</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>9ca9d789-6973-4308-94d5-77a8451d96e2</Id>
+      <Id>34739e37-85b5-4484-a5cb-055d7666bf62</Id>
       <CommandString>((EDDI: commander variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -31,7 +31,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bebcd018-d65c-4831-9b25-f279ebb27999</Id>
+          <Id>c45adfe5-20b3-4d3a-8c0e-f69281bb6ffc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -64,7 +64,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>01bd4f44-9664-4ae7-a17c-12987b04ee45</Id>
+          <Id>145e09eb-9df4-4183-835d-ac28de191b7c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -97,7 +97,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9b9f9d00-816c-4578-8018-b2a1665fc442</Id>
+          <Id>fdfa16f5-e63d-4ea6-bbc3-de446e9f0dd1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -130,7 +130,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9e5b12b-3319-4150-90b2-756b2782d3f2</Id>
+          <Id>18b8117d-2e3d-439e-8e55-e6814ff77ecc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -163,7 +163,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fc277857-a384-4690-9a31-591a640452e9</Id>
+          <Id>925a4767-a4c8-457e-bc98-989bc7a67a8f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -196,7 +196,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bc0c6c63-d8c2-42a9-9f14-2f734be68c8f</Id>
+          <Id>0ab857e2-3769-4096-8ab2-2e52f611d70d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -229,7 +229,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>aa323ffb-f79f-49de-9a02-4f29ff75cd6c</Id>
+          <Id>771aea95-fb92-405d-bc3a-ddd058206971</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -262,7 +262,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fb3105b9-0a17-453b-8f77-194250be0d4a</Id>
+          <Id>c8e09d71-9bac-423e-b2dc-c873dccde00c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -295,7 +295,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a5dccd13-9820-458d-83ed-0c7b7a305e32</Id>
+          <Id>56187c2b-8ea0-4a76-b050-6c57eae7d36d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -328,7 +328,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>93e4aa1b-6f76-4b69-afaa-53ca3253e6d1</Id>
+          <Id>86455586-d96d-4584-bd32-4510ef582db8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -361,7 +361,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>688a9f56-89ad-48fb-afc4-2ebdd39e6d3d</Id>
+          <Id>880c2073-4c62-4fc2-b13b-2ea9f03e2bbb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -394,7 +394,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7c614f80-9e99-4cc4-84a1-cbbb2023f343</Id>
+          <Id>b2ccb3ff-f348-4e03-8df7-75f36c2fb787</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -427,7 +427,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4255d624-a85c-4fa2-b5ed-c2c171f7e711</Id>
+          <Id>0fc8eceb-4d13-4568-bdcf-26f0b7810a6f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -460,7 +460,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>02b81cec-5259-4fec-a7ab-2b9e2cd8fb25</Id>
+          <Id>2674ac4b-da52-442f-8652-9700793f023b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -493,7 +493,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dd2477d5-ca1d-40c3-8576-2a036cc7552c</Id>
+          <Id>f3c047b9-995f-42d9-a243-6ba657e1522d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -526,7 +526,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>414d8397-7fac-43ee-9bb7-84efe17f2d97</Id>
+          <Id>86933e32-0e08-42c8-849b-d4e153eaff54</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -559,7 +559,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bf5147b7-f6de-452f-8ba8-e0c0e919adea</Id>
+          <Id>034edcba-d3bf-4d27-8b3e-a972b9a2a550</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -592,7 +592,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e1b33fc6-3871-4b29-a477-2b1f04fc79eb</Id>
+          <Id>cdf972e1-237d-412b-815e-dee70bba89e2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -625,7 +625,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>041af031-4e2e-4bf5-8868-8a7df50c7d27</Id>
+          <Id>9bbe57d3-06ed-4433-ac8f-c06fad02278f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -658,7 +658,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2fa5755b-48f9-4eb0-b7ed-9145d96c5a1c</Id>
+          <Id>7f8c90f9-81d1-4b43-b85f-0061df9f700a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -736,6 +736,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -752,7 +753,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>ddcd2b7f-1d26-47af-9511-9a05fb007f5b</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>7774543f-fa75-4462-a735-50bb99a3db72</Id>
+      <Id>fe17b6be-acae-4fe6-9fc7-7183caa90b8e</Id>
       <CommandString>((EDDI: EDDI information))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -764,7 +765,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0079bd3c-475e-4bd7-9360-84579e8ac2a0</Id>
+          <Id>091a655b-b5f4-4cbc-8f4b-25dcc09e75fa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -797,7 +798,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6103b500-9151-4941-9789-148ee4b4e647</Id>
+          <Id>47f58392-1c00-4d7f-9fa7-82a049d909b5</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -832,7 +833,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>35483a6f-50dd-430a-bcd0-b2398b9c2453</Id>
+          <Id>5b8b9262-0cf7-4bc1-9177-cc6e3c0db932</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -865,7 +866,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fe45526e-44a5-4859-9d90-1170869c70db</Id>
+          <Id>502e17fb-9669-470e-bf02-f258eb7e2b4f</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -897,7 +898,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6520f81a-1118-43b2-89db-7f1cde97010d</Id>
+          <Id>2fea52ac-fd00-4864-b031-47dad9a41496</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -932,7 +933,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>af5a4034-f313-4d94-9cbf-df0be0f2cf58</Id>
+          <Id>98fce994-3164-485e-a480-a638aa3be135</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -965,7 +966,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d88f2d3b-106c-4a17-9e14-9acdf8ee89bd</Id>
+          <Id>7b412996-576d-4f81-8499-1df4e455c1b1</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1042,6 +1043,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -1058,7 +1060,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>6a51c5cc-1c62-4ffa-8399-f92a15b1b16a</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>8caec172-7532-4d0c-894d-e05d18a9a1d5</Id>
+      <Id>2ffca653-159b-4a88-9129-4e728b6a3b61</Id>
       <CommandString>((EDDI: ship compartment variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -1070,7 +1072,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f046553a-5331-44dd-9506-863aa364919f</Id>
+          <Id>c6194706-6780-44fa-a6e7-381357db60b9</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1104,7 +1106,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fe06654d-80ad-4a97-8555-10ba9979d321</Id>
+          <Id>3a3d101d-b611-4476-899e-7035939492b7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1137,7 +1139,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>954c99fd-cfc6-4e36-93f7-c1bbf8b05186</Id>
+          <Id>70255384-af97-4a3b-812e-2c4d1f075fb9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1170,7 +1172,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ea81b37-0a3b-4062-85f4-4cd7f76355f6</Id>
+          <Id>deec4990-0e5e-49e5-9be3-84c101912302</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1203,7 +1205,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fa74bd1d-4dbd-4e51-85a7-36145ddb501d</Id>
+          <Id>5ff4f510-e944-44f9-a2d0-34224ec2e36d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1236,7 +1238,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d0cf9466-b48a-4303-b468-ee2bcbc16402</Id>
+          <Id>dadd1bfd-ada9-448d-b5be-fa3ec3774892</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1269,7 +1271,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>91434eef-3897-4078-bbe9-8664437f161e</Id>
+          <Id>9a45de69-b422-4af6-8ff1-f73402513844</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1302,7 +1304,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>058ec792-e37a-473f-9e34-55ba01f72a56</Id>
+          <Id>3496af6c-d654-4e00-8c53-07d328adb643</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1335,7 +1337,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>85067646-0c9b-4bc7-a538-c5d0e1dd6d89</Id>
+          <Id>1a8732cb-3e27-419e-a210-599b3f8c6d9e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1368,7 +1370,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b5b2db2d-8b7a-496c-999a-bca55a791356</Id>
+          <Id>b9852a2c-bce3-41d3-8959-ce2fb9d154bf</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1401,7 +1403,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>387977a1-e137-48d3-be26-6c5cc2a8b7d1</Id>
+          <Id>5b3a87e8-a198-42ce-b90e-4d73b01a7cbb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1434,7 +1436,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f7405df5-ea23-46ca-8be6-823a7b59bd28</Id>
+          <Id>a71317b5-96ea-4681-82ad-08e4d8d94898</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1467,7 +1469,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>61e213e7-46cb-4729-bf13-bf6581e06853</Id>
+          <Id>a9ce479e-27da-4944-af84-5f3572552897</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1500,7 +1502,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6dfb5546-d8d9-4527-80ae-d0fc4e7c7207</Id>
+          <Id>85270d95-aef9-4790-bf63-e1f3d9abee22</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1532,7 +1534,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c7e5a7d4-2233-444c-bfc0-d6fea80e45a5</Id>
+          <Id>9f89abd4-9889-4153-bf6c-7c490e9dd01d</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1566,7 +1568,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4794eb14-c57a-420a-9ea9-533eae57217a</Id>
+          <Id>0588a585-650b-453e-aaa5-9cd5e7039530</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1599,7 +1601,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ee49b9c4-c062-4239-807f-464dac2b443f</Id>
+          <Id>c8570915-5a7c-4416-81c4-5cb3213ac079</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1632,7 +1634,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>11f8437e-276b-46a7-a2e9-3dd091b32b3f</Id>
+          <Id>98da6a85-0300-4341-b40b-e4185edc3422</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1665,7 +1667,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f3b0af19-620c-457b-b75f-4eccc1b961f9</Id>
+          <Id>a16a5735-b84d-4bab-9743-98f4996985fb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1698,7 +1700,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a1b2488d-4ea2-494e-bf7b-153bf5e22652</Id>
+          <Id>f139b618-5df4-4ba1-99e2-60fe232cb0ce</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1731,7 +1733,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7b82bf54-dee6-4f75-931b-bd7e27bb0a10</Id>
+          <Id>349260aa-3b91-41b2-81ad-de59e7cae635</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1764,7 +1766,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6167a849-7984-47c2-b33a-749cf3f1c9f7</Id>
+          <Id>ab491516-f3fd-43d9-9abc-7309b7e58b10</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1797,7 +1799,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ff557420-5118-4d84-a518-f50e96d9c348</Id>
+          <Id>0f4b8448-822e-45ef-800d-63aca33682ba</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1830,7 +1832,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a1267cde-29a6-45f4-9aa0-7b332c5caec5</Id>
+          <Id>e36bf541-2f38-43a5-a2cf-aadc2f3b425d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1863,7 +1865,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1dc9345e-ab4b-4a90-83f8-9891fef27bf4</Id>
+          <Id>118df7b5-ecbc-4f3b-b8e2-6bd7e0b32fb6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1896,7 +1898,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>417033f9-ad65-4c32-b16a-880bdb11058b</Id>
+          <Id>0594aae5-7c81-4cb6-a85d-e7d5e406e6af</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1929,7 +1931,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5d04c32f-39fc-4594-a6f4-934de8b4face</Id>
+          <Id>78c5abaf-7a43-4c85-b3c5-b34a7c1fcce6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1962,7 +1964,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a990f600-ddb4-4297-a57c-fe20793ebfe9</Id>
+          <Id>b0223ea4-f6c7-49aa-972f-c7a567e5ad4a</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -1994,7 +1996,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d2043149-2172-4b24-82e7-d30daae6b839</Id>
+          <Id>7ccc5304-3a44-4c87-a3ee-f0c62d3a00a1</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2028,7 +2030,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c143ed2e-b45f-427e-854e-e06b9d361a8c</Id>
+          <Id>a449656f-1711-4e27-a8a5-3a93fcff2994</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2061,7 +2063,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0b5f0ebd-135c-46cf-aaa5-d8664f0b5d40</Id>
+          <Id>3683c51c-9009-4ed7-9279-240cb13e2326</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2094,7 +2096,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6c3ac1f5-cd52-4ce7-9bfd-ace53cebf13a</Id>
+          <Id>f6044160-ba0d-4369-8ca0-c8e2c16a9898</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2127,7 +2129,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9dd53ea3-942d-400d-9a9d-2ecb15d18f55</Id>
+          <Id>ff8e7ee7-5916-4e23-8011-e15359130e98</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2160,7 +2162,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d187a8c6-c5b8-47a6-a1a4-dca2dd1b2493</Id>
+          <Id>3ddf6a05-5d08-4d9a-9d60-b50404e48989</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2193,7 +2195,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a8aa04b3-dc9e-4d55-9f6e-85aa39751a7e</Id>
+          <Id>5872dea4-47fe-417b-91c4-e7e84faf1282</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2226,7 +2228,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b6e212f4-e43f-45e4-9433-8e262d69d5d5</Id>
+          <Id>7584d9af-99c5-4873-b1ad-f1cbf684c999</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2259,7 +2261,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b462e6c2-8b76-41b3-86fe-935afb160a12</Id>
+          <Id>ab9b806a-d329-4997-8fea-23765771a378</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2292,7 +2294,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ce4efb31-352f-4ce2-8927-ce1724b196c6</Id>
+          <Id>ab523461-221a-4832-839a-5f7e86cb195d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2325,7 +2327,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a9326f21-f289-4e93-8422-49d26f298c1b</Id>
+          <Id>35621113-3821-4663-9368-b764d4ac3ca7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2358,7 +2360,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b41f45a5-71d7-4757-a97d-1395baca28a3</Id>
+          <Id>a3e6f7d3-367d-47c2-92d5-eff03e18ea66</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2391,7 +2393,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>99b3963d-f255-40f6-aceb-373a2c533a13</Id>
+          <Id>4aab7dec-715f-4490-89a4-94f2c133bfdf</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2424,7 +2426,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b712c1a7-10d3-40b5-8611-1934f8f1c6b5</Id>
+          <Id>5b84c54b-b9c9-4a75-807f-b54994b6c481</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2456,7 +2458,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dba03b2c-e84e-4579-b57c-9323dea29461</Id>
+          <Id>57b92277-8794-4db4-a6b9-a9732e855ed2</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2490,7 +2492,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a9d9a5a6-97e4-4f04-8d90-b85dfd8d683d</Id>
+          <Id>b3a3faf1-cd0f-44c3-b3a5-faaa5ac4ec75</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2523,7 +2525,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0bf912cb-32ff-4e76-afb6-c5fd70bab365</Id>
+          <Id>abfd8e35-bba8-42b8-968f-26f42fff998c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2556,7 +2558,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f44b665d-d03e-4630-a19d-eb75aa7fc9eb</Id>
+          <Id>0a4b015a-ada8-490d-8417-c4b5fc903725</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2589,7 +2591,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>56426209-7a0d-459f-a03e-9553c3d84858</Id>
+          <Id>e76ce1a2-8e6f-42fb-9243-f6284cab08fd</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2622,7 +2624,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>57c5dbb9-19c0-4dd8-a7ee-90c4e2c9d4ff</Id>
+          <Id>6a389741-bc52-438a-a14d-079885c30f85</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2655,7 +2657,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b9ba8349-b551-4f21-a86d-7924d81d506d</Id>
+          <Id>b2807e01-7e5f-463c-a5e1-7da9ffda558f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2688,7 +2690,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>40f36060-6a6a-41a6-9d55-f5233d65f3e5</Id>
+          <Id>9a0939e0-4485-417f-a660-ab891b19c79b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2721,7 +2723,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>afbc39e9-7a61-4057-9ca0-9f43d0fb9af1</Id>
+          <Id>170bb1ac-494d-46da-a82d-7cd38b7b9fb7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2754,7 +2756,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>94a2b11f-7474-4ee6-b6a6-e3ef88039412</Id>
+          <Id>7448f724-fc62-4e92-9b02-0a3bbdc1e152</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2787,7 +2789,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cce0ac32-2d1a-4fff-b722-8a7b1a0ba93d</Id>
+          <Id>39fa709c-0cf4-4d28-b559-747cf00ac75f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2820,7 +2822,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>781f30d9-5ea4-4f21-ba38-2dbc9840f1e4</Id>
+          <Id>8dbff99f-ef9a-4e7f-9af1-810f78acc580</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2853,7 +2855,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>519978f0-3b59-4845-989a-31449f678e27</Id>
+          <Id>ce57eb8f-30f5-49c9-b929-7780a3f49888</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2886,7 +2888,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>deae14c8-778e-48e5-b31d-48a9918859b1</Id>
+          <Id>18b24b9a-6b68-4ff9-90dc-49276861bfc4</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2918,7 +2920,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>69b4eda8-8cf4-4ee2-8649-2330c07185ff</Id>
+          <Id>2c52399a-d001-48ee-bf1b-94b4b99f6853</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2952,7 +2954,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7017dd79-fbf3-4181-9be2-290e3ea3928d</Id>
+          <Id>2a309567-3534-4901-9c14-d4d2e03aff96</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -2985,7 +2987,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7f51d6b5-00c7-4aed-bf4f-20bae32c2608</Id>
+          <Id>1ca47593-f7d1-40d4-a0b8-c5013a5f2ff1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3018,7 +3020,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>737130c0-3c73-4540-899f-5a8c88458395</Id>
+          <Id>60d5267d-62e8-4724-8ee4-fdb18f398ff7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3051,7 +3053,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2ed8a4e5-2285-4f6e-b5b8-38420a4f1f63</Id>
+          <Id>2d804055-751c-4000-9cdb-446312ef27c4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3084,7 +3086,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e6048104-7778-40d1-a8f8-a1fb3491d603</Id>
+          <Id>1c98ceb1-80d6-4053-b5ce-001c8399142b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3117,7 +3119,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4740b145-799e-429c-b5d9-61315ddc2ca7</Id>
+          <Id>9e63c810-b941-44d0-a80d-6df8f869e822</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3150,7 +3152,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d12c4fff-06d3-4796-9f2f-38d930c4cab9</Id>
+          <Id>a72da752-b497-41a8-9198-7a471e1eed5e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3183,7 +3185,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>edbcdcad-7ce9-436f-8237-6b9718c70fe3</Id>
+          <Id>80e43807-07c5-48db-a438-fdf5f41a8e06</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3216,7 +3218,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ddf79abe-bd6b-4c9a-ac56-c5b66f9e6334</Id>
+          <Id>eb884c58-65ec-4ff5-8e39-35b9fbbe6e33</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3249,7 +3251,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6d644639-6b85-4146-9a02-67a8c60de877</Id>
+          <Id>630fed0e-6e21-45ac-8112-8a616b9dbe53</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3282,7 +3284,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8a74aaa6-cf6f-4d23-b575-0a6a4cf9b4c1</Id>
+          <Id>ec8df01d-1449-4513-9255-96e90952d670</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3315,7 +3317,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f5e99893-1d50-4cb0-aa09-32289b883601</Id>
+          <Id>7190683a-6840-42a8-b7b9-446abffe7be9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3348,7 +3350,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>477e0767-91b2-4388-8f28-de16d7ef299d</Id>
+          <Id>c57b0492-ac12-4ed4-92eb-96ff4f253b39</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3380,7 +3382,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>919bac6a-d7d5-466f-b568-c6e1aa05f808</Id>
+          <Id>2fc623b3-1152-4def-a5b1-39c1f4a41e0f</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3414,7 +3416,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>93f2d353-1a14-4b45-979f-b0543731efd8</Id>
+          <Id>29c1c254-3138-424c-bf19-6d0e470dce92</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3447,7 +3449,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6f68192c-e5cb-4432-8aaf-edfcc81cf7cf</Id>
+          <Id>cbe38d26-4a57-4cf9-886d-06d9ae24c143</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3480,7 +3482,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>515bf934-e15f-4769-be3f-07428daecc86</Id>
+          <Id>07e653dd-2c44-4d22-9d80-90735f40c1e4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3513,7 +3515,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9296ff0-ba78-4e32-91c2-f009a10923e4</Id>
+          <Id>3a6cd0a7-18be-49ec-b94f-9f9162ee85e2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3546,7 +3548,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>42d5d834-1262-48fd-a61d-d518d58b8ea4</Id>
+          <Id>98bb6696-3e44-4933-9982-b685a9bc99d1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3579,7 +3581,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d5bf1234-b924-4f3c-a42e-abb808ff0232</Id>
+          <Id>94bdab85-0729-4ad2-8097-b9fbed79e854</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3612,7 +3614,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d82c4812-72da-47cf-9d23-7e28adde6126</Id>
+          <Id>8a45f371-bfd7-4bcf-99d2-b55025950eba</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3645,7 +3647,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3e0ecda9-b583-4c71-93da-45d3155a6188</Id>
+          <Id>5f14cbd0-2707-4faa-9037-207c25dfbbd5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3678,7 +3680,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b03eb52c-7cf0-45d6-af21-bf61854e2798</Id>
+          <Id>36477c32-5265-4d62-b1c9-0971b4e82e2f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3711,7 +3713,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0457bd93-cffb-4d92-95d6-288ae1ff331d</Id>
+          <Id>e9fcf724-2221-4832-8c51-6072ca401e08</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3744,7 +3746,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8f095a29-1350-4577-bdea-0283b075a657</Id>
+          <Id>2e895f88-0d1c-44d8-8365-66b8943254a9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3777,7 +3779,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6957296e-69a5-4f7a-b195-cd88b686f308</Id>
+          <Id>00aa2388-ca73-482a-819d-1e9d67d8153d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3810,7 +3812,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4788a8c6-1e27-4b36-aaed-de1778b903a7</Id>
+          <Id>0e98ddf3-b558-4b7b-aabd-7e836bdf7aeb</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3842,7 +3844,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5d2062d4-14c5-45d4-be0b-1c835371ed69</Id>
+          <Id>069537a2-13fd-4a5e-bdba-27275f5a7af5</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3876,7 +3878,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>32ab909d-fa77-4386-a93a-0c2c2a80d491</Id>
+          <Id>10564401-d97b-4e50-b4b2-28994b8fe6a1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3909,7 +3911,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7d9a20c1-08de-44d4-b63f-97a0a9b66cd0</Id>
+          <Id>93aa665f-b954-4c76-9e63-e4819a61cf52</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3942,7 +3944,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1367b316-88b2-49c4-b234-fc47d11c5601</Id>
+          <Id>9eb315b8-f4c5-4b66-ac87-47a0cb432f5e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -3975,7 +3977,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6b2d38d3-7847-49d8-9741-4054133882dd</Id>
+          <Id>2b80eebb-81f2-4075-b0c7-e3c3b682a25b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4008,7 +4010,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>47b2d5c4-499d-434d-8b0b-4c37ce528795</Id>
+          <Id>fcdd2d77-dd1d-4a71-9ba5-c43d44303405</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4041,7 +4043,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8f95f752-6855-476e-9fbf-e6c2e0dea2e6</Id>
+          <Id>e08aecbd-b5de-403a-a2bc-291f1f79bebc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4074,7 +4076,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4188ab74-74b0-4f56-8e2e-c819de2b2287</Id>
+          <Id>cbd406ee-c6a5-4420-97d6-f3ec451a81f1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4107,7 +4109,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9682ea0d-fd6a-4e3d-b957-11cfa570a195</Id>
+          <Id>c5c8379b-16ce-488e-85a8-0d7d604c0612</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4140,7 +4142,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>43a005f6-a75d-4c46-b6dd-873e9d84e78c</Id>
+          <Id>fe8b27e1-ea40-41af-b2eb-e58b43d2d2bc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4173,7 +4175,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>42f1c7a9-3809-4dae-8a23-36feac2733ba</Id>
+          <Id>79a16fab-68bf-47ff-8850-823cfa1a9fc7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4206,7 +4208,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>26715cff-867e-433e-9ea6-3d0fe83487b6</Id>
+          <Id>172731d8-b78f-41e1-809b-ab4261c32960</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4239,7 +4241,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bf4a2722-6f18-41ae-8d8b-3f1143de869c</Id>
+          <Id>95ae5f42-a33b-4f87-a642-8e2bc597e9ca</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4272,7 +4274,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4fc4d632-5072-46f8-b84f-12ffacbdff5e</Id>
+          <Id>498846e5-5eb7-43e8-954c-49bc14bf418d</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4304,7 +4306,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e56f2034-7118-4155-a55d-4ca1fe5c3d46</Id>
+          <Id>8b9ddcc4-daee-4079-a971-7adcbf68242f</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4338,7 +4340,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0a179165-fe7e-48e6-881e-1df129bd4bf2</Id>
+          <Id>4326eff6-fd13-49bb-a8f9-99e1ea08dafb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4371,7 +4373,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>85677ed6-0119-40b0-9cb5-61a2f9e3f335</Id>
+          <Id>159bd2c8-88a8-4fc3-95a9-615d366a11a6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4404,7 +4406,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ad1a8774-b6e2-49e1-969e-94ceda57c662</Id>
+          <Id>e187b6f2-4d8e-422a-ad66-5639f640f029</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4437,7 +4439,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>05a996d3-6038-4eaa-bf4e-daf2cda14a00</Id>
+          <Id>a9357d20-55ed-4c0c-96da-4e3986960793</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4470,7 +4472,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6bd5c681-5ace-444b-8474-8f2f6d720b19</Id>
+          <Id>891958e3-eec3-44f1-9fbf-1e0eb2d41a82</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4503,7 +4505,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>db12e318-3eb3-493a-af91-aaee5b2895db</Id>
+          <Id>1bec387d-aca3-4c72-a6af-6589e04cf599</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4536,7 +4538,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cdd1ff6a-1cea-4a2f-8c94-6b0afb4f6eeb</Id>
+          <Id>db3a52ce-8e0d-4027-8b1b-4fad96f14263</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4569,7 +4571,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3feaf7be-8c7f-46c4-9b3b-0411d2934fde</Id>
+          <Id>e5f93a33-c9f4-4abd-946d-8d478d13a09f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4602,7 +4604,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>90a0d9d9-0fcf-48eb-b69a-11d85a778346</Id>
+          <Id>a585c8b4-63a1-4920-9b29-8ce91de43042</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4635,7 +4637,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4f33c727-12dd-4f18-9733-555690ed93fa</Id>
+          <Id>8ed5f370-981d-4ec1-933b-d0a940a5a22a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4668,7 +4670,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e12bf613-4dda-44cd-9eaf-9ab9f94f8914</Id>
+          <Id>cd6b9b4d-cfaf-4292-8b67-bb1c283bae82</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4701,7 +4703,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2b462b9c-483f-44ca-b7f7-f30d74f54434</Id>
+          <Id>7cd072a9-6c0d-46d4-bc9e-366d57a88358</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4734,7 +4736,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b4340936-b9ac-4cd8-8b73-c221169842fc</Id>
+          <Id>861f1dd0-fbd7-4183-be75-a2dc27fd5f5a</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4766,7 +4768,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1c8c265f-3e54-4b72-b777-391056d62d4a</Id>
+          <Id>9cda2419-7ace-45ae-a62c-ef508afdd382</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4800,7 +4802,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>87f1fa46-7ef6-41d5-958d-a08cbee3a83b</Id>
+          <Id>9d7cc77c-8382-4067-983b-1a7173eb80ad</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4833,7 +4835,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>acdbadb9-1fd5-4337-a7dd-1f82b84dfd32</Id>
+          <Id>687a253d-ab1b-4592-8963-2cad5f72511f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4866,7 +4868,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b8a3bb8d-8113-46d3-871d-de2ad8bd15f0</Id>
+          <Id>f7496837-ea8a-460c-b790-aff00d2e5865</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4899,7 +4901,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>645517fb-589a-4142-8368-0ac9d3d189e1</Id>
+          <Id>d10590ae-5cf2-4529-ae78-cdf8cc23175d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4932,7 +4934,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fc25ca28-e495-4529-8706-6c722903f654</Id>
+          <Id>82a34107-4f84-4852-b7d8-abfe02a0124d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4965,7 +4967,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bfbd817b-df0c-4349-86c5-1969856a66bb</Id>
+          <Id>423b53ff-ea74-4194-9d94-8d79f3768e14</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -4998,7 +5000,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>15b20c71-3644-42d0-87f9-b61cf226f31d</Id>
+          <Id>c3da9a78-d305-4ab1-a318-0a3dea759df0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5031,7 +5033,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fa0e7aa8-5572-4437-97ce-7bd6c9084b12</Id>
+          <Id>854785d3-29d2-4183-b6e6-bf158a45758c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5064,7 +5066,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bfd7344d-1cb2-48ff-b191-fd3950f3cd87</Id>
+          <Id>014b7e0b-f7e3-48cc-98ca-801b9872e992</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5097,7 +5099,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8fa8b1c5-aeea-4678-ab07-229b4b367b97</Id>
+          <Id>5e1aa314-663f-4ff5-b24b-e544f38dfc53</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5130,7 +5132,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c4db54d4-8e88-4dcc-872f-158ba617af80</Id>
+          <Id>dac864b9-d661-4f23-bbf0-a6b25d5f369c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5163,7 +5165,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c8737335-7230-4ee5-9e48-0f7b48ecfa8e</Id>
+          <Id>4fbd35fe-951c-4926-af48-a7f4011cd1cd</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5196,7 +5198,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e35c307b-1730-47a3-bbdd-923bb6b82837</Id>
+          <Id>7d16b016-31a8-4b2d-addd-971ebde1a9df</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5229,7 +5231,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>012e5226-1609-44c5-b2de-c1c8204f4e5f</Id>
+          <Id>5d83ff90-cc18-4978-a389-9e97dfc6a0d4</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5261,7 +5263,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1fd43adf-542b-4877-8754-2277cff2c91c</Id>
+          <Id>fd7a68ac-820b-43c4-ac44-d98fceb533a8</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5295,7 +5297,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e1e180b6-2ae1-44eb-b57b-05f329f0eda9</Id>
+          <Id>b34ba1fa-43f7-45cc-a615-e4b6b286db35</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5328,7 +5330,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ab084d6-0165-443c-8112-95fe294f8648</Id>
+          <Id>f76edace-d07b-4a3a-ae5a-2a22521e73e3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5361,7 +5363,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>49703462-a2ba-49fd-af14-1b4f00c62bc7</Id>
+          <Id>6b72930d-cd73-4eb1-aa5c-41573f94694b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5394,7 +5396,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>171de000-f310-49a3-bcc1-d780199d0fc6</Id>
+          <Id>d34ef4f7-2b3e-4307-842c-f85aea90ca7c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5427,7 +5429,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f2b00e81-7bac-4ff4-864a-ed6be0cba6a3</Id>
+          <Id>0f744911-f68a-4cf0-a88a-e5db77778120</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5460,7 +5462,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0b2582dc-18c1-4c7b-b40d-cbf1e13d3fc4</Id>
+          <Id>9d4271eb-558f-4761-a581-bc6bb4464f74</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5493,7 +5495,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>144ae0e4-5bbd-4da0-a878-302bb0c50db2</Id>
+          <Id>91b6b5b9-b2ab-4914-bc25-f2b6dfcad37c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5526,7 +5528,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2a562463-4f40-40f4-bd3c-17ee2e9e01f7</Id>
+          <Id>62149356-2d0f-4680-abf2-43a7df8c6fd7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5559,7 +5561,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ea28f769-9586-4fc8-86cc-0d161d7fcaff</Id>
+          <Id>a84cde19-f89d-4972-b59c-1cb0cbf95413</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5592,7 +5594,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d57300d0-8cf6-4493-b9e0-537518501e8b</Id>
+          <Id>fe66d513-2a1f-41da-b601-f2cbcd14ed4f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5625,7 +5627,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b53fe3d7-239d-43db-a643-1452769d5f31</Id>
+          <Id>cb374dcb-47d3-409c-b377-5e059a70db51</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5658,7 +5660,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>73f036a4-ca6d-4cd8-b144-598bfb65ea18</Id>
+          <Id>2bcfdbf4-1aa1-4d4c-8610-f053f12c382d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5691,7 +5693,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>22225dcd-50a3-4a25-849b-7c85bf9840ad</Id>
+          <Id>208ba898-8976-40f9-ba7d-ed4d096659a5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5724,7 +5726,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2878f020-17fc-453f-871c-bdeb42ba87f6</Id>
+          <Id>2c97ba68-35ba-4323-af8d-a11f7f39915d</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5756,7 +5758,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1cf140b0-d26d-4e79-ac09-05c639467c31</Id>
+          <Id>7e6c2ad1-95f1-4134-b269-dc738f848984</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5790,7 +5792,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f345a44d-2c4e-48d5-82f7-4bf1c4d5a97f</Id>
+          <Id>5967604c-7d4e-4878-8fb8-9a55cb999797</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5823,7 +5825,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1b576aa3-24ae-48d9-8528-51cb7eb60e89</Id>
+          <Id>9c4d8788-2c7a-4d3f-ae54-8ab5d5791f83</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5856,7 +5858,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9efb6e74-36de-45cc-ba24-a03146617a52</Id>
+          <Id>9f421a0b-7b92-495c-94ad-45b3105c6157</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5889,7 +5891,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a8c50d07-f983-4f15-bc19-079c071eb080</Id>
+          <Id>657940bf-d369-457a-af27-154d14c434cc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5922,7 +5924,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>24d5b695-289a-4c97-b92b-f5a8fce13866</Id>
+          <Id>de45c129-873a-49a4-9ae1-9522ff0d38fa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5955,7 +5957,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8a18d4c9-847c-490a-aa5e-765357a8837a</Id>
+          <Id>c943dc6a-9f58-42dc-88a3-fd523ba20839</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -5988,7 +5990,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>15c4feac-46af-4387-a05e-882994a313e6</Id>
+          <Id>8c59047e-e40c-40bd-a01b-67aecf1df77b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6021,7 +6023,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9c10a029-8b35-449f-bda2-8dea43ee1ad9</Id>
+          <Id>499820af-cfbf-42c2-a225-332b51fbac14</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6054,7 +6056,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>80db3115-e67a-4cfc-b066-18e82b2cdf7e</Id>
+          <Id>916b4d5d-dde9-4031-9634-c5304d613ada</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6087,7 +6089,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2a1923b7-6a14-4cec-9bda-efa643d3d1a0</Id>
+          <Id>84f2ee8b-b975-4a0d-a007-2f179e4f145a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6120,7 +6122,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>31122c17-c1fb-4432-a0f1-cf7705f8bf80</Id>
+          <Id>65b6f47e-b4bc-4719-887d-8098880b32e6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6153,7 +6155,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d10c542f-00be-4627-a665-8a0e95bdc3e7</Id>
+          <Id>e9125e2e-2f14-4ea7-9992-2e1fa07d53d8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6186,7 +6188,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fe39288e-8b7c-4999-8f8b-33b3d02b3fd1</Id>
+          <Id>efae1c2b-6692-4e84-ad14-070293dcae2c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6219,7 +6221,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3e833a45-032d-4c6f-9129-7bedc4e144f9</Id>
+          <Id>de696f9a-a5fa-4308-82f4-e731b1041938</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6251,7 +6253,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>64ce96c7-6438-4a33-89e6-3643c6ddadb4</Id>
+          <Id>1c3f2c9d-3518-4317-9197-6736b3411722</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6329,6 +6331,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -6345,7 +6348,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>45852062-70a0-43bf-bb8c-646c5a6e5353</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>6e46f6bb-20a4-417e-a3a4-47ec53820470</Id>
+      <Id>89cb4807-410a-4872-a18e-1d1d1ff1f22a</Id>
       <CommandString>((EDDI: ship hardpoint variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -6357,7 +6360,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>90f4bdea-26bc-4d8a-9d19-bb160348607f</Id>
+          <Id>b98fafa9-78bf-441d-9191-85fc92be8801</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6391,7 +6394,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f45fc270-6466-4c5d-b2a6-8ad92e083513</Id>
+          <Id>545d5963-170d-413d-8369-dded6d97d629</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6424,7 +6427,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f821a345-abb8-4769-bd90-7dd98966d5bc</Id>
+          <Id>eadd8e4d-970b-4906-a6b9-027cfffa29bc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6457,7 +6460,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c43ec190-4d66-420e-88e2-d67b4aa717c8</Id>
+          <Id>cfce6859-8ae4-4fc5-b929-a9bed666da1a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6490,7 +6493,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dbeb5672-483b-4eef-886f-9be31789f83f</Id>
+          <Id>b4e1797c-8ef8-4635-8782-b0d3099cf0a2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6523,7 +6526,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fd8541e4-8d6d-41a4-9f28-c470e9ed6953</Id>
+          <Id>b45c2f7b-837f-4e83-983a-01617f2b7219</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6556,7 +6559,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>94fabf27-77ea-4c2d-a9d5-5a70b937dfe0</Id>
+          <Id>ae09269b-032a-48cf-9d01-bc20908e876a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6589,7 +6592,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eda86a91-d435-4ce9-8e4b-b80e0a871b88</Id>
+          <Id>e1600c06-2d6a-4aec-8dd3-45362df12af8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6622,7 +6625,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5c21aaf9-1db2-4492-8082-fe4ea8f6424d</Id>
+          <Id>d7161bba-368f-4641-9d21-8e3e8b83e228</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6655,7 +6658,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c6c3e8e5-d41c-4987-b106-1fa20c055549</Id>
+          <Id>21c57808-0321-40eb-8cd4-80dab2189380</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6688,7 +6691,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ff1c6ac-cc0d-4117-b95d-8eba001320a6</Id>
+          <Id>13ef6b94-fcae-4426-bfb4-032658c50c70</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6721,7 +6724,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5219787a-52f7-48cc-9c1c-2a905091416f</Id>
+          <Id>ac003950-73d4-45c8-ae90-1514b971478f</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6753,7 +6756,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f7bbb419-dfd0-48ea-9cb6-eb06f233800f</Id>
+          <Id>09e2c0d7-aa45-4060-ad1e-6f8da547e771</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6787,7 +6790,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f2514932-839f-4ec5-a40a-f7d07e112cf2</Id>
+          <Id>a4a483ae-c032-4d4c-9e5f-9de6351c8286</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6820,7 +6823,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3d4c6185-04a9-4c9f-a510-92ec5ee22506</Id>
+          <Id>12e722d6-0ec7-4a2a-b71f-c9dfe46f9317</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6853,7 +6856,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>45b8d1e4-3dbe-4f6a-b26f-eb813ac9af68</Id>
+          <Id>3b866531-f0e2-4860-b322-713ef57eec6a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6886,7 +6889,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>043410ad-8127-4ad7-81ee-fa00a9e13270</Id>
+          <Id>3e229874-3b07-42ff-9bbb-89ae12d998e2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6919,7 +6922,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fc864404-b129-4311-9851-5db99df15b66</Id>
+          <Id>9224d2cc-ed2d-4660-8090-d55117ea6812</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6952,7 +6955,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>14e43db6-08a1-43c4-99c0-dbb1968fd9ab</Id>
+          <Id>3eb4bdca-ab25-433e-a667-1930c6a69a73</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -6985,7 +6988,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cc031cf5-4121-4d5b-b2b9-8d5fe086f61d</Id>
+          <Id>13ba7f9e-d593-4dca-88d0-dc811f379605</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7018,7 +7021,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d3098ba0-b7a4-44cb-b4e7-6c259b723424</Id>
+          <Id>9b4156a7-fd44-41ce-aa8a-62a9c6907e67</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7051,7 +7054,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>898233fd-27c3-47f2-8f6c-bed2f9ce4cd8</Id>
+          <Id>85fc9b57-7271-46bc-b3aa-7d4079dd1841</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7084,7 +7087,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0c6e8e67-5585-4077-b0ce-65b6bd10ae2c</Id>
+          <Id>764d17cb-671a-4b07-b8fa-e8b2f19b56ad</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7117,7 +7120,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2999b7d1-9b8f-460a-b148-62e6795b64dd</Id>
+          <Id>0f20ab9d-bfa8-41b9-9077-4c8f62e87802</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7149,7 +7152,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ce8b61ca-31ef-4740-9f9e-f41043ac44fd</Id>
+          <Id>e56f96a8-bb47-4037-b831-25f5b8df817f</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7183,7 +7186,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>55ae018a-6f56-4d89-a7d1-418dd03e15ea</Id>
+          <Id>a076b3ca-b6de-4500-979d-51f6a3ff9f64</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7216,7 +7219,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>90c5c9b7-246e-479c-8b68-2f8b6c1003ce</Id>
+          <Id>3aee2687-c93c-4883-a280-d67b65b9c67f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7249,7 +7252,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cee7ab47-8e86-4b1f-ac08-e548e2430750</Id>
+          <Id>69665195-edf0-4c0d-90a3-ac076010543b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7282,7 +7285,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d326de60-f201-4c68-bda9-2dd44e17bad7</Id>
+          <Id>dea89ff1-9fdc-454a-b875-931a64507fa2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7315,7 +7318,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b10c0401-495b-4231-b557-609ebb6cf15a</Id>
+          <Id>5c291c80-de0c-4628-95f3-6619cd76503c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7348,7 +7351,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4ca4e13a-816e-4362-9486-991c73f45579</Id>
+          <Id>13e9861b-b8cd-4a66-b496-75c5d1040687</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7381,7 +7384,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>10a0ced1-4e82-4986-912d-81766f0dcc41</Id>
+          <Id>500670ea-fcb4-4e64-aed2-99a9c05ba8e9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7414,7 +7417,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2eda3493-ffb4-4ecd-b151-87411aabe609</Id>
+          <Id>f294c85f-82c6-4252-98de-00bb45d7ca97</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7447,7 +7450,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>839e567a-4844-4056-8147-82aab1312d02</Id>
+          <Id>50b261c6-0046-4bbf-8911-bb1213610c9a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7480,7 +7483,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>06dc2359-d71e-497c-a39e-98bf9e59f369</Id>
+          <Id>ed4a64cc-fc67-40ea-8cdb-8b547750f5aa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7513,7 +7516,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>716b9567-3d6d-411a-8a02-196a7eeaa715</Id>
+          <Id>6cc8d4ce-c150-4c6f-acb7-099dd72df3ca</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7545,7 +7548,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1d2679ad-af2d-4e67-a42f-ad0289564989</Id>
+          <Id>7a1ff52f-0362-43d2-9d04-556ac4b2477b</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7579,7 +7582,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4dda8179-744b-42be-aa6e-c8cf6e2bfd73</Id>
+          <Id>9e87f1bc-d816-4c10-b83a-663e3db42473</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7612,7 +7615,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f9bacee8-462d-4154-85f6-4f7d45f3cd30</Id>
+          <Id>b026bb0c-12d5-43f7-953c-23f77c7a8ec8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7645,7 +7648,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ce930f69-231d-4cd2-9088-1d2ddb728625</Id>
+          <Id>e57e404c-a51f-4850-9e3b-1d0a7fc5693a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7678,7 +7681,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>66969d02-ba07-4524-9750-fcf91220a0a1</Id>
+          <Id>1921b3ee-54cb-408f-8cb4-e06948b20c64</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7711,7 +7714,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7ca0b3d8-aaf0-4b5f-b930-3399d7bd655f</Id>
+          <Id>03850118-6887-4d04-bae2-58de66d30cd9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7744,7 +7747,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9b20e340-e4f0-4667-b242-c1de8f791ee4</Id>
+          <Id>643d0d53-d17a-4114-a468-50ee0461fdbc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7777,7 +7780,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>915d93ac-2bfd-41ef-9ea4-9d7dc05f2b60</Id>
+          <Id>ba09c765-a1bf-47d0-84a1-e21fd999b7cb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7810,7 +7813,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>636321e0-4646-4e49-b58c-c790ab94a25e</Id>
+          <Id>9950c8a6-ccb5-4a0e-86fa-616c89572f61</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7843,7 +7846,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8acca0e4-f228-4fdb-ba06-444432472ec7</Id>
+          <Id>59cb535b-8119-4410-a3b5-6f3c246897bd</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7876,7 +7879,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9cb22614-482d-410b-bca4-36b09b6fbe6d</Id>
+          <Id>1230082d-a4b4-4b70-977a-8f84f9542f78</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7909,7 +7912,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c5982086-ba52-4045-947a-25cf7bea0e7b</Id>
+          <Id>73e5b9b9-d3fd-4849-a599-1d3cc78ab780</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7941,7 +7944,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ee2b4c34-af79-4a26-8c6c-6943abd3f0d4</Id>
+          <Id>6ce944bc-0b02-44dd-b661-f072f001d696</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -7975,7 +7978,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3483017f-9d65-4823-ab9e-cca909af2f25</Id>
+          <Id>cf5e369f-f926-4a59-8c58-c227cd0bb75e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8008,7 +8011,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ceaf5f74-1662-4868-8237-5e21118bc647</Id>
+          <Id>7082dc79-f739-44fa-93c2-785a8d7e4b83</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8041,7 +8044,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d9777fa9-5c01-492a-b504-3d2b444abd55</Id>
+          <Id>4cf72fd4-28b9-4f41-bbd4-0bb99aef592f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8074,7 +8077,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>67a61c40-54f2-4e34-9b71-d1ae4a4d73aa</Id>
+          <Id>8ff52ed3-a182-4352-8ed9-6452f6815175</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8107,7 +8110,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>808a6063-fecb-4d6e-bf95-2b9e908c00e9</Id>
+          <Id>2f32937b-bc45-4abb-962c-8c002c868b10</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8140,7 +8143,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b6d9ec4f-aa67-4b96-a0c2-72caad2f210d</Id>
+          <Id>c1a399f6-958b-4142-bb47-632406ecb0bb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8173,7 +8176,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dd3b1709-e0dd-4ae4-ad84-fef74a90b4ea</Id>
+          <Id>0cd57573-9df5-4d53-a316-e4bcf3c4c1d6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8206,7 +8209,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ff02175c-79bc-4695-a217-a902bd6fcb33</Id>
+          <Id>1398c49d-bd52-4896-ac91-dab2ecdfbd7d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8239,7 +8242,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b563f2bf-c2d0-4d48-9f59-69b3ed3ff605</Id>
+          <Id>831fd23b-54f8-47f9-87c0-94c531fd148a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8272,7 +8275,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b0271b72-d867-4f54-8376-fe6c2798d49a</Id>
+          <Id>4a0f05c8-268e-4747-a505-231cec99ebd7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8305,7 +8308,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ede6336c-e91a-42fc-9f0d-7da613848502</Id>
+          <Id>abb538e1-e797-495b-a2a8-cdcf4d94a2f9</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8337,7 +8340,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1837f881-0dec-4948-820f-9bacb385ea5f</Id>
+          <Id>bdfd2c19-4ecd-4138-9d73-a430126e25f6</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8371,7 +8374,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8d7349e6-12ed-471f-9acc-a01a4f75fc20</Id>
+          <Id>6b394230-d685-4aae-8f02-b24abd2a9842</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8404,7 +8407,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d48ade77-b194-4d83-b958-02eaf0b8647a</Id>
+          <Id>030c3866-b6c9-463d-81eb-936a2a571ae2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8437,7 +8440,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>60cb119d-ac73-412c-97eb-48c03176a7da</Id>
+          <Id>e8648804-ad39-4167-9ccc-dccbdbd4e6a9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8470,7 +8473,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2eb6fd4f-1a5e-4a6f-830f-9fa63e0635e4</Id>
+          <Id>4cc2cd37-58b2-4f9e-afa4-7605c5f673b6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8503,7 +8506,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7ced833f-f4c4-4a4c-a7a0-1cbd9e695846</Id>
+          <Id>b13c26d1-16e5-48dd-9846-41e69af1339d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8536,7 +8539,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bcef204e-ff47-48a6-880a-69f6bf056fd4</Id>
+          <Id>35a2b392-d6a0-4256-a62f-7b207dd4a088</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8569,7 +8572,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c6dc21b5-e988-4ceb-ae6e-f5bf91f61d0b</Id>
+          <Id>6227b4da-ff19-4888-9d06-4ff063978d80</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8602,7 +8605,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>00f7f5e8-3cd6-40cd-aa5a-b0bb83a6c309</Id>
+          <Id>eacd8387-583e-4280-8e87-508409a8ed51</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8635,7 +8638,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5c9dcd1a-5d44-46c5-bd4b-834c2834acee</Id>
+          <Id>32cb1c66-8fab-4cb5-b446-7b1adc2dce2a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8668,7 +8671,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3dbbe94e-3e90-4365-8b32-2dee49b62fae</Id>
+          <Id>10a79a9c-bf8b-4938-9f16-a5139ac4f595</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8701,7 +8704,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f52593dd-b2ad-4f4d-b312-989137c92896</Id>
+          <Id>46085948-abfe-4123-baba-890ee3069201</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8733,7 +8736,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cf905571-d39b-4b54-b4a7-1bca1623c14c</Id>
+          <Id>9a4bb0bf-80e5-46ad-bb5d-be54754b8a37</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8767,7 +8770,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8e68baf3-590b-47b3-a401-e609c908ff02</Id>
+          <Id>d080c763-f8ec-41ad-907a-319d2e419d69</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8800,7 +8803,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cf35fcc9-a273-4f47-8a6d-c6bdc46af3ed</Id>
+          <Id>06b3c4b2-1f61-4040-b6e5-1568597a4076</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8833,7 +8836,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1d6f9b89-0dcc-497b-9237-177554c41f7d</Id>
+          <Id>a50be4c6-44dd-480c-b061-8628604552b4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8866,7 +8869,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3ea97ea8-3af6-4afa-91a3-d132002371d6</Id>
+          <Id>6a2d5cda-05f3-44b8-8f55-821ad81e0c00</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8899,7 +8902,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9d506bb5-c876-4c47-ae60-71efc78d55b1</Id>
+          <Id>0e0f34f7-7bb9-4205-bec3-2eaa02e97433</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8932,7 +8935,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7fb3fa65-e711-4944-b8a4-261003b385f5</Id>
+          <Id>cb2da27a-cae5-4125-b6cf-77ae147990b6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8965,7 +8968,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ae05ce5-f6ad-43ce-9aad-f3d2565aca30</Id>
+          <Id>7354697b-b8d7-40b1-9453-e582c6bfe2de</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -8998,7 +9001,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9c89c160-c729-4c5d-a30b-1fbe1ac31dfb</Id>
+          <Id>432f8564-09d6-43fb-96fc-d7bf3135133b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9031,7 +9034,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6b0e7966-eeda-440f-a2e6-7a112bfddd36</Id>
+          <Id>e6e6ce3a-6fa6-4b15-b3be-b005ee96b819</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9064,7 +9067,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e81ae014-3f79-49de-a095-9d7f172b107c</Id>
+          <Id>d726eded-81a6-45ec-8c41-8058aa2558c9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9097,7 +9100,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8833b132-43c9-4af4-8d92-47ffd40b675e</Id>
+          <Id>6d729972-8db1-4132-9b2f-868dea4abc5c</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9129,7 +9132,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>64f7e24c-ad1b-4975-8416-ffd45c2320cd</Id>
+          <Id>b2697d99-607c-4128-8497-abf119a27634</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9163,7 +9166,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fdc89b50-459b-450d-a97f-b43b000fa034</Id>
+          <Id>901cb250-8f86-4059-8b6c-d2ea50a43b9f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9196,7 +9199,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5b5e4977-5e1e-4f9d-9bbc-e34e090b0eb5</Id>
+          <Id>0c7dc5ae-8e07-497b-8bf2-6f1adbf41ad3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9229,7 +9232,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>35fb1b1a-b12a-4662-a89d-595de6772268</Id>
+          <Id>f0e79aa3-70c4-45d6-8db3-4e1810d72e53</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9262,7 +9265,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f5a5d560-b52c-479e-892d-9c9b189005da</Id>
+          <Id>7ff51194-f7c9-49bc-9cbc-0db0b2eaa2c7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9295,7 +9298,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5879d03a-7b4e-4bf5-a5ab-5a0fcfc8cdcd</Id>
+          <Id>27f30d71-c96e-4ec4-94d6-660032d92e14</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9328,7 +9331,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b6e9f53a-2602-4123-b0da-d0d63e0ab888</Id>
+          <Id>4199b49b-6902-4555-ac44-d35c3822b4d1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9361,7 +9364,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>11ca22ba-6eab-4754-b663-b5cf276adbf9</Id>
+          <Id>8c9962b4-c501-4316-b249-274c5819ef04</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9394,7 +9397,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>feea7740-705e-47fa-ade5-7fd538a21703</Id>
+          <Id>43633e07-aad5-4570-9456-d359ab8947d6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9427,7 +9430,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>27f59250-aea4-4d82-9a2b-1d71161a7ad9</Id>
+          <Id>f5780bfa-87a6-46dc-8ecb-396f270b0aa0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9460,7 +9463,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3d03f4ec-2f47-4c22-8f88-e67795ba541a</Id>
+          <Id>3db35005-062f-4e45-9685-8fa29ccef6ed</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9493,7 +9496,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9ca2f5bc-2e8d-4705-af26-7ec004b23e8a</Id>
+          <Id>00db5b24-8181-4d6b-9837-32f16f3b680c</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9525,7 +9528,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>39e9a8b2-7e7f-4df5-bee7-6a39a86dc671</Id>
+          <Id>787c8cb4-cadf-4f0d-a185-22d8712c0700</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9559,7 +9562,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>996aa662-7ce5-42e0-a4b1-61d59bfefac7</Id>
+          <Id>27169395-90f2-4e6b-ab9a-005ee789942e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9592,7 +9595,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1a567811-9a37-45c9-9007-9f16deea4648</Id>
+          <Id>76bb007a-2830-41f7-bd02-0f57b401d398</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9625,7 +9628,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a0eef6a3-77a5-4880-9f19-dfad4558ab05</Id>
+          <Id>893aaf03-97a7-4f07-88b8-249e5546b81e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9658,7 +9661,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>90c1a1bb-a1ed-46cf-87fe-9020745b799f</Id>
+          <Id>06981b6b-1747-463a-8214-c5cbc4e3c857</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9691,7 +9694,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d1f5453a-e47c-443b-8a82-4148a4b38dbd</Id>
+          <Id>878d0044-a149-4a05-b39f-7ae196fbb641</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9724,7 +9727,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>458da044-315c-421a-be60-1a8276a797b5</Id>
+          <Id>30995ab3-c868-4ef2-bb0e-fd64441602f2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9757,7 +9760,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2febc44c-d41b-4a31-9cdd-d73fe6f2f95e</Id>
+          <Id>646fc553-0dae-4654-a63b-28bd55892566</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9790,7 +9793,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c6247674-1bdb-4b2e-8a01-24a7ed016391</Id>
+          <Id>245548c4-d950-4b1e-bb02-dfc3dba4ad2e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9823,7 +9826,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>70c6ae04-2785-45cd-968c-9a4deba5fc45</Id>
+          <Id>70f4d074-40c0-4aca-aa0f-339bc6d99b05</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9856,7 +9859,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cbaa34f2-b26e-4e25-89bb-de620b5ac64c</Id>
+          <Id>b7db8a05-2093-40ba-901f-213a549a3c18</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9889,7 +9892,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>354c1aab-e49c-4c58-a531-e69faa7c1f8f</Id>
+          <Id>0159b6ed-9ac7-4085-9565-d7930b36312c</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9921,7 +9924,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5608fd2f-cd4c-46f3-b6ef-5d6bdf60170c</Id>
+          <Id>a54e1997-8f48-41f7-9463-f8ad5b77b351</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9955,7 +9958,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>15b8f132-b040-4d07-99b6-9efc0873ea33</Id>
+          <Id>dbfe6e4b-bdb2-4ee6-b308-b918a9c232a5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -9988,7 +9991,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>51807ddc-c749-4263-9398-c516ea83fc23</Id>
+          <Id>09a2629e-24e0-49e8-9a93-ae65944d5b50</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10021,7 +10024,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>338181bf-b4ee-41d8-802e-968c82cbd8bc</Id>
+          <Id>42c4a782-c6fe-42af-9c6f-bbaae69c7627</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10054,7 +10057,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ba726332-db8e-4ef8-a3d5-5a2b434ed048</Id>
+          <Id>8d95ea9b-e5e9-436e-bb0b-0fcb17cd6116</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10087,7 +10090,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b5da2364-cdcd-4027-acb3-e47364b7ffda</Id>
+          <Id>33e8d48d-9ba3-41a2-97fa-afcd16405702</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10120,7 +10123,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a705b7e4-0e7e-401a-9053-84a67b245906</Id>
+          <Id>8be8f891-6b9c-4cf3-9efb-3142ccf82a8c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10153,7 +10156,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>097f85a7-026c-4886-8f9b-a96e4af88202</Id>
+          <Id>db55e215-5b07-4bc9-a55f-b8bd5d79d455</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10186,7 +10189,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ce791830-b727-43fb-8c70-dc875359e695</Id>
+          <Id>5ad92ed3-aeb2-4bbe-9c5d-2780c8dc9fb4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10219,7 +10222,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>13aeb3a5-6430-4150-bb30-456f974fdb59</Id>
+          <Id>c1275769-2b37-4293-838e-a0c51cb26d79</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10252,7 +10255,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f494e717-c72d-4732-b88f-aa0c0514002e</Id>
+          <Id>4f5b5178-64fa-4f56-9215-a28013bbee0f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10285,7 +10288,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e7a32c0d-ed73-4556-83f0-0057c78ad919</Id>
+          <Id>9a1f1c96-fe6c-44d6-b271-1d12998ea0dd</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10317,7 +10320,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ac44aea-9c61-486c-80b5-62cfdcee83dc</Id>
+          <Id>9299daa1-f26d-420a-a1a5-d07b020eb218</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10351,7 +10354,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>876c9fe0-f2f1-4123-9732-03cfffe6d303</Id>
+          <Id>d9fad01c-4274-4798-963a-0f0f6b9c153a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10384,7 +10387,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0d071e13-59e1-4ce1-b931-d4fc1446311c</Id>
+          <Id>88bb56dd-b41c-45d2-9608-cf6346b5cd67</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10417,7 +10420,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cdb23d2d-11c0-4c7b-825b-1bab1eb9f8a1</Id>
+          <Id>a46a3827-99bc-44d3-b362-9bdb08f688bc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10450,7 +10453,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fe660614-58e1-4c84-ac74-f447d53def51</Id>
+          <Id>8c3a691e-67af-4988-8986-240824a1716a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10483,7 +10486,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>94b6e528-23a0-4f27-901e-86ca89ecafc8</Id>
+          <Id>965648ea-1909-4341-b89a-7045fba202db</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10516,7 +10519,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d1e16683-0e5e-4cc8-ab41-fe37ddb04413</Id>
+          <Id>6961053e-2238-4078-9e7b-50feab095e5e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10549,7 +10552,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e75c1a19-0349-41d5-8493-bf8cab12313a</Id>
+          <Id>61a75002-ae9e-426e-8d2d-887cf0e2b633</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10582,7 +10585,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2b0f2a6e-96bc-4137-8592-b3882ef37b6c</Id>
+          <Id>2ada93ea-b171-4edd-aee6-5346918447ac</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10615,7 +10618,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9f4ab6d-9384-4c62-baeb-8e996237a3fa</Id>
+          <Id>b9233cb9-646f-4885-83bc-9a71719d7eba</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10648,7 +10651,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3f3bae52-aaf1-426f-85b2-c3a08c031fb2</Id>
+          <Id>c21cc4be-469b-4e49-9386-a1bc2cb993d3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10681,7 +10684,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>035f98d4-44eb-461c-b709-de7564359fd2</Id>
+          <Id>fe9081bc-eb7a-4e01-9570-b49d9993278d</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10713,7 +10716,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c2f04410-e969-4c91-abbd-8c08a8933bb2</Id>
+          <Id>fe2df60e-c3ce-4152-be65-6a29322371a0</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10747,7 +10750,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a4c4bcf2-8fc9-4aa1-ae35-c369af7ea54c</Id>
+          <Id>36b9f633-5133-4b83-bbb0-e221d9710740</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10780,7 +10783,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>36ee5e1e-08c0-46d2-a101-509f6cb139b7</Id>
+          <Id>902ec509-2b26-473c-9eab-b4e7fcd4bc0e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10813,7 +10816,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>310ba4d6-33b5-45f7-a2a9-7edc99dbca91</Id>
+          <Id>ebcdd619-6b76-423c-a527-e5173dfd1f58</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10846,7 +10849,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>13616aba-0469-4035-a15d-d09cd60a78db</Id>
+          <Id>e884a577-7211-4343-a849-d8a7a6693844</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10879,7 +10882,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b450d900-2bec-4959-a1d4-ec5d5d07e376</Id>
+          <Id>a95c00c8-c99a-4326-a404-4e82ca02e272</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10912,7 +10915,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dfaae95b-f7bd-4b8c-920a-9ff3e1e2bba0</Id>
+          <Id>15350079-555e-42de-beee-09a4977e99a6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10945,7 +10948,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3087f5b2-5068-46a7-8f42-5811ba77985a</Id>
+          <Id>f719066e-51bb-4e87-999e-56eedeecda95</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -10978,7 +10981,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>19ee2ab0-bb64-4ee9-9c05-a7196ecde05f</Id>
+          <Id>aad84130-0c38-4c7c-8d8e-4469d61cdf5d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11011,7 +11014,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>28cce388-d5f0-4338-8e80-5141e81e19a6</Id>
+          <Id>469a0650-e684-4e6a-80b0-bdf907714c41</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11044,7 +11047,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eb7eb804-dc65-4af1-956f-c2cac4bbc1da</Id>
+          <Id>3247ead2-a106-4e2d-aca9-e841405b166a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11077,7 +11080,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4df336d0-52c2-45f9-8db4-593d0964b91a</Id>
+          <Id>1e664c04-01a7-4ba1-904f-f5eb174eba52</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11109,7 +11112,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8c6e9031-f5f7-40fa-86bb-da5c02b1b18c</Id>
+          <Id>2b366abd-ce2d-423d-9633-02232d8e6a61</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11143,7 +11146,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6ca3a675-33fb-4ee8-a73a-752171cfa176</Id>
+          <Id>e42e8035-986f-4e9f-ad97-feb0cbfe6096</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11176,7 +11179,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>23b71de1-3aa6-4a74-8157-d184dab2c637</Id>
+          <Id>381d0248-ff47-4f54-a6fa-58c985713795</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11209,7 +11212,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8284aedd-1c35-454c-a00b-1ff2a97bd50c</Id>
+          <Id>cd02ea4c-4a9e-4d7d-8331-89c875019257</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11242,7 +11245,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a679ffff-d890-4265-b39f-ab176a2aa4d3</Id>
+          <Id>53a53859-adb4-4796-a961-5ff52a772b0c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11275,7 +11278,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>df85a0c6-0336-4e00-86c7-27f5ef5f399c</Id>
+          <Id>a5226b7e-e0fa-4076-9b58-21cd1ddb4583</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11308,7 +11311,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1ca4b1bb-e79f-4c7c-9bc3-2f4cb42928ce</Id>
+          <Id>4cba53e5-1a0a-47d7-aac9-975873c5fb71</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11341,7 +11344,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>66af8af2-4bf6-41b9-8889-d112361eff64</Id>
+          <Id>86b6ecc2-5f5f-48d7-aeee-5a5eda7062f3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11374,7 +11377,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7f9702af-8a43-4e05-abc7-d7e89e12861f</Id>
+          <Id>b42dc58d-8c1b-4e6b-b5c0-6198186238b5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11407,7 +11410,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d2a5046a-f388-4ffc-b38b-003d1b01a08a</Id>
+          <Id>f94ecb62-a964-481c-9498-53d8ec808473</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11440,7 +11443,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9408e827-c436-4f19-a331-c4c23e71fb03</Id>
+          <Id>33cfefa2-43b7-4e9a-aabc-4182b770a34b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11473,7 +11476,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3c02d90d-2e3b-430a-8385-46aef475e377</Id>
+          <Id>f1898295-8ebb-4fa4-97bf-a7466ff914f4</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11505,7 +11508,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fcc39a86-30bd-461b-9d10-a062379bbaa1</Id>
+          <Id>236e27c5-f6f4-44c8-8b86-2aae6f8e922b</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11539,7 +11542,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c764d8c1-cbf7-494c-8094-0af61e6c4e0b</Id>
+          <Id>6523e278-e77e-4a16-9d1c-c96dc03aab56</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11572,7 +11575,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>871fc64b-f3af-4a4a-9ecc-039fec787b6a</Id>
+          <Id>46e4b16b-c44e-4817-82c9-bdcefe68465c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11605,7 +11608,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>55358f99-e887-40e9-b492-587cca29f8dc</Id>
+          <Id>1c0caa35-57f4-4df3-b99d-6b503f2deb9a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11638,7 +11641,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4fda60ff-2603-4dbf-b453-ba2ec043e7b1</Id>
+          <Id>5e17697d-878c-4d65-9b36-a10a069078ad</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11671,7 +11674,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6eab5ca7-510d-4a6b-a74c-9fceb0f41aee</Id>
+          <Id>20e2ddf8-0ecc-4bad-9ab1-e86bbc43ad4f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11704,7 +11707,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>aef253c0-e213-406f-8528-62c3f6954ead</Id>
+          <Id>3fa7df09-178c-4618-919d-001b261bf102</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11737,7 +11740,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4f183f12-0f2c-4d9f-b0f1-b2665992e865</Id>
+          <Id>0b366df0-eb74-4346-b037-c90abaa8c24b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11770,7 +11773,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1489d855-7790-4f84-83bf-384495292805</Id>
+          <Id>1e64f67d-9ec8-450a-a694-47152a66dac9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11803,7 +11806,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9b614098-1eb8-4218-83e3-ae8c8fc75fe3</Id>
+          <Id>ba11a659-c30b-488e-8281-dc47e837730b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11836,7 +11839,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a9589f92-0d8c-46fe-bb78-c2c1b3d47d49</Id>
+          <Id>9f5c2bff-bc43-4c14-9170-7082111c87cf</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11869,7 +11872,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c3ef2985-2425-4011-9b67-e17d53ee3d32</Id>
+          <Id>a6e6023e-6700-4129-a7c2-a947c7b45025</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11901,7 +11904,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f0cb8ce7-9478-4f04-845a-f1a71ae731bf</Id>
+          <Id>04ce4f95-a20a-4d7d-8f8b-0b2c828ef057</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -11979,6 +11982,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -11995,7 +11999,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>2c6745a8-cb45-4589-af9e-a4054a04ef04</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>f73f1e7d-e76d-4936-a9d5-96f627e7c5d8</Id>
+      <Id>19d26cdc-11a2-4276-a790-f68c2d677a62</Id>
       <CommandString>((EDDI: ship variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -12007,7 +12011,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1727e5ca-e7d7-463d-87fd-43bcdb3931e4</Id>
+          <Id>9d712956-263d-48ec-9740-3a7de1ff4458</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12040,7 +12044,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4bd34920-0439-48dd-81d8-7928341ac522</Id>
+          <Id>6279fdc5-d774-4552-86e1-2ec8b8fd9b5b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12073,7 +12077,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cfd38cc6-711a-4006-8d32-2f675ddc760e</Id>
+          <Id>c7fee02b-6788-4a7b-9f81-e314e8aeb0c7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12106,7 +12110,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>88fc6920-d8bb-446c-9743-fef0511f6f41</Id>
+          <Id>e023d194-8c3f-4b56-95d1-1be67d7412a2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12139,7 +12143,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e784fb83-76fd-42a2-8dfe-b0a680738456</Id>
+          <Id>9b3208a6-7c32-47eb-b84e-f975ab46c3a4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12172,7 +12176,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4b2fcf39-259d-47d2-b725-7e9726e6d48f</Id>
+          <Id>e3cab1cf-2039-4414-81a2-e6a1568851eb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12205,7 +12209,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>78d6e849-c165-44c0-a7ec-f3735d07f320</Id>
+          <Id>705836e5-d4ad-4ab2-b820-b00e3fc7dc08</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12238,7 +12242,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d9ef376c-6ea1-41f0-9859-73b028348e42</Id>
+          <Id>fe6b4288-e02b-48b8-807b-36ebb7cbc98f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12271,7 +12275,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>27fd07a5-13dd-4526-8206-0fc786b6a56f</Id>
+          <Id>2549f19e-daab-467a-b825-feca5dc971e7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12304,7 +12308,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>05ecea3b-298b-475d-821d-d2d92edb4410</Id>
+          <Id>8de92322-1dc0-42ab-b387-87e5c60ea6ce</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12337,7 +12341,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ee78f962-d5e4-487a-b111-bfabfb75018d</Id>
+          <Id>56cbdeab-82a2-48f8-a6ea-58608e392283</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12370,7 +12374,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a1f318e9-6110-4d44-8cc8-e637e78698f3</Id>
+          <Id>1cc53c7b-7862-4f68-af48-c4f4069af8a0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12403,7 +12407,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ea1d211e-5db5-41e5-a031-8d6c862611d2</Id>
+          <Id>79f3c372-9cf4-45be-bbf6-73eaad22c7f1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12436,7 +12440,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>402f31ad-43e8-49ae-a834-c923427b7bf6</Id>
+          <Id>8d4d4778-9d0c-4ee5-ae26-ac4b133c6075</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12469,7 +12473,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1df5e379-84a8-410d-aeed-b23673d3a8a9</Id>
+          <Id>08dcae01-2b6f-45db-8c76-4f7c081b1ff2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12502,7 +12506,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>986593eb-d00a-4899-954e-df65375675b5</Id>
+          <Id>9311ae1c-d920-4f0f-8430-75ac0dc5c66c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12535,7 +12539,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4ec60863-418e-4360-9707-1a7c1299c69a</Id>
+          <Id>3c7597b3-3edd-4caf-a500-9b45b4cf9d81</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12568,7 +12572,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>34f8d01d-d1dc-42bf-9f3d-9df8823bb602</Id>
+          <Id>bddb2388-24aa-4d5b-a6b4-65f27a4d510f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12601,7 +12605,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>869218b8-69b6-4de8-9e37-5794c54cb35a</Id>
+          <Id>8fc812e1-e8e0-4307-bbf3-3d927bc38410</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12634,7 +12638,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0f17ca82-4b7e-4679-9dd2-26a31064d5f5</Id>
+          <Id>eb693e21-1005-40e2-b7af-8bde2bc70be2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12667,7 +12671,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eb86995f-d3a6-4d7a-8298-12688b74b655</Id>
+          <Id>ce57b3eb-d182-41e7-bcdc-b97293e63373</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12700,7 +12704,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f051457a-adf8-4017-b3ff-ae42bd0546d1</Id>
+          <Id>35ce9697-b58f-4082-a028-849ecb8110ab</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12733,7 +12737,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>479895cd-de9c-4243-aa5a-c346f5f5fada</Id>
+          <Id>c674f4fb-78f9-44bc-888b-ab5da2353107</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12766,7 +12770,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0db97b89-5a70-49bb-9311-814d64ebc51f</Id>
+          <Id>06b2427e-ea76-4364-987f-4643faf002cd</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12799,7 +12803,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f6682e59-30fb-49e1-8137-bfdfee4a5b37</Id>
+          <Id>a6dadd56-1658-402d-959b-c9f69c761ccc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12832,7 +12836,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3f504ae8-0d1d-4009-bce1-bd1442487c2e</Id>
+          <Id>f95a04ef-60bd-44a3-89aa-acf205975d99</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12865,7 +12869,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f96879e9-79b0-4ce7-b6a2-e5ce4915f6e8</Id>
+          <Id>9a0ee302-c8b6-4de0-a877-39c7a703253c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12898,7 +12902,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fa16e5a0-141d-4011-bf9b-9ecf4d5b5e7a</Id>
+          <Id>7ff3bc1e-5a0f-4e08-9ec7-ac4bc028db09</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12931,7 +12935,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b26ba218-006e-4b26-a860-60fa0dfa0b75</Id>
+          <Id>fa747da2-c476-4f81-b3e8-e872f0a53a9b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12964,7 +12968,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>311fcee2-37de-45ae-95bb-4d196310183d</Id>
+          <Id>3d5055a4-791e-4061-86b2-d7cb39af7506</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -12997,7 +13001,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f079019c-4032-4e8c-9a95-1c88d750ee9d</Id>
+          <Id>2517b4ba-d8a6-40d3-bc6d-fde90578084b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13030,7 +13034,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>44016ddc-dfbd-4bd7-803a-3393e93a2f90</Id>
+          <Id>f61b8def-6df1-488d-9e19-2ca9c8c2e898</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13063,7 +13067,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e7829c0f-a3ad-45c7-b0f7-a4cc4504214f</Id>
+          <Id>15eca6ee-fb2a-444f-9cf1-bcb9be901788</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13096,7 +13100,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>54c89aa6-45e0-4a85-872c-9296b9ddf5fe</Id>
+          <Id>f2186322-b66d-4aa6-a908-2fed43f6427f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13129,7 +13133,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>92c1f2b4-c54e-486a-ab46-5a0a3d90248b</Id>
+          <Id>a5b60802-2181-4630-bec0-f46ea94a9620</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13162,7 +13166,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1cab9bff-2c26-4f8c-937a-217ee8540379</Id>
+          <Id>5b65a7b8-aa58-421d-b62b-2b76ec1cee42</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13195,7 +13199,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a662206a-4eb8-436f-9cd7-fca54dd15ef8</Id>
+          <Id>84cf7f36-1885-4971-b7d3-e5b9141e135b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13228,7 +13232,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>09905a77-a7af-4ce3-bf01-01120f5b8f4c</Id>
+          <Id>ee5e320e-0029-4589-9e66-c208cfe66336</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13261,7 +13265,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f7133389-f0d7-4922-9dda-32a0fa38b440</Id>
+          <Id>8969b6ca-c817-42d8-8012-0c56e332e7da</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13294,7 +13298,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0d7da17d-0cc3-4a3d-a4d3-d9f8572a4486</Id>
+          <Id>92832d9f-d6ef-426e-b659-6c3b862ef024</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13327,7 +13331,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a1a9fe07-c0b0-40f3-bbe2-a14b5850ad1c</Id>
+          <Id>7acb7f38-f122-4df5-888b-ba0da3d3fd80</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13360,7 +13364,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>de6a5fa4-d50c-4bdd-9ac1-2c4238cc8b9e</Id>
+          <Id>c6ff99ea-2426-462f-85b5-f88d33d400d7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13393,7 +13397,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8ba3a318-bcb9-433f-ad36-2ac7c234c5d6</Id>
+          <Id>fc3a895b-7263-43c1-b8e7-a73f605abdfa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13426,7 +13430,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fc5644aa-1597-4cfb-8b97-cd498293a6d5</Id>
+          <Id>c2ca8faf-94f1-4e24-bea8-fd1484aa4228</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13459,7 +13463,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c95b5747-57b0-4008-914a-c8879cdb03b5</Id>
+          <Id>738ddbc2-4216-4ca6-b764-3c78f5269e2f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13492,7 +13496,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3d8d8b05-7e85-450e-a9a1-aed9308bec1c</Id>
+          <Id>f978023b-caef-4f69-90a5-dced98de2787</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13525,7 +13529,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>61613e3d-c4b1-4bcd-930b-f098fd92286b</Id>
+          <Id>b9ec71c6-f8bc-4675-9bdc-966e8999806e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13558,7 +13562,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>24f76641-e0a3-48b2-bf9f-ef92d8a03b98</Id>
+          <Id>cde375cf-212c-4485-a71e-1035f2d1fea9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13591,7 +13595,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>463f1b90-05de-4cd3-924f-2fadb97fa69a</Id>
+          <Id>5c6c0944-0659-457c-b458-35d67e571f88</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13624,7 +13628,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d97bcc8b-1843-4eb2-b2c4-08ecd7073ddc</Id>
+          <Id>eee834ff-4ae6-4159-95a3-afb35f91ca63</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13657,7 +13661,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d84e898f-5239-45a8-913c-fcc3a324d5ea</Id>
+          <Id>60e9b88a-2e29-4306-b27b-c9b49458e786</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13690,7 +13694,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a91ce8fe-d78a-4fbc-b8bb-3d49d266b24b</Id>
+          <Id>f0abe0e5-24a8-4565-bc7c-de17917eff68</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13723,7 +13727,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>69e2d047-cf9c-46b1-ac5f-fe38c262f95f</Id>
+          <Id>37f50762-86c8-4f8a-b8d7-e5eec2058910</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13756,7 +13760,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b8d7f384-0b65-4d5a-9a73-ce3ee9e9c9a6</Id>
+          <Id>e151e13e-8fbd-4c75-b873-6bb3fe202724</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13789,7 +13793,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ba9d73dd-09eb-441b-8668-9d14779f145f</Id>
+          <Id>a77a445f-a354-48f5-a431-30fbc1378c22</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13822,7 +13826,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b744d5bf-a25c-49fb-b114-6a9ae370705e</Id>
+          <Id>0c465664-e6ed-443a-84e1-97cc802976ab</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13855,7 +13859,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f3117794-8efa-456b-b693-21afa79b30e4</Id>
+          <Id>9a6881bc-1bd6-485a-83c0-871a6c3e79a8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13888,7 +13892,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9919e415-8c56-4ab9-af3b-abfb477a01b5</Id>
+          <Id>febc44b9-81b1-4fbd-ad48-7f4ad60df9fa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13921,7 +13925,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>83eef165-770d-4e89-821f-16cd7f61d5e7</Id>
+          <Id>53264895-09b0-4290-a4ef-f43967d0c46e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13954,7 +13958,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4c1913a7-8ae0-4a50-94a9-4ee6d54ce684</Id>
+          <Id>1f646716-1914-4ee3-9855-7c928a19f8bf</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -13987,7 +13991,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>16347de8-cdcb-4764-a19c-efa90d93dd32</Id>
+          <Id>718101a2-7338-4a10-acb9-0fe756e9f031</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14020,7 +14024,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ada2590-8f4b-4009-ba07-c3e38e398e89</Id>
+          <Id>6a0be2b6-9c41-4e1d-ab85-b38a4680c78b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14053,7 +14057,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a103e5ff-5c34-4827-b4a3-49b1a24c259c</Id>
+          <Id>ffc9cd5b-7262-4730-aa22-6770220cf2b4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14086,7 +14090,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cf4afd1c-75d3-4788-9543-78ee8b1f8765</Id>
+          <Id>8125290e-9e5b-4c3b-aa76-88a5cce5ab51</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14119,7 +14123,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>18f112e4-b431-4305-9542-aaa3b410b429</Id>
+          <Id>cc21abce-cbf4-4215-8a20-2521b639e1ab</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14152,7 +14156,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>144817b1-203a-4b1d-8355-c5ab0c4a61a6</Id>
+          <Id>bab7e2e5-6a7e-4c51-97bd-73bb9457ec3b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14185,7 +14189,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b5703d46-920b-4533-a846-7913ed404577</Id>
+          <Id>96ed993b-fec6-4075-8879-c5210692ce90</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14218,7 +14222,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b7cbcd54-179b-49eb-914b-cfbd19ac3048</Id>
+          <Id>03b5b225-6715-4148-a07e-c5d2890e905c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14251,7 +14255,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c98dbc5d-a213-46c7-82bc-e3dd54c4a73f</Id>
+          <Id>258d8d09-23da-44db-b1ee-df2b2a5dbc09</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14284,7 +14288,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b3ebdd51-5512-4cbc-88b7-a60af8caa601</Id>
+          <Id>c637893a-e67c-4be9-999c-1f3a9dc960d8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14317,7 +14321,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a1be2c7c-446a-4252-a1ad-7b5d064b7d49</Id>
+          <Id>11184fc3-48a1-4188-8029-e52ae85ffffe</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14350,7 +14354,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8b4cec9c-7d71-486a-a041-e3e80968b7b3</Id>
+          <Id>7482d795-fe37-47d2-84f8-ccc0a7d562c1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14383,7 +14387,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>59366d3b-ceec-448f-af3f-fbf85e02364f</Id>
+          <Id>9b6b81e8-78a4-4eb6-9a6c-9cfca81d7ea0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14416,7 +14420,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>86b8ace7-54ef-4645-ba0d-c6a06afb903a</Id>
+          <Id>fdfa4ee2-322a-48a6-a6cf-6fbd8c597b06</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14449,7 +14453,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e78f3c31-c872-4a51-9a91-137d6476422f</Id>
+          <Id>e325c448-2bf5-4b84-be07-fa5eb7810c16</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14482,7 +14486,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d35d9348-046e-4bff-ae7e-e667e48d56db</Id>
+          <Id>9aae4826-77e5-427e-a68c-d2876f551050</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14515,7 +14519,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>91700b28-11a0-43d9-88c8-67e1c13006ed</Id>
+          <Id>ff540b8f-726b-4440-a59a-b9f48783d978</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14548,7 +14552,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6d23aaab-8c66-4c4f-bac7-a44e0c63e2d1</Id>
+          <Id>a1d42710-f82c-485d-9406-d3b98f90ac1e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14581,7 +14585,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>86e18d70-4e7b-4db8-8fc2-410d77e28338</Id>
+          <Id>84536804-67ea-4c28-b1a0-d921e07b6419</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14614,7 +14618,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2ab648f4-b274-48c7-9b9c-889d639e3387</Id>
+          <Id>886b3319-6df3-43aa-9a2b-d49b84d958a0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14647,7 +14651,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eaf0f678-6e05-43b5-8199-9c37d2ea8e19</Id>
+          <Id>f4917f53-3ebe-4a67-82fa-b05e76f1bd10</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14680,7 +14684,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f0b0772c-404f-458b-bd41-2a789e241fc0</Id>
+          <Id>4743f9ac-221a-4394-95e3-d9f49e6b6075</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14713,7 +14717,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7f854b49-6e31-4ca8-bcae-0b603560b60d</Id>
+          <Id>322d8b29-6f66-4bb1-8388-9cb2e83af749</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14746,7 +14750,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>542b1621-73ff-4d02-8567-9c295418d92f</Id>
+          <Id>bdf773af-b658-4b71-b59b-80fec9a2ae3d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14779,7 +14783,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>22ebfaa5-8e9c-4b06-afc4-f8edb9e338bf</Id>
+          <Id>4eb1eb38-fa27-4440-a089-3689d01e7e04</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14812,7 +14816,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9332a4da-64b0-46f8-a3f9-713eab0355c7</Id>
+          <Id>7f6458ed-0639-4a7c-99e9-1c2c0ef74661</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14845,7 +14849,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>263c9c43-58a6-415c-b0be-681df2b7b054</Id>
+          <Id>63a4665b-e7e2-49b5-9afe-c93386e162f5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14923,6 +14927,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -14939,7 +14944,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>3ce26190-52e9-4300-9c01-584fb4a0b349</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>3fbd59e9-2c83-4764-979d-04a9840c8310</Id>
+      <Id>3590145d-5a80-48af-b6ac-0735635b3a5d</Id>
       <CommandString>((EDDI: shipyard variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -14951,7 +14956,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9c662c0-8abe-4e03-8c9f-4f290e6882e8</Id>
+          <Id>fc175007-9292-4b01-bf2c-796a8e8f6697</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -14986,7 +14991,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d1822f7d-a10f-48a2-9a59-1b4642f69dd8</Id>
+          <Id>b46a8a1d-1857-4d8d-ad00-920258e05508</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15019,7 +15024,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>78371247-1c05-4955-b372-1902d8a7f044</Id>
+          <Id>1c0c6f2b-0870-4264-b2e1-76d3f15ac12a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15052,7 +15057,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>01364315-9817-4a6a-a9bc-d0e6e78203b6</Id>
+          <Id>da3f31c1-d3d6-494b-9a4a-b57d19800a7b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15085,7 +15090,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3950105d-58d0-4fd5-a3b5-2dbeff6e6e38</Id>
+          <Id>9733900c-fe6a-4697-9213-5539ef9bbe82</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15118,7 +15123,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3952fa44-6bc7-4143-9795-e68da6ed3cf1</Id>
+          <Id>84c9ab18-0985-40d5-ba85-7b8ca602cdc0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15151,7 +15156,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5a4052d1-3b20-47ec-9cbf-5f4925cf8dd3</Id>
+          <Id>acb57441-ac64-4b7f-be81-4a4b747dd1d3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15184,7 +15189,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>94e30e70-7dd1-4ed2-b2ac-df19f1e90cfd</Id>
+          <Id>fbf5119d-48c0-40e3-beca-1313e69afed4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15217,7 +15222,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b504e3fc-948f-41e2-baeb-d72a26141796</Id>
+          <Id>939aa7e7-20e4-40aa-a586-8777000d512e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15250,7 +15255,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cd7f4032-1af6-4ef5-b4d0-e3f260096489</Id>
+          <Id>d978e4d9-626f-4d9b-97cd-c45f0d991cd2</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15282,7 +15287,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1f309660-45db-4f5a-9d8b-a5b2c12ce8b2</Id>
+          <Id>ef4768c6-079d-48da-9031-6339dc632684</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15317,7 +15322,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2f812662-9d4c-4f1c-a067-061c4fc67955</Id>
+          <Id>05e42e66-604e-4680-a587-71b48776a670</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15350,7 +15355,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4fcd2cf5-dbc0-4d74-abdd-3f193ce27457</Id>
+          <Id>f79017c4-0b11-471f-ae8f-349a2882863e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15383,7 +15388,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bb52e0c7-fd7c-4c1e-bae3-9c79a1fdfd9d</Id>
+          <Id>4f8d3fa0-c229-41d5-b94a-e4b0a3495151</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15416,7 +15421,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>40928e99-32e6-4c4c-957a-309ea7845712</Id>
+          <Id>d7762359-eb73-474b-a92f-e2b4ccc06e6e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15449,7 +15454,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>489a23b8-d91e-46e3-8c49-7e080dc57bb0</Id>
+          <Id>df0e18d1-05a0-488c-8d2c-83f6deebee8e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15482,7 +15487,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ededb8ed-aecb-4a3a-b01c-65f1ba55cce9</Id>
+          <Id>04fea5f3-328f-438e-9409-441e48b86b00</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15515,7 +15520,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6b96e789-eed3-4c8b-85f2-8d2febb6ccf9</Id>
+          <Id>6e597ded-21ea-4331-82b4-4bd5b8e942a3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15548,7 +15553,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>58cc1880-deb6-4091-8ffe-31e230d94ac1</Id>
+          <Id>8f37e7d2-a2cd-435b-914f-9a8915a90983</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15581,7 +15586,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f308c510-4ecc-46f0-828d-bcf2e24108a4</Id>
+          <Id>2df2a273-7c1a-4e97-bec0-19b58b24b620</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15613,7 +15618,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5e4aa6ad-d442-4118-842e-ef2ad9763250</Id>
+          <Id>28e042a5-addf-4dd0-9419-0030f2da6d33</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15648,7 +15653,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7bc814b3-6645-463c-8153-67a45c7a2cd2</Id>
+          <Id>7837ea4e-c4b2-4430-98d4-dfcfbeb3b6a4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15681,7 +15686,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8b7f7167-6001-4b99-b11a-51a15d61d56b</Id>
+          <Id>3c929f88-0b46-4850-be3f-9ef842ef4a9f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15714,7 +15719,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>59412757-5142-42f9-9c20-bb7936bd305c</Id>
+          <Id>3628efcb-8d36-4ef3-bc19-c818852c3235</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15747,7 +15752,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>08043be1-569f-439f-9528-241d55112fa7</Id>
+          <Id>9074e60a-ab10-4704-aac8-91134a39ce90</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15780,7 +15785,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a41b734c-6087-40d1-a1ce-9299f2325e0b</Id>
+          <Id>e0f674b1-8ed3-4f1c-84d1-12bdac084dda</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15813,7 +15818,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>db235921-51b1-44c0-beb8-687e6eeafd6d</Id>
+          <Id>a99f3182-6d30-4a8f-8f12-f29aa58d8140</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15846,7 +15851,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>26d02e58-6e03-4547-a7cc-6d8f5000e944</Id>
+          <Id>27e7b04f-68ce-436d-ae07-998dea042a92</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15879,7 +15884,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eb01e84b-f5f0-4b53-86c7-d7d4a00a1e63</Id>
+          <Id>6cb7f44d-7a3f-4aab-a0d9-69ccd95684f6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15912,7 +15917,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7e92dd4a-38da-460b-b6b0-138d4e53be27</Id>
+          <Id>6d99fb3c-f97e-4a2e-baa9-f4aca385343a</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15944,7 +15949,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7e8e301c-b82d-4e05-86e5-453c053cd55b</Id>
+          <Id>65273ae5-14ba-42f5-9a52-77b495925d1c</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -15979,7 +15984,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f4691a52-3353-40e7-9909-e49a229ab33b</Id>
+          <Id>7519c1fe-695d-4bf9-bd89-bcace151a3cc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16012,7 +16017,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1ea7c5f6-4549-48db-8b89-53e16d6abcf4</Id>
+          <Id>0045bc8f-c366-4d99-b55e-2093e1a82895</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16045,7 +16050,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6842d275-4980-44cf-a38b-f260276bf139</Id>
+          <Id>9fc219de-8541-495d-bc36-53e66e6578ff</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16078,7 +16083,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>484e72f8-158e-42ca-a334-1b9ca4466652</Id>
+          <Id>853e6bb9-2e13-4a13-b842-ec98b641daf7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16111,7 +16116,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0ce0db47-b30d-41f1-b8f0-436074075ed0</Id>
+          <Id>0fe8b36c-6c8a-461a-be94-66586bc326a6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16144,7 +16149,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ea71743a-6ee5-44ee-a29c-654023ba8416</Id>
+          <Id>c10a125a-bd5e-4720-a4be-01d172185e5b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16177,7 +16182,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>520f561c-70b1-4002-8080-5badee919ae7</Id>
+          <Id>46d37f27-ad8e-47bf-8779-af871f94b720</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16210,7 +16215,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5eef2f43-af7e-4792-9f85-3ce27e566354</Id>
+          <Id>079166b9-47bd-4239-965e-9c9ea49216d5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16243,7 +16248,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ffe93ec2-e522-415c-8529-227741e7eb87</Id>
+          <Id>5a4e9f6d-eb45-46f2-a094-46b96d2f9bfa</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16275,7 +16280,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3b89c5ab-e0ab-42b6-bf8c-f8e5939300ee</Id>
+          <Id>29b309ec-615d-4be1-b110-3ed5d2808264</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16310,7 +16315,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d339fbe0-61dc-4c64-a236-489d31bc3226</Id>
+          <Id>ae568288-5038-41a6-81ac-ed1b3b0fd6a3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16343,7 +16348,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5032e8cf-18db-425c-932b-2c722fd38524</Id>
+          <Id>6b833047-399a-4f80-bb89-14dadaafc164</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16376,7 +16381,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d1225400-b3ca-468e-9df6-8f79a72d2d53</Id>
+          <Id>64eeb591-ffcd-4153-a647-6fdde3cd0944</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16409,7 +16414,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f547e3e9-50cc-4f90-b22b-6c6d2e9f9923</Id>
+          <Id>da43709c-7e23-48e5-a9b9-db2a4447a203</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16442,7 +16447,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9315695d-9d0b-4560-9bcf-1ca892182ceb</Id>
+          <Id>24947a1a-da52-4b9f-a051-58167415f265</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16475,7 +16480,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5611e7e3-77ec-4f3b-b88a-2cdd6a32147e</Id>
+          <Id>7fee47d1-85ff-47fe-bd26-acfe1eeb6f98</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16508,7 +16513,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>505cbe6a-2db3-48fe-a17c-3afa8859d5b0</Id>
+          <Id>2072df34-0f11-45dd-84b8-4948e1b7d83c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16541,7 +16546,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5e560aee-9549-47a9-b7a0-ef5cf2d90f48</Id>
+          <Id>3ffcbcb1-98f4-49df-8ba4-ffe750af73b1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16574,7 +16579,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e6c46e5e-5992-4537-bf45-bbb21e4b5846</Id>
+          <Id>b78c85bb-7a49-4b64-aa2a-9a203ae5a94f</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16606,7 +16611,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2d8ad69d-365e-4e05-9519-4b7bf10c6ee1</Id>
+          <Id>04dc2c9f-b90b-49ae-9957-f7c38fa27657</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16641,7 +16646,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>80222dd1-1f5d-4988-8eae-300ba4bdab0f</Id>
+          <Id>4db859a6-b5ca-4871-9a96-065b4d08b2a0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16674,7 +16679,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>68d5b374-7237-447d-a3d5-7e74ad7feb42</Id>
+          <Id>87478fff-c303-4ffa-83f0-f72bb8dfb8e8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16707,7 +16712,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d095b458-9e54-43da-a0eb-51ea5c2891bf</Id>
+          <Id>4c55f004-e118-4f71-8921-7685c9646c16</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16740,7 +16745,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>58d00e5b-83eb-456a-8735-722d761c9dc6</Id>
+          <Id>91af3668-5bc0-4470-86c8-944dc395831a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16773,7 +16778,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bd80bb27-bfac-4aa8-8a49-6d92378e06b7</Id>
+          <Id>ff4365da-cf28-4081-8d2d-7243c991e6d4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16806,7 +16811,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>73a50478-7622-49a9-9560-4d8f61d4d76d</Id>
+          <Id>d8d1a46b-2f8b-45ca-b13b-1ca6a78fe611</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16839,7 +16844,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9f43dbb1-4974-48c3-b363-f0d0aca37b93</Id>
+          <Id>8a5ad33a-727f-4910-a168-e4f28c02b9fb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16872,7 +16877,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dc29068a-32e5-438f-8f7b-184a6154c707</Id>
+          <Id>5f6ed640-357c-498f-aca6-8da8dcd51261</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16905,7 +16910,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6d5a6542-329e-49e9-85c6-5bc82b87b526</Id>
+          <Id>2319830a-b1e1-4efc-b3c5-27ebc0860b0c</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16937,7 +16942,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dc2bd4e9-6d72-4fb3-b067-5f878c01d53f</Id>
+          <Id>107a3dbe-a250-447a-870a-2ffc078691b1</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -16972,7 +16977,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c16502b7-8d3f-4ffb-8d79-038ccf8013fb</Id>
+          <Id>833ee5ed-5a5b-46a9-aa57-7d39161388fe</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17005,7 +17010,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dbe002ca-9a78-4304-beab-1e49359ff356</Id>
+          <Id>170b455d-7f6b-48c8-be9b-ddce812eec31</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17038,7 +17043,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>58803022-2e7e-448c-aa24-9e30f4d90f81</Id>
+          <Id>12df16aa-c759-464c-a19f-33991b34efd3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17071,7 +17076,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>206cfe6e-0708-4836-898b-50ad28bc4645</Id>
+          <Id>d111ca2c-3795-4424-96c6-d02c143075d4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17104,7 +17109,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5745d1cc-a6e7-4afd-9936-0bad62112ff1</Id>
+          <Id>1792fdb2-d78d-4df2-9865-0a7e04284e80</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17137,7 +17142,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ef82271b-86a7-4a0a-a74f-3d9b6dcf4759</Id>
+          <Id>ffc06ee4-86c4-460e-b54a-fca5f21c68b0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17170,7 +17175,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5d1608ab-5eb2-4dbc-acf4-ff184d9b0299</Id>
+          <Id>4ba7787d-bd4e-4d06-8916-a3557b3e9246</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17203,7 +17208,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8d4d335a-f967-4bfd-910d-c6045f11e5a7</Id>
+          <Id>e68dbab9-7f65-47d0-b3c8-31776ed32e87</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17236,7 +17241,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>902a8bb2-1407-4c7c-a184-170276f0da46</Id>
+          <Id>cd2a364b-14fc-49a6-ad4a-afb3084146c6</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17268,7 +17273,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eaaf25b4-10bd-4d14-935c-bab5c23940b1</Id>
+          <Id>2572f041-8691-4c45-bb64-cb0e3482a8d5</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17303,7 +17308,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9703cbc5-cb84-401c-8020-dbf11b2c9655</Id>
+          <Id>bd7ccdf2-aee3-4cdc-b77e-0e7e07a073cc</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17336,7 +17341,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7a4c4e54-ce1a-4f90-a828-acc82016ac4e</Id>
+          <Id>8c63f64a-ec99-4289-bcef-9a14d5dc2a74</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17369,7 +17374,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2d5f5393-f691-4f99-93bc-1a78d9ef0188</Id>
+          <Id>3f073937-1557-4f9a-9ce1-8bdf6c76f3d5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17402,7 +17407,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ea157bf8-0860-4a20-bb85-6055a542fa08</Id>
+          <Id>f03d6266-31fe-4d38-b2c8-02785bc97384</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17435,7 +17440,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>08603533-0439-44fc-b803-9db0168068f1</Id>
+          <Id>653df654-a96d-48d6-8df9-3d6a4982593d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17468,7 +17473,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0ee3bdac-a39e-43fe-9bfc-8f330ea9717d</Id>
+          <Id>01272c93-6734-4e07-aeb9-ca66ae6b3095</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17501,7 +17506,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>db104244-7337-4988-8ed1-f6789b80fd5f</Id>
+          <Id>551c789b-a4d0-4041-9951-b43637288bac</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17534,7 +17539,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b7aa41d4-a685-4fc4-b841-65a0a8d2adee</Id>
+          <Id>a28dc6b2-2396-4772-9963-4a1d8261cdc2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17567,7 +17572,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cf97bfe0-049a-4d5d-8a2b-c1e7e16e3847</Id>
+          <Id>06e06686-0b83-4094-8268-3b11ea2d95f8</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17599,7 +17604,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>afee3ad7-9307-4891-b9c8-60ff5f0131be</Id>
+          <Id>3137ce4e-5de7-4af1-86f3-990f1ba83098</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17634,7 +17639,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fc71d78c-1bcd-4524-9708-d0a92c5b9d44</Id>
+          <Id>f3f802ff-d580-4c82-9508-36505fe26a0b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17667,7 +17672,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5600000b-eddd-4530-8389-ba5f5dfc5b3c</Id>
+          <Id>7f55da2a-9e80-45d0-84e8-45dedda5e9aa</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17700,7 +17705,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>12909328-a384-4e40-b059-aec6b57cbfd6</Id>
+          <Id>cbb50a11-53af-4e70-a315-85f34e8bff2d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17733,7 +17738,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f62ce291-d18a-43c3-bf1d-f9eedb75b97a</Id>
+          <Id>bbc064ea-747c-4059-bf52-1e0550733321</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17766,7 +17771,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9d9053cc-c89a-4624-bfaf-458d95a2a50c</Id>
+          <Id>1cf1a84a-aa30-4bb3-b0d9-1ffa689b6ad2</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17799,7 +17804,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f22676dc-a864-4813-bfde-87deb0421164</Id>
+          <Id>1b0ba98c-ea89-4ce3-bcac-8f9232f4da84</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17832,7 +17837,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ba78dd3-ea94-4f37-ad2e-57649cf00f74</Id>
+          <Id>562d20f4-3025-4703-95f8-7845d48dfa13</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17865,7 +17870,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f25c05d1-9a17-485a-9702-3d51aee45cb7</Id>
+          <Id>22f317f6-4249-4125-911c-26ca88590776</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17898,7 +17903,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>068d615c-f4dc-4d89-a105-d31b8e7aa73d</Id>
+          <Id>bb5e6a56-1b8d-41c3-8708-9a883cec57ce</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17930,7 +17935,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>55a6f0a1-aee2-4346-9704-5631a75e875b</Id>
+          <Id>88633681-398d-4c97-a0fa-b9e04292db7a</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17965,7 +17970,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>02987911-e8dc-4ad3-b96e-67540a3bd2ee</Id>
+          <Id>7ea25891-cb19-4f32-b132-5f5c3e04ae1d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -17998,7 +18003,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2a57012f-5c24-4742-b9e9-662a83ebdca1</Id>
+          <Id>c5656632-21e0-43ed-a624-812df07fbac1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18031,7 +18036,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>68408b74-13a1-453d-b476-f92d565ced50</Id>
+          <Id>48b673c8-3e27-49cc-832f-89d782e63f61</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18064,7 +18069,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>76dc63c4-3edf-4cbe-a100-bd9ff7b1bb33</Id>
+          <Id>3bd19ea2-979b-4a79-945a-bb922c66b90f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18097,7 +18102,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>17375708-5f5f-424c-9e44-d2f8ec8b6abb</Id>
+          <Id>87fb56fa-a7dd-4a70-81a4-589fa7a05d59</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18130,7 +18135,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f7ce21c0-b9db-441f-b79c-b03daa4e0d67</Id>
+          <Id>960fe61c-e3c7-403b-b03a-02c555831e5c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18163,7 +18168,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>19756bf0-2926-475d-93f4-7d69513ad2b9</Id>
+          <Id>d6e67080-3c52-48d9-a885-4d68db08f7d3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18196,7 +18201,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>db21b96b-f895-46d8-b0b3-466b44d5eefa</Id>
+          <Id>bf1b4eb7-00cb-480c-9b7d-29d0aba9aabd</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18229,7 +18234,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5cc9f7b1-85a3-4184-9df1-7cd0cb0629c1</Id>
+          <Id>36d44899-e1c8-4b45-8f96-45f17781b7da</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18261,7 +18266,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bba57b75-0066-489c-aaae-b3a76130e73c</Id>
+          <Id>ed26ab53-e672-4f86-aa93-5f7075a62311</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18339,6 +18344,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -18355,7 +18361,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>b6986556-31e4-45eb-8840-35c2660e07f8</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>5e788bb0-2003-41ec-bfbe-88026fddffd7</Id>
+      <Id>49e597f6-6dfe-4203-97dc-16482766eb31</Id>
       <CommandString>((EDDI: station variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -18367,7 +18373,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>72150237-9014-4038-914d-1292b7abb2fd</Id>
+          <Id>bbf767b7-9dc5-4b03-8e08-f050610334c1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18400,7 +18406,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ac23cc98-c54d-477a-a19c-1570bb59423b</Id>
+          <Id>c4afe12d-df62-4ccc-af74-677708455d07</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18433,7 +18439,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>29f36f4d-e503-4420-bca3-37b177529ed3</Id>
+          <Id>a2c68013-3975-4c9f-88cf-4127f14da0f3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18466,7 +18472,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7dfc2eec-de14-4f75-8c04-7b1ef553c304</Id>
+          <Id>dc68086b-565b-48fe-87c8-30e5d2791523</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18499,7 +18505,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ae434462-00f6-41b4-a177-fe9de6e868c2</Id>
+          <Id>6aeb01a8-2400-4729-b55e-5b8a2b5753b7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18532,7 +18538,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a409f1fc-3c51-4356-9d7c-7a64fcaa6f4e</Id>
+          <Id>8ff6aaa7-8c9b-46d2-bdda-0942354b4430</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18565,7 +18571,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b91cef5d-34e5-458f-82d2-593b780d1133</Id>
+          <Id>6c191f89-d920-4fff-8152-397dd0384993</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18598,7 +18604,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>95a0b318-4d7d-4fde-81c3-aca59ca73e7c</Id>
+          <Id>07c00777-e668-45b6-abb1-414b3f21a31d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18631,7 +18637,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a094e1d8-f654-4035-bafe-1497585521a2</Id>
+          <Id>1b7b8096-3141-4772-978a-73ea52489940</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18664,7 +18670,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>806ed5b3-5470-452b-a3fb-1b4643607c19</Id>
+          <Id>946a46f1-7acf-4717-9060-b1f26a70c36d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18697,7 +18703,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ad8e0523-c2c6-4791-9670-cc8eb7f648aa</Id>
+          <Id>3defa25a-0307-4fdf-b20f-c54c79c83b59</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18730,7 +18736,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9f0454ae-2f7f-4f28-a442-07661cd6541c</Id>
+          <Id>eeaf37ed-e43d-4eb0-824b-bda4d04fad75</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18763,7 +18769,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dc70bd33-430e-4610-be3d-0106076de3bc</Id>
+          <Id>331327e4-59b0-426e-95b8-5790916f4955</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18796,7 +18802,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d1f6de9d-2c30-4b85-aee1-5b5d54b503cc</Id>
+          <Id>48f48675-7f30-4bbc-be40-7305e96b56c4</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18829,7 +18835,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>023fd6a2-dffe-43fb-a8d2-05960891395d</Id>
+          <Id>de2f39a1-77be-484d-a5e4-cafcb5f3cb2e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18907,6 +18913,1373 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
+    </Command>
+    <Command>
+      <Referrer xsi:nil="true" />
+      <ExecType>3</ExecType>
+      <Confidence>0</Confidence>
+      <PrefixActionCount>0</PrefixActionCount>
+      <IsDynamicallyCreated>false</IsDynamicallyCreated>
+      <TargetProcessSet>false</TargetProcessSet>
+      <TargetProcessType>0</TargetProcessType>
+      <TargetProcessLevel>0</TargetProcessLevel>
+      <CompareType>0</CompareType>
+      <ExecFromWildcard>false</ExecFromWildcard>
+      <IsSubCommand>false</IsSubCommand>
+      <IsOverride>false</IsOverride>
+      <BaseId>5c6eb8c0-6adf-4b64-871c-655372604bc1</BaseId>
+      <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
+      <Id>093ba8ea-2117-4f7a-ae08-a03d7ca50ff5</Id>
+      <CommandString>((EDDI: status variables))</CommandString>
+      <ActionSequence>
+        <CommandAction>
+          <_caption>Write [Blue] 'Vehicle: {TXT:Status vehicle}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>0</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Vehicle: {TXT:Status vehicle}' to log</Caption>
+          <Id>6083648c-034a-47e1-abf4-82c98bf5d3ba</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Vehicle: {TXT:Status vehicle}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Being interdicted: {BOOL:Status being interdicted}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>1</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Being interdicted: {BOOL:Status being interdicted}' to log</Caption>
+          <Id>8d19c1e5-e49b-4783-9ae6-69f3822a60b5</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Being interdicted: {BOOL:Status being interdicted}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'In danger: {BOOL:Status in danger}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>2</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'In danger: {BOOL:Status in danger}' to log</Caption>
+          <Id>ac83aa3d-da3f-4430-a52c-29d239f6b1f3</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>In danger: {BOOL:Status in danger}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Near surface: {BOOL:Status near surface}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>3</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Near surface: {BOOL:Status near surface}' to log</Caption>
+          <Id>ab8ce7b7-094c-49d9-a0c5-4b4f39275750</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Near surface: {BOOL:Status near surface}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Overheating: {BOOL:Status overheating}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>4</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Overheating: {BOOL:Status overheating}' to log</Caption>
+          <Id>3513818f-dfac-424e-ad31-d2df82084ffd</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Overheating: {BOOL:Status overheating}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Low fuel: {BOOL:Status low fuel}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>5</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Low fuel: {BOOL:Status low fuel}' to log</Caption>
+          <Id>ee032b6f-8eda-4d6f-81d9-31cbffbb967b</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Low fuel: {BOOL:Status low fuel}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'FSD status: {TXT:Status fsd status}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>6</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'FSD status: {TXT:Status fsd status}' to log</Caption>
+          <Id>47a59f51-f309-420c-96bc-f896087c460d</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>FSD status: {TXT:Status fsd status}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'SRV drive assist: {BOOL:Status srv drive assist}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>7</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'SRV drive assist: {BOOL:Status srv drive assist}' to log</Caption>
+          <Id>1ff016a6-49ba-44a2-b317-4da4e5c1986a</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>SRV drive assist: {BOOL:Status srv drive assist}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'SRV under ship: {BOOL:Status srv under ship}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>8</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'SRV under ship: {BOOL:Status srv under ship}' to log</Caption>
+          <Id>5d02b520-b63e-425e-8183-f53c7c19341f</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>SRV under ship: {BOOL:Status srv under ship}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'SRV turret deployed: {BOOL:Status srv turret deployed}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>9</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'SRV turret deployed: {BOOL:Status srv turret deployed}' to log</Caption>
+          <Id>58122689-5e27-4f08-995d-904ac38f7d0d</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>SRV turret deployed: {BOOL:Status srv turret deployed}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'SRV handbrake actived: {BOOL:Status srv handbrake activated}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>10</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'SRV handbrake actived: {BOOL:Status srv handbrake activated}' to log</Caption>
+          <Id>d7db0576-79be-4099-a600-78c7f7d57fd1</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>SRV handbrake actived: {BOOL:Status srv handbrake activated}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Scooping fuel: {BOOL:Status scooping fuel}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>11</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Scooping fuel: {BOOL:Status scooping fuel}' to log</Caption>
+          <Id>d3e7ce14-2398-4405-8970-fc7c9cf95126</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Scooping fuel: {BOOL:Status scooping fuel}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Silent running: {BOOL:Status silent running}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>12</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Silent running: {BOOL:Status silent running}' to log</Caption>
+          <Id>74c91703-01d0-412c-a0ee-e455ce14de25</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Silent running: {BOOL:Status silent running}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Cargo scoop deployed: {BOOL:Status cargo scoop deployed}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>13</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Cargo scoop deployed: {BOOL:Status cargo scoop deployed}' to log</Caption>
+          <Id>da3167f2-f20a-4261-afde-e2bd6130bde6</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Cargo scoop deployed: {BOOL:Status cargo scoop deployed}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Lights on: {BOOL:Status lights on}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>14</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Lights on: {BOOL:Status lights on}' to log</Caption>
+          <Id>af50e589-db73-4ce1-8957-285cd00aa5b8</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Lights on: {BOOL:Status lights on}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'In wing: {BOOL:Status in wing}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>15</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'In wing: {BOOL:Status in wing}' to log</Caption>
+          <Id>86a9b805-d3d2-409e-b8e5-8fca5fb4f66d</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>In wing: {BOOL:Status in wing}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Hardpoints deployed: {BOOL:Status hardpoints deployed}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>16</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Hardpoints deployed: {BOOL:Status hardpoints deployed}' to log</Caption>
+          <Id>381061af-8c3b-4f0e-8737-59b6249759d6</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Hardpoints deployed: {BOOL:Status hardpoints deployed}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Flight assist off: {BOOL:Status flight assist off}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>17</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Flight assist off: {BOOL:Status flight assist off}' to log</Caption>
+          <Id>2c8ba0e8-8ffa-4cf3-87a5-76d1e3c151d8</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Flight assist off: {BOOL:Status flight assist off}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Supercruise: {BOOL:Status supercruise}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>18</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Supercruise: {BOOL:Status supercruise}' to log</Caption>
+          <Id>cf833613-d7c0-4ca0-bac1-1ce2cbebd4ba</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Supercruise: {BOOL:Status supercruise}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Shields up: {BOOL:Status shields up}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>19</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Shields up: {BOOL:Status shields up}' to log</Caption>
+          <Id>54998cce-7ace-4d4f-b372-453ed5f6ab9e</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Shields up: {BOOL:Status shields up}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Landing gear down: {BOOL:Status landing gear down}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>20</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Landing gear down: {BOOL:Status landing gear down}' to log</Caption>
+          <Id>fb3afad9-caed-4d42-9459-5c3252502510</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Landing gear down: {BOOL:Status landing gear down}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Landed: {BOOL:Status landed}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>21</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Landed: {BOOL:Status landed}' to log</Caption>
+          <Id>80c57c04-a3b3-4520-a998-b6f1c0eaf2b0</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Landed: {BOOL:Status landed}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Docked: {BOOL:Status docked}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>22</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Docked: {BOOL:Status docked}' to log</Caption>
+          <Id>4cb7a6d7-75db-4483-b569-3b5e849f553c</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Docked: {BOOL:Status docked}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Analysis mode: {BOOL:Status analysis mode}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>23</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Analysis mode: {BOOL:Status analysis mode}' to log</Caption>
+          <Id>4d0dab55-1c56-4c1e-aa43-871d59338601</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Analysis mode: {BOOL:Status analysis mode}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Night vision: {BOOL:Status night vision}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>24</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Night vision: {BOOL:Status night vision}' to log</Caption>
+          <Id>d22f3b87-539b-4e53-ac22-2e7bb58a0680</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Night vision: {BOOL:Status night vision}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'System pips: {DEC:Status system pips}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>25</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'System pips: {DEC:Status system pips}' to log</Caption>
+          <Id>1d9c008e-becf-464f-b5c6-d188f362846d</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>System pips: {DEC:Status system pips}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Engine pips: {DEC:Status engine pips}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>26</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Engine pips: {DEC:Status engine pips}' to log</Caption>
+          <Id>0a36daa5-b7a0-4d85-b4a9-17eeeacedc3d</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Engine pips: {DEC:Status engine pips}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Weapon pips: {DEC:Status weapon pips}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>27</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Weapon pips: {DEC:Status weapon pips}' to log</Caption>
+          <Id>8b40d733-df7e-4375-97dd-20175b5bd277</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Weapon pips: {DEC:Status weapon pips}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Firegroup: {INT:Status firegroup}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>28</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Firegroup: {INT:Status firegroup}' to log</Caption>
+          <Id>4bf7a5ea-6dc3-4a7a-afdf-83db77da5a29</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Firegroup: {INT:Status firegroup}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'GUI focus: {TXT:Status gui focus}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>29</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'GUI focus: {TXT:Status gui focus}' to log</Caption>
+          <Id>dd3b4dc6-21bb-4956-b9d9-7285152a1472</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>GUI focus: {TXT:Status gui focus}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Latitude: {DEC:Status latitude}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>30</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Latitude: {DEC:Status latitude}' to log</Caption>
+          <Id>c5d947be-a438-4d36-9528-69db85845f77</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Latitude: {DEC:Status latitude}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Longitude: {DEC:Status longitude}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>31</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Longitude: {DEC:Status longitude}' to log</Caption>
+          <Id>f7cbdea0-b4ba-412e-b8df-68ae070886c5</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Longitude: {DEC:Status longitude}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Altitude: {DEC:Status altitude}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>32</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Altitude: {DEC:Status altitude}' to log</Caption>
+          <Id>d901ec3f-7209-4640-913f-f7dcd3d68a54</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Altitude: {DEC:Status altitude}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Heading: {DEC:Status heading}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>33</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Heading: {DEC:Status heading}' to log</Caption>
+          <Id>24e862bd-b16e-434f-8c5d-8ac2861f3911</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Heading: {DEC:Status heading}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Fuel: {DEC:Status fuel}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>34</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Fuel: {DEC:Status fuel}' to log</Caption>
+          <Id>5068a9bd-032f-4605-8c51-98c862ae8478</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Fuel: {DEC:Status fuel}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Fuel percent: {DEC:Status fuel percent}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>35</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Fuel percent: {DEC:Status fuel percent}' to log</Caption>
+          <Id>1cdfc08d-dfed-4245-8bb0-b3de415adab7</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Fuel percent: {DEC:Status fuel percent}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Fuel rate: {DEC:Status fuel rate}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>36</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Fuel rate: {DEC:Status fuel rate}' to log</Caption>
+          <Id>ab00e47d-5a1d-4b56-866b-b83d63980bf2</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Fuel rate: {DEC:Status fuel rate}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+        <CommandAction>
+          <_caption>Write [Blue] 'Cargo carried: {INT:Status cargo carried}' to log</_caption>
+          <PairingSet>false</PairingSet>
+          <PairingSetElse>false</PairingSetElse>
+          <Ordinal>37</Ordinal>
+          <ConditionMet xsi:nil="true" />
+          <IndentLevel>0</IndentLevel>
+          <ConditionSkip>false</ConditionSkip>
+          <IsSuffixAction>false</IsSuffixAction>
+          <DecimalTransient1>0</DecimalTransient1>
+          <Caption>Write [Blue] 'Cargo carried: {INT:Status cargo carried}' to log</Caption>
+          <Id>fb93cba9-095d-44eb-b130-e9b37c654206</Id>
+          <ActionType>WriteToLog</ActionType>
+          <Duration>0</Duration>
+          <Delay>0</Delay>
+          <KeyCodes />
+          <Context>Cargo carried: {INT:Status cargo carried}</Context>
+          <X>0</X>
+          <Y>0</Y>
+          <Z>0</Z>
+          <InputMode>0</InputMode>
+          <ConditionPairing>0</ConditionPairing>
+          <ConditionGroup>0</ConditionGroup>
+          <ConditionStartOperator>0</ConditionStartOperator>
+          <ConditionStartValue>0</ConditionStartValue>
+          <ConditionStartValueType>0</ConditionStartValueType>
+          <ConditionStartType>0</ConditionStartType>
+          <DecimalContext1>0</DecimalContext1>
+          <DecimalContext2>0</DecimalContext2>
+          <DateContext1>0001-01-01T00:00:00</DateContext1>
+          <DateContext2>0001-01-01T00:00:00</DateContext2>
+          <Disabled>false</Disabled>
+          <RandomSounds />
+        </CommandAction>
+      </ActionSequence>
+      <Async>true</Async>
+      <Enabled>true</Enabled>
+      <Description>write out status variables</Description>
+      <Category>EDDI information</Category>
+      <UseShortcut>true</UseShortcut>
+      <keyValue>56</keyValue>
+      <keyShift>160</keyShift>
+      <keyAlt>164</keyAlt>
+      <keyCtrl>162</keyCtrl>
+      <keyWin>0</keyWin>
+      <keyPassthru>false</keyPassthru>
+      <UseSpokenPhrase>false</UseSpokenPhrase>
+      <onlyKeyUp>false</onlyKeyUp>
+      <RepeatNumber>2</RepeatNumber>
+      <RepeatType>0</RepeatType>
+      <CommandType>0</CommandType>
+      <SourceProfile>00000000-0000-0000-0000-000000000000</SourceProfile>
+      <UseConfidence>false</UseConfidence>
+      <minimumConfidenceLevel>0</minimumConfidenceLevel>
+      <UseJoystick>false</UseJoystick>
+      <joystickNumber>0</joystickNumber>
+      <joystickButton>0</joystickButton>
+      <joystickNumber2>0</joystickNumber2>
+      <joystickButton2>0</joystickButton2>
+      <joystickUp>false</joystickUp>
+      <KeepRepeating>false</KeepRepeating>
+      <UseProcessOverride>false</UseProcessOverride>
+      <ProcessOverrideActiveWindow>true</ProcessOverrideActiveWindow>
+      <LostFocusStop>false</LostFocusStop>
+      <PauseLostFocus>false</PauseLostFocus>
+      <LostFocusBackCompat>true</LostFocusBackCompat>
+      <UseMouse>false</UseMouse>
+      <Mouse1>false</Mouse1>
+      <Mouse2>false</Mouse2>
+      <Mouse3>false</Mouse3>
+      <Mouse4>false</Mouse4>
+      <Mouse5>false</Mouse5>
+      <Mouse6>false</Mouse6>
+      <Mouse7>false</Mouse7>
+      <Mouse8>false</Mouse8>
+      <Mouse9>false</Mouse9>
+      <MouseUpOnly>false</MouseUpOnly>
+      <MousePassThru>true</MousePassThru>
+      <joystickExclusive>false</joystickExclusive>
+      <lastEditedAction>7b5a9b27-e8be-4911-a326-de3b8af05b47</lastEditedAction>
+      <UseProfileProcessOverride>false</UseProfileProcessOverride>
+      <ProfileProcessOverrideActiveWindow>false</ProfileProcessOverrideActiveWindow>
+      <RepeatIfKeysDown>false</RepeatIfKeysDown>
+      <RepeatIfMouseDown>false</RepeatIfMouseDown>
+      <RepeatIfJoystickDown>false</RepeatIfJoystickDown>
+      <AH>0</AH>
+      <CL>0</CL>
+      <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -18923,7 +20296,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>dc4c8c7a-4e12-4e8e-9443-dec2d5597375</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>dbd282ef-7dba-4a8a-8e7f-96af5b70e12d</Id>
+      <Id>87bee1cb-1524-41d7-b146-f738ce086e78</Id>
       <CommandString>((EDDI: system variables))</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -18935,7 +20308,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ae8b7ca3-4790-4ddf-a781-6453e7f4a3d9</Id>
+          <Id>8152546f-23fd-4651-8077-4abf3b18baf3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -18968,7 +20341,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6f1a8502-62f8-4009-a88e-a04f26b341b1</Id>
+          <Id>0a4501a3-62c3-4c48-871a-5a3d3349038b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19001,7 +20374,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9664ab63-0cdd-4f00-927c-e1a8af6dfd08</Id>
+          <Id>84d20d9d-c00f-4efc-aaec-33d0bc0fae48</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19034,7 +20407,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a48575e3-bfd6-4ae7-9ccc-d633af6cf6f8</Id>
+          <Id>709edb31-4a5e-4dc5-b00e-b8b6945fac4f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19067,7 +20440,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>811e760e-50d3-4c3d-be92-afde564777a3</Id>
+          <Id>cfafb417-d783-4a52-b3fb-b4c16edcd34e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19100,7 +20473,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>954aaf3e-d533-42f3-b04b-c9d4e490c772</Id>
+          <Id>072f8f24-3d33-4488-9804-f3c7b6e9550a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19133,7 +20506,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9be93be0-1267-411c-95a0-4eda1fd76429</Id>
+          <Id>c6f5b5e1-f157-4b42-8612-fab455edb248</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19166,7 +20539,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>638d3a26-093e-40a9-9c55-6cdee7a4c325</Id>
+          <Id>0f9b82d8-d94f-425d-a5d3-a26ad3ea0134</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19199,7 +20572,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3432821d-09a5-44b3-92b9-6a076f354d85</Id>
+          <Id>a96c9246-a350-4660-a730-12e20b778c09</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19232,7 +20605,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>048491ce-8333-498d-b9d3-e084783a5a6b</Id>
+          <Id>b752c5c8-3902-4e0e-9ca6-119b4b72ef5f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19265,7 +20638,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1e586e18-16e8-4356-ac94-826e021a6bdd</Id>
+          <Id>2c9aa1bc-2471-4c83-8d74-b94b5206cd9f</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19298,7 +20671,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>83077dd3-29ce-4bd1-a3ef-66bbc08789e1</Id>
+          <Id>d2cf257c-18ee-41ff-bbc4-262050f53a97</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19331,7 +20704,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b99c0cf3-4b59-4730-a0ae-fcbc3e0ede24</Id>
+          <Id>4da9a94f-6fec-443f-98a4-173a6fac384c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19364,7 +20737,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>29530b25-53c5-44e5-b867-30a9fbc20c12</Id>
+          <Id>48c7552c-5d80-4b78-ad9a-b0b13d21c8b7</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19397,7 +20770,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d6694a31-7909-416a-994e-86c0e9003b1e</Id>
+          <Id>5a74a7d3-fc75-429b-a977-df76de30055a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19430,7 +20803,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>013c1982-ef46-4368-8411-08412783989f</Id>
+          <Id>a80880cd-9157-4cf7-94c4-eae291cd062a</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19463,7 +20836,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3c5d343c-3baf-4297-bf30-cba07cd2f763</Id>
+          <Id>899a2004-deb1-4f8a-bb14-7e3f6bbbb1be</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19496,7 +20869,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>79afb93c-1657-4a37-bcd0-4ddd851eea2f</Id>
+          <Id>2504f4c8-bb4a-472e-8c50-ba6e64eb39df</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19529,7 +20902,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fd23ae09-ec6f-4d66-b052-c3cda70bafab</Id>
+          <Id>481cf00f-e8e7-42ea-95bc-9f5aeb8ae4a0</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19562,7 +20935,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5dbe72cb-5f98-4d06-ab0b-f3145d5fd0ad</Id>
+          <Id>0fd4d2b0-1ede-484b-957b-534146b8b6e1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19595,7 +20968,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d4813463-2e40-49c0-a529-2a5f5903fb10</Id>
+          <Id>d7862b2d-ef55-4ac9-99f7-8ac580e1c494</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19628,7 +21001,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>160270ed-33bb-40be-b7b5-774f080d6de0</Id>
+          <Id>9eb19118-1c34-4e67-a5b3-60661ad4b94b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19661,7 +21034,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b79140e9-811f-4ef3-bc4b-c1cf94e63613</Id>
+          <Id>16bfff9d-ef66-4038-9ffd-2ce4e4166a49</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19694,7 +21067,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2ecac93f-f960-4096-86ee-84478d1ea3a4</Id>
+          <Id>d4335265-88ca-4dee-9173-3b8f8d1056d5</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19727,7 +21100,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cebe5481-a2ac-4af5-bcee-6e531d08ec9b</Id>
+          <Id>d1b39d2e-5202-43ac-9e82-a16cc75dfa50</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19760,7 +21133,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a5b989e3-cc18-47f8-bc03-baf2e85cbb7a</Id>
+          <Id>b732ea18-0c68-484a-9621-a3de12337121</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19793,7 +21166,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8bf33c0c-492a-4a56-93e1-c463750037e6</Id>
+          <Id>47a70696-d673-456e-8ff9-13c4b53aa08d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19826,7 +21199,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2186bae9-d835-4e03-a857-9c8d35a384bd</Id>
+          <Id>55228908-3bd4-4281-bdcb-48b6b227b553</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19859,7 +21232,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1679cd1c-4d73-4015-bec9-5671a66e4263</Id>
+          <Id>0d7ef3f4-1dbb-4e21-8546-0f338b43e34c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19892,7 +21265,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>93df1425-61fc-4d22-9b78-103816a5b939</Id>
+          <Id>5e07705a-b90e-4805-9a4c-3a5b218b7ff9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19925,7 +21298,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7469f04d-a47c-46bb-af4d-a9e671bb25c4</Id>
+          <Id>87f88d83-c440-4122-8e12-92ef1ca2c225</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19958,7 +21331,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1872a04a-ab28-4629-bd41-cdf51ab192e2</Id>
+          <Id>9139bf8b-0efd-4209-9486-49a1552e1ca6</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -19991,7 +21364,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f5109027-d48b-480b-bdfa-706dd58736a6</Id>
+          <Id>159133a9-c734-4906-a8f6-fdad509453d3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20024,7 +21397,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e1a23f04-e7e6-4d9e-bf10-58709c59a378</Id>
+          <Id>64a89583-e60c-4bd0-9dec-1c55d6246d0b</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20057,7 +21430,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>901da952-563e-4d42-9e56-d83e83fd9420</Id>
+          <Id>72961d61-0b78-43e6-8792-2b1affdc1ccb</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20090,7 +21463,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a02082e5-6db3-4094-a282-d961ab5d8912</Id>
+          <Id>6db47603-4cad-4931-a662-79fbe4de3356</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20123,7 +21496,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>298beb94-520a-4dc3-8a4e-bc0017d1b692</Id>
+          <Id>d7339afd-420f-481d-83ed-6292f9756f56</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20156,7 +21529,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f4c9b3ed-535a-416f-824d-28f16bf1efa7</Id>
+          <Id>732e932d-67cc-49c9-8606-45f604291289</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20189,7 +21562,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fe27fbc6-85c6-4c12-ab54-3eb85f87bb47</Id>
+          <Id>2935ae2c-fd8a-4620-80ee-9f2a5c76f215</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20222,7 +21595,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4e2618d1-3363-4d88-bc38-5728aba94c19</Id>
+          <Id>fb58f23a-a18f-484c-9273-842e4a119fb3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20255,7 +21628,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>032d4da0-0aae-4fb0-b5bd-c6c64d5c58b9</Id>
+          <Id>7a27adac-900f-4992-bf28-e0a68645f58e</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20288,7 +21661,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6032ed4e-0154-4477-a20e-4b8c02784df9</Id>
+          <Id>a4af976a-8f47-468f-8a9d-29bf5502c0e9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20321,7 +21694,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>02291f16-b824-469f-af85-4525f2466fcf</Id>
+          <Id>f6a80daf-2495-4575-bdc8-912de07691f8</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20354,7 +21727,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>616ff054-7b45-4b55-b960-bca2bd4db491</Id>
+          <Id>2eb973fa-82d5-4c17-9ddd-4b1031772871</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20387,7 +21760,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7548486a-a372-4bc1-96ac-3cb62ecdb67a</Id>
+          <Id>8cfee2bc-79e8-4bfc-a828-f327d3a0fd0d</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20420,7 +21793,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4eda8a35-fa93-4d52-b519-621053243b5b</Id>
+          <Id>4add941d-d6e6-4ea6-9536-e6f2940139d3</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20453,7 +21826,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1bf943de-8319-4b44-badf-0863bbabb048</Id>
+          <Id>da987a18-6a79-4ad3-b689-a3402960b6ab</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20486,7 +21859,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f7d5dac7-fbbf-4afa-bc6b-20d5c9c4b054</Id>
+          <Id>8f654ee1-22a1-47e4-8d73-7f2d0c4b7511</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20519,7 +21892,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>24c7d370-6c9e-4e80-90da-db765cf9ccb4</Id>
+          <Id>73fe425c-de2f-484b-b95d-ef68cb59d42c</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20597,6 +21970,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -20613,7 +21987,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>9a7fbbc3-bbef-4f2c-b2d0-ea86be5079e6</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>36fe019c-29ad-4823-85d9-2f612cb44d44</Id>
+      <Id>4b9363a8-0b1a-412f-88a7-761892f77fd6</Id>
       <CommandString>Be quiet</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -20625,7 +21999,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a3d6e882-84ec-4ce9-ab81-0f0af03c5307</Id>
+          <Id>a3069489-64a7-434e-824f-2259e792e58b</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20701,7 +22075,7 @@
       <MouseUpOnly>false</MouseUpOnly>
       <MousePassThru>true</MousePassThru>
       <joystickExclusive>false</joystickExclusive>
-      <lastEditedAction>00000000-0000-0000-0000-000000000000</lastEditedAction>
+      <lastEditedAction>2a738113-81fd-4509-9246-2aa745362415</lastEditedAction>
       <UseProfileProcessOverride>false</UseProfileProcessOverride>
       <ProfileProcessOverrideActiveWindow>false</ProfileProcessOverrideActiveWindow>
       <RepeatIfKeysDown>false</RepeatIfKeysDown>
@@ -20710,6 +22084,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -20726,7 +22101,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0aac2272-6232-471a-ade7-e62eac05b323</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>92d6c244-f595-4273-9b18-9009c74e8e34</Id>
+      <Id>65b61d45-2ce4-408e-974e-1e60ce71b8f2</Id>
       <CommandString>[Configure; Initialize; Minimize; Maximize; Restore; Close; Open] EDDI</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -20738,7 +22113,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e8cadc94-f518-4a41-87d9-87bbf73bb3b1</Id>
+          <Id>dc046975-4fdc-435e-8c10-33361b495750</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>1</Duration>
           <Delay>0</Delay>
@@ -20765,7 +22140,7 @@
           <ConditionExpressions>
             <ArrayOfConditionStruct>
               <ConditionStruct>
-                <Id>647f875d-c7a4-4784-89e8-8a2f9cd04fe0</Id>
+                <Id>081fc6e8-1a8e-406f-92bf-99f8d412e87b</Id>
                 <ConditionStartType>1</ConditionStartType>
                 <ConditionStartNameFrom>{LASTSPOKENCMD}</ConditionStartNameFrom>
                 <ConditionStartValueType>0</ConditionStartValueType>
@@ -20780,7 +22155,7 @@
             </ArrayOfConditionStruct>
             <ArrayOfConditionStruct>
               <ConditionStruct>
-                <Id>626dca48-8824-43e1-8f3e-890d200755a8</Id>
+                <Id>30a09fd0-fbff-4701-8b14-84b2785904dc</Id>
                 <ConditionStartType>1</ConditionStartType>
                 <ConditionStartNameFrom>{LASTSPOKENCMD}</ConditionStartNameFrom>
                 <ConditionStartValueType>0</ConditionStartValueType>
@@ -20804,7 +22179,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e5d797eb-9962-4b3d-9b1c-cdad160485f2</Id>
+          <Id>a90a97a4-0b5f-4078-bc7e-5bdc05987d8c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20844,7 +22219,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>15078ed8-d13a-4b69-9464-80092b057e2d</Id>
+          <Id>e6954a06-f57f-41dc-bca7-b17083512dff</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20879,7 +22254,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3c5bfea1-dbe2-4a0a-9e6c-82f4272979d5</Id>
+          <Id>f9c4a9fd-958f-42e9-ae1f-ff6a48a52745</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20919,7 +22294,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>97cdb2ec-c860-4b8b-9ee7-1983f0b819b8</Id>
+          <Id>999159c3-9251-4d80-90cb-a00f462c7bb2</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20954,7 +22329,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b56bf052-39a8-470c-a0b7-b3a7404e4e07</Id>
+          <Id>bf1f8089-d119-4436-8615-be85f7c082ba</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -20994,7 +22369,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bd1c7fdf-12b5-4364-ba62-22ffa3733124</Id>
+          <Id>474099fa-a12c-4554-a4a1-e725ce3e5d7a</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21029,7 +22404,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6524cf78-5ee2-41b2-ade8-a4cc3503b683</Id>
+          <Id>95c11090-0764-410c-9c55-9cad12372f6d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21069,7 +22444,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a370db29-0eba-453a-acfb-7dbc8889ccd0</Id>
+          <Id>511085f0-51fd-41d6-a473-f21b4817a75f</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21104,7 +22479,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c881e0a2-e833-4856-98f7-959c9e63431c</Id>
+          <Id>ff423f29-c6d9-4ff7-8b00-eb29bbe5cc76</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21144,7 +22519,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e6566def-7545-44a0-ab32-54dcc1672af4</Id>
+          <Id>f919264a-155c-4b16-97c0-8dd708dbedaa</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21179,7 +22554,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e2bffe2e-5122-45fe-940a-5299e833b110</Id>
+          <Id>acd81c94-5ca6-495d-b91f-282a12b7b281</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21219,7 +22594,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b835b1b4-cf5d-4bba-b796-b8e44344f3d2</Id>
+          <Id>69222f5f-70c3-4fbb-840a-c4c830cb8b86</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21296,6 +22671,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -21312,7 +22688,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>f940fa43-6099-4db2-8761-5a579db391f2</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>e9f3eeb1-9104-45ee-bf54-3bed0410992f</Id>
+      <Id>203b3278-64eb-47e1-91c0-7d2cf32d6afa</Id>
       <CommandString>Damage report</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -21324,7 +22700,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>580f6634-8795-47d1-b60f-af27966a5c38</Id>
+          <Id>92b3d446-3d57-4864-a598-49d77601d1c3</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21362,7 +22738,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c71611ac-02d8-4230-8736-e147ce3a883f</Id>
+          <Id>2569cdd8-e9c9-4d84-ae57-7103231c8539</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21447,6 +22823,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -21463,11 +22840,10 @@
       <IsOverride>false</IsOverride>
       <BaseId>79f8292e-6884-4389-a57a-622e0f8c6460</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>2198c6c6-13f5-4746-bdea-6eafada41fc6</Id>
+      <Id>47cdb58e-cc2a-40a8-a285-413778bf586f</Id>
       <CommandString>[Display;show] [this;the current] station in E D D B</CommandString>
       <ActionSequence>
         <CommandAction>
-          <_caption>Set Boolean [EDDI open uri in browser] to True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
           <Ordinal>0</Ordinal>
@@ -21476,8 +22852,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Set Boolean [EDDI open uri in browser] to True</Caption>
-          <Id>9088b0a8-cd8f-49e5-941e-e9b8bce9d242</Id>
+          <Id>10523496-8708-4e0a-a2b9-1c7d106b917c</Id>
           <ActionType>BooleanSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21504,17 +22879,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>1</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</Caption>
-          <Id>675e11d9-99eb-4088-84ff-dac8bb3688bc</Id>
+          <Id>7568fa21-22d9-427f-b55a-3a33fd8af38e</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21539,17 +22912,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Set Text [Script] to 'Displaying {TXT:Last station name} in EDDB.'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>2</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Set Text [Script] to 'Displaying {TXT:Last station name} in EDDB.'</Caption>
-          <Id>2eff1b20-bb22-4a3b-8c9d-042b117a99bf</Id>
+          <Id>ad1ef5f7-d5fd-4483-bf2b-e6580725a810</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21579,17 +22950,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>    Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>3</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</Caption>
-          <Id>a8aecf20-4f32-40e5-b3ab-a3f3bcb123b9</Id>
+          <Id>432d7583-0066-4976-b445-91605d4f43a7</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21621,17 +22990,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>Else</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>4</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Else</Caption>
-          <Id>511e0687-6aaa-46ba-8a1c-7cc02c8f11d2</Id>
+          <Id>9a4b00a4-0e79-4bde-b602-bdff858a061d</Id>
           <ActionType>ConditionElse</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21654,17 +23021,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Write [Blue] '{TXT:EDDI uri}' to log</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>5</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Write [Blue] '{TXT:EDDI uri}' to log</Caption>
-          <Id>792afbba-c490-445f-bde3-98a0dabbf760</Id>
+          <Id>e656dcab-a6b1-41ab-84ff-c88be0432cbe</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21688,17 +23053,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>End Condition</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>6</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>End Condition</Caption>
-          <Id>69b2576c-cccc-4883-a5e2-1de8dffd007b</Id>
+          <Id>d03f00e1-9897-462b-a87d-26347bdefdec</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21721,17 +23084,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Execute external plugin, 'EDDI 3.1.0-b4'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>7</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Execute external plugin, 'EDDI 3.1.0-b4'</Caption>
-          <Id>4b82e629-45c5-4b08-8fbf-2e752aa248cb</Id>
+          <Id>034dfdd1-dbe5-45c1-b117-8aa61450008c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21816,6 +23177,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -21832,11 +23194,10 @@
       <IsOverride>false</IsOverride>
       <BaseId>e79aab53-9ee0-456b-b4af-14ff777dd706</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>95e18ae6-9744-4d09-aeba-bb50f553f7ca</Id>
+      <Id>7318f2dd-f28c-4460-be50-fb1b00daa241</Id>
       <CommandString>[Display;show] [this;the current] system in E D D B</CommandString>
       <ActionSequence>
         <CommandAction>
-          <_caption>Set Boolean [EDDI open uri in browser] to True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
           <Ordinal>0</Ordinal>
@@ -21845,8 +23206,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Set Boolean [EDDI open uri in browser] to True</Caption>
-          <Id>409aa090-f9c1-450f-9c9e-d6acb39c2d6d</Id>
+          <Id>4b452475-096c-41be-99f0-97e01f4d23a3</Id>
           <ActionType>BooleanSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21873,17 +23233,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>1</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</Caption>
-          <Id>5dce0d11-5ac0-4390-b30c-421e9b193308</Id>
+          <Id>63ca37be-d186-4c08-a87e-27b987631f15</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21908,17 +23266,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Set Text [Script] to 'Displaying {TXT:System name (spoken)} in EDDB.'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>2</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Set Text [Script] to 'Displaying {TXT:System name (spoken)} in EDDB.'</Caption>
-          <Id>ebf4135b-983f-4266-a940-3c2c346deaca</Id>
+          <Id>febb1a98-b4ee-44d9-b7e8-f7f03fde3151</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21948,17 +23304,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>    Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>3</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</Caption>
-          <Id>a71de03b-effc-48ad-91ac-b4828bdb1a4b</Id>
+          <Id>6bbec1e2-e81a-4fff-93ae-91e491fd1bba</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -21990,17 +23344,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>Else</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>4</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Else</Caption>
-          <Id>0075f20b-219f-41fe-95a7-d5bce3b7b30a</Id>
+          <Id>db5e6bff-a8f2-4016-b2c2-cfa4a41aa7e9</Id>
           <ActionType>ConditionElse</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22023,17 +23375,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Write [Blue] '{TXT:EDDI uri}' to log</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>5</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Write [Blue] '{TXT:EDDI uri}' to log</Caption>
-          <Id>307d106a-ccb6-473b-afaa-ce32ba48fe53</Id>
+          <Id>e1a13a41-77da-4f7e-bded-4b83b7cff6da</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22057,17 +23407,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>End Condition</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>6</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>End Condition</Caption>
-          <Id>08e44ee1-dfb4-4be7-813e-8f5177498a84</Id>
+          <Id>18adfe31-7f06-4ca5-9b0e-11ecba50d68e</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22090,17 +23438,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Execute external plugin, 'EDDI 3.1.0-b4'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>7</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Execute external plugin, 'EDDI 3.1.0-b4'</Caption>
-          <Id>562557b2-faa6-4377-8d9e-185c7274e468</Id>
+          <Id>a3c5046c-f712-43e3-affd-986af23fed10</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22185,6 +23531,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -22201,11 +23548,10 @@
       <IsOverride>false</IsOverride>
       <BaseId>599ef1ff-4fba-497a-bd0e-255ea57649ae</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>4b881ade-3263-4777-ae38-35b5152c4963</Id>
+      <Id>87c9883b-6aa6-4297-8471-d8808a0c9b07</Id>
       <CommandString>[Display;show;send] [my;this;the;] ship [in;to] Coriolis</CommandString>
       <ActionSequence>
         <CommandAction>
-          <_caption>Set Boolean [EDDI open uri in browser] to True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
           <Ordinal>0</Ordinal>
@@ -22214,8 +23560,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Set Boolean [EDDI open uri in browser] to True</Caption>
-          <Id>d473b628-4be5-4f5d-a6cc-d5b10fbf89e9</Id>
+          <Id>4ec64133-5670-4d8d-a992-144a1657e730</Id>
           <ActionType>BooleanSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22242,17 +23587,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>1</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</Caption>
-          <Id>1ba3e5e2-6e0e-4992-83bf-c8c214f48161</Id>
+          <Id>93d5c4ea-64d3-4afb-bb71-c4ca5021df7b</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22277,17 +23620,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Set Text [Script] to 'Displaying $= in Coriolis.;Sending $= to Coriolis.'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>2</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Set Text [Script] to 'Displaying $= in Coriolis.;Sending $= to Coriolis.'</Caption>
-          <Id>79ef384a-2eca-4081-86ed-bcc7bea1e5f2</Id>
+          <Id>0e130df4-c2cc-491b-ad31-f70df3149f95</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22317,17 +23658,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>    Execute external plugin, 'EDDI 3.1.0-b4'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>3</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Execute external plugin, 'EDDI 3.1.0-b4'</Caption>
-          <Id>dbaa0be2-2e4f-45a7-9fd3-61583fd2e016</Id>
+          <Id>a244e91c-df80-4816-b110-89003784c1fb</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22359,17 +23698,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>Else</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>4</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Else</Caption>
-          <Id>6b798e42-40d1-459e-9d94-f99b6fa974e8</Id>
+          <Id>681e0779-e6c7-4b8e-a9d5-02367b765c81</Id>
           <ActionType>ConditionElse</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22392,17 +23729,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Write [Blue] '{TXT:EDDI uri}' to log</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>5</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Write [Blue] '{TXT:EDDI uri}' to log</Caption>
-          <Id>0131dc7d-582f-4210-a942-2a53f8315f96</Id>
+          <Id>7af4cd9d-2c8d-4eab-961b-8c375fdc2988</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22426,17 +23761,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>End Condition</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>6</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>End Condition</Caption>
-          <Id>b9dd1c0d-e52e-483e-8337-5c48f906b8b4</Id>
+          <Id>08e145e7-4a00-40d7-bac3-cac5ff433b3d</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22459,17 +23792,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>7</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</Caption>
-          <Id>c25bf9b4-61e6-4b94-95a8-7bb6e7bbf56d</Id>
+          <Id>b72a2355-f1ca-4936-89f9-0087d3c4e7d7</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22554,6 +23885,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -22570,11 +23902,10 @@
       <IsOverride>false</IsOverride>
       <BaseId>462ada72-e009-436d-a68f-bb1140a1ef28</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>c97cd970-c246-46da-ab0b-fdb43f68fba0</Id>
+      <Id>7eda5233-10a0-40e6-b1a3-473a4ee8ed96</Id>
       <CommandString>[Display;show;send] [my;this;the;] ship [in;to] E D Shipyard</CommandString>
       <ActionSequence>
         <CommandAction>
-          <_caption>Set Boolean [EDDI open uri in browser] to True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
           <Ordinal>0</Ordinal>
@@ -22583,8 +23914,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Set Boolean [EDDI open uri in browser] to True</Caption>
-          <Id>48388ee0-0527-48b3-9940-ae299da4a5c3</Id>
+          <Id>9f9e3b3e-e0b4-47af-99ef-c33e2391eef6</Id>
           <ActionType>BooleanSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22611,17 +23941,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>1</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Begin Boolean Compare : [EDDI open uri in browser] Equals True</Caption>
-          <Id>f26a7792-2ac9-4436-a24d-6886ae3c94a0</Id>
+          <Id>2b5e7d1a-cc6f-4e8f-ab2f-2411d40b7c14</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22646,17 +23974,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Set Text [Script] to 'Displaying $= in E D Shipyard.;Sending $= to E D Shipyard'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>2</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Set Text [Script] to 'Displaying $= in E D Shipyard.;Sending $= to E D Shipyard'</Caption>
-          <Id>fb45d4e8-5d55-48cd-a907-b4bfac4d55fd</Id>
+          <Id>c187c4ad-f9f8-4b6f-86c2-d3f0ee2b6d83</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22686,17 +24012,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>    Execute external plugin, 'EDDI 3.1.0-b4'</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>3</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Execute external plugin, 'EDDI 3.1.0-b4'</Caption>
-          <Id>8216a83f-5189-4a24-8ec0-2604bff2c757</Id>
+          <Id>4956aaa4-a84c-4e93-a121-02ff3921fa85</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22728,17 +24052,15 @@
           <ConditionExpressions />
         </CommandAction>
         <CommandAction>
-          <_caption>Else</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>4</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Else</Caption>
-          <Id>8a80e36a-118b-4132-b2e0-7fd93f9170b5</Id>
+          <Id>69f677b5-4e81-40a8-b93d-2aa99f1ac789</Id>
           <ActionType>ConditionElse</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22761,17 +24083,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>    Write [Blue] '{TXT:EDDI uri}' to log</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>5</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
-          <IndentLevel>1</IndentLevel>
+          <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>    Write [Blue] '{TXT:EDDI uri}' to log</Caption>
-          <Id>9fc1f6f5-ec30-4c37-879d-bdcc7cd56b81</Id>
+          <Id>e9a0672c-07f2-4cf0-8fb6-1e8c30d8b8c9</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22795,17 +24115,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>End Condition</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>6</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>End Condition</Caption>
-          <Id>0b128113-b1d7-43cb-8319-942055b47716</Id>
+          <Id>1ba95920-5c5b-4d42-bd75-1ba3c7e71335</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22828,17 +24146,15 @@
           <RandomSounds />
         </CommandAction>
         <CommandAction>
-          <_caption>Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</_caption>
           <PairingSet>false</PairingSet>
           <PairingSetElse>false</PairingSetElse>
-          <Ordinal>7</Ordinal>
+          <Ordinal>0</Ordinal>
           <ConditionMet xsi:nil="true" />
           <IndentLevel>0</IndentLevel>
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Caption>Execute external plugin, 'EDDI 3.1.0-b4' and wait for return</Caption>
-          <Id>3aa8445a-c5ce-4187-a60a-fddbb7d9d841</Id>
+          <Id>5e04c2e2-2a44-4b01-a77f-ce14edb752b6</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22923,6 +24239,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -22939,7 +24256,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>853e6192-9ff0-429d-8779-3961da34eb16</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>f176e3c9-4cb4-43ed-b78f-d196f1fbf861</Id>
+      <Id>9c3e5459-bfd4-4c7a-be81-be3d038d66ad</Id>
       <CommandString>How far [away;] is [the;that] [system;]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -22951,7 +24268,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3bac93db-b602-4838-b6a3-0c6a70f8e533</Id>
+          <Id>5080fc10-d987-48cb-ad95-019d93c4624c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -22989,7 +24306,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>14c244d9-8112-484f-ba3c-83b8e10d9d05</Id>
+          <Id>68658d7e-b652-4ead-9a7e-a31813a90638</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23074,6 +24391,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -23090,7 +24408,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>33932adb-a920-4aed-800b-7f83ec8f817a</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>0bf4d4ca-42b2-49f3-abc8-90c199452b76</Id>
+      <Id>7a9159e5-9fff-4f6f-aa90-5adbaeb01e34</Id>
       <CommandString>How many [aberrant shield pattern analysis;abnormal compact emission data;adaptive encryptors capture;anomalous bulk scan data;anomalous fsd telemetry;antimony;arsenic;atypical disrupted wake echoes;atypical encryption archives;basic conductors;biotech conductors;cadmiun;carbon;chemical distillery;chemical manipulators;chemical processors;chemical storage units;chromium;classified scan databanks;classified scan fragment;compact composites;compound shielding;conductive ceramics;conductive components;conductive polymers;configurable components;core dynamics composites;cracked industrial firmware;crystal shards;datamined wake exceptions;decoded emission data;distorted shield cycle recordings;divergent scan data;eccentric hyperspace trajectories;electrochemical arrays;exceptional scrambled emission data;exquisite focus crystals;filament composites;flawed focus crystals;focus crystals;galvanising alloys;germanium;grid resistors;heat conduction wiring;heat dispersion plate;heat exchangers;heat resistant ceramics;heat vanes;high density composites;hybrid capacitors;imperial shielding;improvised components;inconsistent shield soak analysis;iron;irregular emission data;manganese;mechanical components;mechanical equipment;mechanical scrap;mercury;military grade alloys;military supercapacitors;modified consumer firmware;modified embedded firmware;molybdenum;nickel;niobium;open symmetric keys;peculiar shield frequency data;pharmaceutical isolators;phase alloys;phosphorus;polonium;polymer capacitors;precipitated alloys;proprietary composites;proto heat radiators;proto light alloys;proto radiolic alloys;refined focus crystals;ruthenium;salvaged alloys;security firmware patch;selenium;shield emitters;shielding sensors;specialised legacy firmware;strange wake solutions;sulphur;tagged encryption codes;technetium;tellurium;tempered alloys;thermic alloys;tin;tungsten;unexpected emission data;unidentified scan archives;unknown fragment;untypical shield scans;unusual encrypted files;vanadium;worn shield emitters;yttrium;zinc;zirconium] [are on board;do i have]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -23102,7 +24420,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>91a1e6de-a8de-4da4-9d01-81c648eaad85</Id>
+          <Id>92aa21a5-714b-4fd7-bdb2-acdbae0006ce</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23140,7 +24458,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d2267116-e7ae-4929-bc95-e61340613b49</Id>
+          <Id>cb026b70-da59-4669-9921-b53227ab1c8c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23178,7 +24496,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a39b4c4b-ff35-4429-87ec-4343a78cea63</Id>
+          <Id>229302ab-451a-4a10-9c1a-3474c107d903</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23216,7 +24534,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>695b6df7-8c38-4c03-9cfc-a042480a7463</Id>
+          <Id>c47c8b93-6a1c-4194-a740-e0e7c29edcca</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23254,7 +24572,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>61aca1ea-0e1c-4957-ac0b-8136e08b633d</Id>
+          <Id>32d39efe-bef8-4dfd-9c72-67b10290a558</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23292,7 +24610,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5ab98ddc-ad06-4662-9f0f-0e2a2051f29c</Id>
+          <Id>eeaf588d-2d87-4c2a-94f3-e35a4e5e487e</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23332,7 +24650,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>13d45f8a-b27d-49ab-87f7-6319fe4d2d3f</Id>
+          <Id>90ed0e9c-ccbb-4bc3-986a-ec68de38514f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23370,7 +24688,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>31fe33eb-d8e6-46f1-bdff-784adbc68f17</Id>
+          <Id>b951ab8b-758a-4633-8847-05859e5990be</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23455,6 +24773,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -23471,7 +24790,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>7b798642-afca-4f37-90ce-2f7607004749</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>f8f38857-ad5a-421a-983c-4a1c3217e0ac</Id>
+      <Id>c68d345f-2332-4c2a-95cf-3b3f5bf895ae</Id>
       <CommandString>How many [aberrant shield pattern analysis;abnormal compact emission data;adaptive encryptors capture;anomalous bulk scan data;anomalous fsd telemetry;antimony;arsenic;atypical disrupted wake echoes;atypical encryption archives;basic conductors;biotech conductors;cadmiun;carbon;chemical distillery;chemical manipulators;chemical processors;chemical storage units;chromium;classified scan databanks;classified scan fragment;compact composites;compound shielding;conductive ceramics;conductive components;conductive polymers;configurable components;core dynamics composites;cracked industrial firmware;crystal shards;datamined wake exceptions;decoded emission data;distorted shield cycle recordings;divergent scan data;eccentric hyperspace trajectories;electrochemical arrays;exceptional scrambled emission data;exquisite focus crystals;filament composites;flawed focus crystals;focus crystals;galvanising alloys;germanium;grid resistors;heat conduction wiring;heat dispersion plate;heat exchangers;heat resistant ceramics;heat vanes;high density composites;hybrid capacitors;imperial shielding;improvised components;inconsistent shield soak analysis;iron;irregular emission data;manganese;mechanical components;mechanical equipment;mechanical scrap;mercury;military grade alloys;military supercapacitors;modified consumer firmware;modified embedded firmware;molybdenum;nickel;niobium;open symmetric keys;peculiar shield frequency data;pharmaceutical isolators;phase alloys;phosphorus;polonium;polymer capacitors;precipitated alloys;proprietary composites;proto heat radiators;proto light alloys;proto radiolic alloys;refined focus crystals;ruthenium;salvaged alloys;security firmware patch;selenium;shield emitters;shielding sensors;specialised legacy firmware;strange wake solutions;sulphur;tagged encryption codes;technetium;tellurium;tempered alloys;thermic alloys;tin;tungsten;unexpected emission data;unidentified scan archives;unknown fragment;untypical shield scans;unusual encrypted files;vanadium;worn shield emitters;yttrium;zinc;zirconium] can i discard</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -23483,7 +24802,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>dbad15a8-f3d4-4450-9848-ae69b6d5373d</Id>
+          <Id>2387f381-90a9-47c4-a4a1-3c5dba17ced1</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23521,7 +24840,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ca86bb44-4f42-4c4b-9c67-3cc05bbbc537</Id>
+          <Id>6351b2fc-05b5-4071-a81f-f66573e8ce1c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23559,7 +24878,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>07bea210-4308-43d8-927b-ba553e9e7235</Id>
+          <Id>1191c344-bce6-4581-8817-6032c1e04fe0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23597,7 +24916,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ed3b451e-8368-4396-a800-7c37e763857d</Id>
+          <Id>e0ba63fb-73eb-41c7-b75a-b91abaafade0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23635,7 +24954,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>14c27b8a-33fa-4a96-abe2-c916df93b703</Id>
+          <Id>0d190570-0bc8-4dff-811e-142beb374a3d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23675,7 +24994,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d70b2449-ea34-4187-be25-bc67162c9466</Id>
+          <Id>358e060c-6506-41fd-9fb5-5d2ccb258922</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23713,7 +25032,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>be21df13-8e22-4189-8526-ada170e61b96</Id>
+          <Id>69d320a0-e686-4842-99bf-eea037598bd8</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23798,6 +25117,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -23814,7 +25134,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>52a69cba-7f2c-49a4-9f1d-1e62fec9880a</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>c5ca0a52-7ad7-4a15-9e21-e6bb4e163285</Id>
+      <Id>edbe1c1a-d2fc-4d36-90d4-70e14af39590</Id>
       <CommandString>How many [aberrant shield pattern analysis;abnormal compact emission data;adaptive encryptors capture;anomalous bulk scan data;anomalous fsd telemetry;antimony;arsenic;atypical disrupted wake echoes;atypical encryption archives;basic conductors;biotech conductors;cadmiun;carbon;chemical distillery;chemical manipulators;chemical processors;chemical storage units;chromium;classified scan databanks;classified scan fragment;compact composites;compound shielding;conductive ceramics;conductive components;conductive polymers;configurable components;core dynamics composites;cracked industrial firmware;crystal shards;datamined wake exceptions;decoded emission data;distorted shield cycle recordings;divergent scan data;eccentric hyperspace trajectories;electrochemical arrays;exceptional scrambled emission data;exquisite focus crystals;filament composites;flawed focus crystals;focus crystals;galvanising alloys;germanium;grid resistors;heat conduction wiring;heat dispersion plate;heat exchangers;heat resistant ceramics;heat vanes;high density composites;hybrid capacitors;imperial shielding;improvised components;inconsistent shield soak analysis;iron;irregular emission data;manganese;mechanical components;mechanical equipment;mechanical scrap;mercury;military grade alloys;military supercapacitors;modified consumer firmware;modified embedded firmware;molybdenum;nickel;niobium;open symmetric keys;peculiar shield frequency data;pharmaceutical isolators;phase alloys;phosphorus;polonium;polymer capacitors;precipitated alloys;proprietary composites;proto heat radiators;proto light alloys;proto radiolic alloys;refined focus crystals;ruthenium;salvaged alloys;security firmware patch;selenium;shield emitters;shielding sensors;specialised legacy firmware;strange wake solutions;sulphur;tagged encryption codes;technetium;tellurium;tempered alloys;thermic alloys;tin;tungsten;unexpected emission data;unidentified scan archives;unknown fragment;untypical shield scans;unusual encrypted files;vanadium;worn shield emitters;yttrium;zinc;zirconium] do i need</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -23826,7 +25146,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1939e8d0-2acc-43a8-969c-971a2d63d9df</Id>
+          <Id>a45cd07d-abac-403d-8512-8149a9cb1f73</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23864,7 +25184,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8b9d47e8-7b38-4077-8d46-7fa69ca7a898</Id>
+          <Id>2009c647-1f88-4d1d-88bb-9b0361084a4f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23902,7 +25222,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>23320ad0-e0e9-49ad-9c68-600190f145dd</Id>
+          <Id>c86aaf9b-548d-4b71-8615-08ae9c4a3091</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23940,7 +25260,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c2806c8a-b3ee-4a28-859d-5e478db15221</Id>
+          <Id>e2ed8750-dd04-48a4-9f58-fb00081f4527</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -23978,7 +25298,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1abc8fab-adcf-4a4b-bb4c-d46523b059c3</Id>
+          <Id>537f107e-711a-424a-97f1-5430d725347d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24018,7 +25338,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>921552c5-0e3d-47d8-a5cc-4e171366f3d3</Id>
+          <Id>6fa57175-167a-4916-a37a-fa2a94fa016f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24056,7 +25376,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9955d9c-a1a7-426c-ad77-d744dd660d35</Id>
+          <Id>aaddf3c9-5a08-4ffe-8dd7-626c4fe6f98c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24141,6 +25461,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -24157,7 +25478,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>4e3ba5ff-8005-4fde-a92b-e53c7f0384a2</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>77dc0d3d-a3d1-48c5-8ee3-715f6c5b4426</Id>
+      <Id>eb3a8f30-fec7-4183-a70b-2a8a9817c1f4</Id>
       <CommandString>How many [system focused power distributor grade 1;system focused power distributor grade 3;system focused power distributor grade 2;shielded kill warrant scanner grade 1;shielded kill warrant scanner grade 3;shielded kill warrant scanner grade 2;shielded kill warrant scanner grade 5;shielded kill warrant scanner grade 4;ammo capacity point defence grade 3;specialised shield cell bank grade 1;specialised shield cell bank grade 3;specialised shield cell bank grade 2;fast scan detailed surface scanner grade 1;fast scan detailed surface scanner grade 3;fast scan detailed surface scanner grade 2;fast scan detailed surface scanner grade 5;fast scan detailed surface scanner grade 4;long range detailed surface scanner grade 1;long range detailed surface scanner grade 3;long range detailed surface scanner grade 2;long range detailed surface scanner grade 5;long range detailed surface scanner grade 4;lightweight life support grade 1;lightweight life support grade 3;lightweight life support grade 2;lightweight life support grade 4;shielded heat sink launcher grade 1;shielded heat sink launcher grade 3;shielded heat sink launcher grade 2;shielded heat sink launcher grade 5;shielded heat sink launcher grade 4;blast resistant hull reinforcement grade 1;blast resistant hull reinforcement grade 3;blast resistant hull reinforcement grade 2;blast resistant hull reinforcement grade 5;blast resistant hull reinforcement grade 4;rapid charge shield cell bank grade 1;rapid charge shield cell bank grade 3;rapid charge shield cell bank grade 2;heavy duty hull reinforcement grade 1;heavy duty hull reinforcement grade 3;heavy duty hull reinforcement grade 2;heavy duty hull reinforcement grade 5;heavy duty hull reinforcement grade 4;wide angle kill warrant scanner grade 1;wide angle kill warrant scanner grade 3;wide angle kill warrant scanner grade 2;wide angle kill warrant scanner grade 5;wide angle kill warrant scanner grade 4;resistance augmented shield booster grade 1;resistance augmented shield booster grade 3;resistance augmented shield booster grade 2;resistance augmented shield booster grade 5;resistance augmented shield booster grade 4;blast resistant shield booster grade 1;blast resistant shield booster grade 3;blast resistant shield booster grade 2;blast resistant shield booster grade 5;blast resistant shield booster grade 4;lightweight heat sink launcher grade 1;lightweight heat sink launcher grade 3;lightweight heat sink launcher grade 2;lightweight heat sink launcher grade 5;lightweight heat sink launcher grade 4;lightweight sensors grade 1;lightweight sensors grade 3;lightweight sensors grade 2;lightweight sensors grade 5;lightweight sensors grade 4;lightweight frame shift wake scanner grade 1;lightweight frame shift wake scanner grade 3;lightweight frame shift wake scanner grade 2;lightweight frame shift wake scanner grade 5;lightweight frame shift wake scanner grade 4;shielded refinery grade 1;shielded refinery grade 3;shielded refinery grade 2;shielded refinery grade 4;armoured power distributor grade 1;armoured power distributor grade 3;armoured power distributor grade 2;armoured power distributor grade 5;armoured power distributor grade 4;kinetic resistant hull reinforcement grade 1;kinetic resistant hull reinforcement grade 3;kinetic resistant hull reinforcement grade 2;kinetic resistant hull reinforcement grade 5;kinetic resistant hull reinforcement grade 4;long range frame shift drive interdictor grade 1;long range frame shift drive interdictor grade 3;long range frame shift drive interdictor grade 2;reinforced shield generator grade 1;reinforced shield generator grade 3;reinforced shield generator grade 2;reinforced shield generator grade 5;reinforced shield generator grade 4;ammo capacity chaff launcher grade 3;faster boot sequence frame shift drive grade 1;faster boot sequence frame shift drive grade 3;faster boot sequence frame shift drive grade 2;faster boot sequence frame shift drive grade 5;faster boot sequence frame shift drive grade 4;reinforced frame shift wake scanner grade 1;reinforced frame shift wake scanner grade 3;reinforced frame shift wake scanner grade 2;reinforced frame shift wake scanner grade 5;reinforced frame shift wake scanner grade 4;shielded point defence grade 1;shielded point defence grade 3;shielded point defence grade 2;shielded point defence grade 5;shielded point defence grade 4;lightweight point defence grade 1;lightweight point defence grade 3;lightweight point defence grade 2;lightweight point defence grade 5;lightweight point defence grade 4;reinforced thrusters grade 1;reinforced thrusters grade 3;reinforced thrusters grade 2;reinforced thrusters grade 5;reinforced thrusters grade 4;ammo capacity heat sink launcher grade 3;reinforced prospector limpet controller grade 1;reinforced prospector limpet controller grade 3;reinforced prospector limpet controller grade 2;reinforced prospector limpet controller grade 5;reinforced prospector limpet controller grade 4;fast scan kill warrant scanner grade 1;fast scan kill warrant scanner grade 3;fast scan kill warrant scanner grade 2;fast scan kill warrant scanner grade 5;fast scan kill warrant scanner grade 4;reinforced kill warrant scanner grade 1;reinforced kill warrant scanner grade 3;reinforced kill warrant scanner grade 2;reinforced kill warrant scanner grade 5;reinforced kill warrant scanner grade 4;lightweight bulkheads grade 1;lightweight bulkheads grade 3;lightweight bulkheads grade 2;lightweight bulkheads grade 5;lightweight bulkheads grade 4;long range weapon grade 1;long range weapon grade 3;long range weapon grade 2;long range weapon grade 5;long range weapon grade 4;dirty thrusters grade 1;dirty thrusters grade 3;dirty thrusters grade 2;dirty thrusters grade 5;dirty thrusters grade 4;shielded life support grade 1;shielded life support grade 3;shielded life support grade 2;shielded life support grade 4;shielded frame shift drive grade 1;shielded frame shift drive grade 3;shielded frame shift drive grade 2;shielded frame shift drive grade 5;shielded frame shift drive grade 4;reinforced electronic counter measures grade 1;reinforced electronic counter measures grade 3;reinforced electronic counter measures grade 2;reinforced electronic counter measures grade 5;reinforced electronic counter measures grade 4;lightweight kill warrant scanner grade 1;lightweight kill warrant scanner grade 3;lightweight kill warrant scanner grade 2;lightweight kill warrant scanner grade 5;lightweight kill warrant scanner grade 4;wide angle detailed surface scanner grade 1;wide angle detailed surface scanner grade 3;wide angle detailed surface scanner grade 2;wide angle detailed surface scanner grade 5;wide angle detailed surface scanner grade 4;reinforced fuel transfer limpet controller grade 1;reinforced fuel transfer limpet controller grade 3;reinforced fuel transfer limpet controller grade 2;reinforced fuel transfer limpet controller grade 5;reinforced fuel transfer limpet controller grade 4;reinforced point defence grade 1;reinforced point defence grade 3;reinforced point defence grade 2;reinforced point defence grade 5;reinforced point defence grade 4;long range cargo scanner grade 1;long range cargo scanner grade 3;long range cargo scanner grade 2;long range cargo scanner grade 5;long range cargo scanner grade 4;kinetic resistant shield generator grade 1;kinetic resistant shield generator grade 3;kinetic resistant shield generator grade 2;kinetic resistant shield generator grade 5;kinetic resistant shield generator grade 4;shielded auto field mainentance unit grade 1;shielded auto field mainentance unit grade 3;shielded auto field mainentance unit grade 2;shielded auto field mainentance unit grade 4;thermal resistant hull reinforcement grade 1;thermal resistant hull reinforcement grade 3;thermal resistant hull reinforcement grade 2;thermal resistant hull reinforcement grade 5;thermal resistant hull reinforcement grade 4;reinforced heat sink launcher grade 1;reinforced heat sink launcher grade 3;reinforced heat sink launcher grade 2;reinforced heat sink launcher grade 5;reinforced heat sink launcher grade 4;double shot weapon grade 1;double shot weapon grade 3;double shot weapon grade 2;double shot weapon grade 5;double shot weapon grade 4;engine focused power distributor grade 1;engine focused power distributor grade 3;engine focused power distributor grade 2;shielded power distributor grade 1;shielded power distributor grade 3;shielded power distributor grade 2;shielded power distributor grade 5;shielded power distributor grade 4;long range kill warrant scanner grade 1;long range kill warrant scanner grade 3;long range kill warrant scanner grade 2;long range kill warrant scanner grade 5;long range kill warrant scanner grade 4;reinforced cargo scanner grade 1;reinforced cargo scanner grade 3;reinforced cargo scanner grade 2;reinforced cargo scanner grade 5;reinforced cargo scanner grade 4;shielded prospector limpet controller grade 1;shielded prospector limpet controller grade 3;shielded prospector limpet controller grade 2;shielded prospector limpet controller grade 5;shielded prospector limpet controller grade 4;wide angle wake scanner grade 1;wide angle wake scanner grade 3;wide angle wake scanner grade 2;wide angle wake scanner grade 5;wide angle wake scanner grade 4;wide angle sensors grade 1;wide angle sensors grade 3;wide angle sensors grade 2;wide angle sensors grade 5;wide angle sensors grade 4;clean thrusters grade 1;clean thrusters grade 3;clean thrusters grade 2;clean thrusters grade 5;clean thrusters grade 4;lightweight prospector limpet controller grade 1;lightweight prospector limpet controller grade 3;lightweight prospector limpet controller grade 2;lightweight prospector limpet controller grade 5;lightweight prospector limpet controller grade 4;kinetic resistant bulkheads grade 1;kinetic resistant bulkheads grade 3;kinetic resistant bulkheads grade 2;kinetic resistant bulkheads grade 5;kinetic resistant bulkheads grade 4;blast resistant bulkheads grade 1;blast resistant bulkheads grade 3;blast resistant bulkheads grade 2;blast resistant bulkheads grade 5;blast resistant bulkheads grade 4;lightweight hull reinforcement grade 1;lightweight hull reinforcement grade 3;lightweight hull reinforcement grade 2;lightweight hull reinforcement grade 5;lightweight hull reinforcement grade 4;weapon focused power distributor grade 1;weapon focused power distributor grade 3;weapon focused power distributor grade 2;low emissions power distributor grade 1;low emissions power distributor grade 3;low emissions power distributor grade 2;focused weapon grade 1;focused weapon grade 3;focused weapon grade 2;focused weapon grade 5;focused weapon grade 4;sturdy weapon grade 1;sturdy weapon grade 3;sturdy weapon grade 2;sturdy weapon grade 5;sturdy weapon grade 4;high capacity weapon grade 1;high capacity weapon grade 3;high capacity weapon grade 2;high capacity weapon grade 5;high capacity weapon grade 4;lightweight electronic counter measures grade 1;lightweight electronic counter measures grade 3;lightweight electronic counter measures grade 2;lightweight electronic counter measures grade 5;lightweight electronic counter measures grade 4;shielded electronic counter measures grade 1;shielded electronic counter measures grade 3;shielded electronic counter measures grade 2;shielded electronic counter measures grade 5;shielded electronic counter measures grade 4;shielded hatch breaker limpet controller grade 1;shielded hatch breaker limpet controller grade 3;shielded hatch breaker limpet controller grade 2;shielded hatch breaker limpet controller grade 5;shielded hatch breaker limpet controller grade 4;lightweight cargo scanner grade 1;lightweight cargo scanner grade 3;lightweight cargo scanner grade 2;lightweight cargo scanner grade 5;lightweight cargo scanner grade 4;overcharged weapon grade 1;overcharged weapon grade 3;overcharged weapon grade 2;overcharged weapon grade 5;overcharged weapon grade 4;lightweight collector limpet controller grade 1;lightweight collector limpet controller grade 3;lightweight collector limpet controller grade 2;lightweight collector limpet controller grade 5;lightweight collector limpet controller grade 4;lightweight weapon grade 1;lightweight weapon grade 3;lightweight weapon grade 2;lightweight weapon grade 5;lightweight weapon grade 4;shielded chaff launcher grade 1;shielded chaff launcher grade 3;shielded chaff launcher grade 2;shielded chaff launcher grade 5;shielded chaff launcher grade 4;lightweight chaff launcher grade 1;lightweight chaff launcher grade 3;lightweight chaff launcher grade 2;lightweight chaff launcher grade 5;lightweight chaff launcher grade 4;high charge capacity power distributor grade 1;high charge capacity power distributor grade 3;high charge capacity power distributor grade 2;high charge capacity power distributor grade 5;high charge capacity power distributor grade 4;rapid fire weapon grade 1;rapid fire weapon grade 3;rapid fire weapon grade 2;rapid fire weapon grade 5;rapid fire weapon grade 4;shielded cargo scanner grade 1;shielded cargo scanner grade 3;shielded cargo scanner grade 2;shielded cargo scanner grade 5;shielded cargo scanner grade 4;thermal resistant bulkheads grade 1;thermal resistant bulkheads grade 3;thermal resistant bulkheads grade 2;thermal resistant bulkheads grade 5;thermal resistant bulkheads grade 4;reinforced hatch breaker limpet controller grade 1;reinforced hatch breaker limpet controller grade 3;reinforced hatch breaker limpet controller grade 2;reinforced hatch breaker limpet controller grade 5;reinforced hatch breaker limpet controller grade 4;fast scan cargo scanner grade 1;fast scan cargo scanner grade 3;fast scan cargo scanner grade 2;fast scan cargo scanner grade 5;fast scan cargo scanner grade 4;heavy duty bulkheads grade 1;heavy duty bulkheads grade 3;heavy duty bulkheads grade 2;heavy duty bulkheads grade 5;heavy duty bulkheads grade 4;heavy duty shield booster grade 1;heavy duty shield booster grade 3;heavy duty shield booster grade 2;heavy duty shield booster grade 5;heavy duty shield booster grade 4;reinforced collector limpet controller grade 1;reinforced collector limpet controller grade 3;reinforced collector limpet controller grade 2;reinforced collector limpet controller grade 5;reinforced collector limpet controller grade 4;charge enhanced power distributor grade 1;charge enhanced power distributor grade 3;charge enhanced power distributor grade 2;charge enhanced power distributor grade 5;charge enhanced power distributor grade 4;reinforced chaff launcher grade 1;reinforced chaff launcher grade 3;reinforced chaff launcher grade 2;reinforced chaff launcher grade 5;reinforced chaff launcher grade 4;long range wake scanner grade 1;long range wake scanner grade 3;long range wake scanner grade 2;long range wake scanner grade 5;long range wake scanner grade 4;expanded capture arc frame shift drive interdictor grade 1;expanded capture arc frame shift drive interdictor grade 3;expanded capture arc frame shift drive interdictor grade 2;expanded capture arc frame shift drive interdictor grade 4;shielded collector limpet controller grade 1;shielded collector limpet controller grade 3;shielded collector limpet controller grade 2;shielded collector limpet controller grade 5;shielded collector limpet controller grade 4;increased range frame shift drive grade 1;increased range frame shift drive grade 3;increased range frame shift drive grade 2;increased range frame shift drive grade 5;increased range frame shift drive grade 4;kinetic resistant shield booster grade 1;kinetic resistant shield booster grade 3;kinetic resistant shield booster grade 2;kinetic resistant shield booster grade 5;kinetic resistant shield booster grade 4;lightweight fuel transfer limpet controller grade 1;lightweight fuel transfer limpet controller grade 3;lightweight fuel transfer limpet controller grade 2;lightweight fuel transfer limpet controller grade 5;lightweight fuel transfer limpet controller grade 4;wide angle cargo scanner grade 1;wide angle cargo scanner grade 3;wide angle cargo scanner grade 2;wide angle cargo scanner grade 5;wide angle cargo scanner grade 4;thermal resistant shield generator grade 1;thermal resistant shield generator grade 3;thermal resistant shield generator grade 2;thermal resistant shield generator grade 5;thermal resistant shield generator grade 4;shielded fuel transfer limpet controller grade 1;shielded fuel transfer limpet controller grade 3;shielded fuel transfer limpet controller grade 2;shielded fuel transfer limpet controller grade 5;shielded fuel transfer limpet controller grade 4;long range sensors grade 1;long range sensors grade 3;long range sensors grade 2;long range sensors grade 5;long range sensors grade 4;short range weapon grade 1;short range weapon grade 3;short range weapon grade 2;short range weapon grade 5;short range weapon grade 4;shielded frame shift wake scanner grade 1;shielded frame shift wake scanner grade 3;shielded frame shift wake scanner grade 2;shielded frame shift wake scanner grade 5;shielded frame shift wake scanner grade 4;fast scan wake scanner grade 1;fast scan wake scanner grade 3;fast scan wake scanner grade 2;fast scan wake scanner grade 5;fast scan wake scanner grade 4;overcharged power distributor grade 1;overcharged power distributor grade 3;overcharged power distributor grade 2;overcharged power distributor grade 5;overcharged power distributor grade 4;lightweight hatch breaker limpet controller grade 1;lightweight hatch breaker limpet controller grade 3;lightweight hatch breaker limpet controller grade 2;lightweight hatch breaker limpet controller grade 5;lightweight hatch breaker limpet controller grade 4;thermal resistant shield booster grade 1;thermal resistant shield booster grade 3;thermal resistant shield booster grade 2;thermal resistant shield booster grade 5;thermal resistant shield booster grade 4;efficient weapon grade 1;efficient weapon grade 3;efficient weapon grade 2;efficient weapon grade 5;efficient weapon grade 4;shielded fuel scoop grade 1;shielded fuel scoop grade 3;shielded fuel scoop grade 2;shielded fuel scoop grade 4;enhanced low power shield generator grade 1;enhanced low power shield generator grade 3;enhanced low power shield generator grade 2;enhanced low power shield generator grade 5;enhanced low power shield generator grade 4;reinforced life support grade 1;reinforced life support grade 3;reinforced life support grade 2;reinforced life support grade 4
 ] can I make</CommandString>
       <ActionSequence>
@@ -24170,7 +25491,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8514fa80-b216-444d-a7ce-8a186b7cb5f9</Id>
+          <Id>34e3d552-0a06-4db6-8835-ee97989ee6d7</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24208,7 +25529,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>eb6ab579-ec7a-4418-9822-b96d784c9b7c</Id>
+          <Id>89738c06-36e2-4fbd-b208-6422f6b400cd</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24246,7 +25567,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8d746aac-cc08-4551-a825-ac89531a178b</Id>
+          <Id>27f0d5ee-4b72-427f-bea3-5ffeb3b02ab8</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24284,7 +25605,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>26bb6d34-df1e-4219-9321-a7ffcbab38b3</Id>
+          <Id>28b55c8c-c9ef-49c6-9747-08d2e97d930c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24322,7 +25643,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d157c198-18b4-4748-b9a4-0be733be0a93</Id>
+          <Id>346a132f-2e6d-4a78-8126-882a0f1e7f18</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24362,7 +25683,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>14399c0e-4ca1-4757-9046-9606966d084f</Id>
+          <Id>f5a8d153-7fb7-421a-b6cd-1e0459e378b1</Id>
           <ActionType>WriteToLog</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24395,7 +25716,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>342a32cf-e3b3-4b39-a42e-f5ce2e097085</Id>
+          <Id>172c0ec2-9791-4511-8265-3abb4189a77a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24433,7 +25754,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>efbbc52e-1cdb-43c3-9896-c6f6530b6de1</Id>
+          <Id>be0cb2d5-cdbb-487b-8855-3c8abc98422d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24518,6 +25839,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -24534,7 +25856,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0e77c0ed-26d4-4842-859d-59095929f2e4</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>45127e80-e82d-4e37-93d8-bda381ef9823</Id>
+      <Id>66635ffb-ef50-4671-a1f4-44c48c58cac5</Id>
       <CommandString>Is there any news?</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -24546,7 +25868,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>082b934c-7aa7-440d-a27e-ed6c94186baa</Id>
+          <Id>fe660a13-0920-41a1-b4ae-ac8c496a13f8</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24584,7 +25906,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>acbc994e-8db0-4424-a687-00f97c4692af</Id>
+          <Id>e10a5754-9b03-4c77-a5e8-87413fe4c7a3</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24669,6 +25991,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -24685,7 +26008,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>461abecc-92b1-4ce5-bc7f-a90209188698</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>287b2c1c-1453-4ddc-aee7-a201f36e4c51</Id>
+      <Id>045bdc7a-a24b-4e78-ae76-44ccfa9a0955</Id>
       <CommandString>[Make;Take;Enter;Set] a [comment;note] [on;for] this system</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -24697,7 +26020,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2e356efb-b1e4-4bb8-864c-5a7bfd0e8f94</Id>
+          <Id>bbadae89-d603-4eb4-a168-1fb2a4352ce0</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24732,7 +26055,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cbe8452e-c136-45e4-abde-5292721d3a49</Id>
+          <Id>59e85904-5002-4909-bf05-079b47487781</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24770,7 +26093,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>30831714-2d18-4d34-98f5-5a10c2528875</Id>
+          <Id>0d34c0c6-5522-471e-9476-916c787c74c8</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24810,7 +26133,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>23afdd77-c6e8-4c81-b951-1cc61e20bb91</Id>
+          <Id>cd754f6e-88b4-4be5-ad5f-f587966547e7</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24842,7 +26165,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>998e7e42-8e23-4b99-9d89-9237a08b8799</Id>
+          <Id>d8eb8218-efff-4b9a-9e5f-e50a53c096db</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24880,7 +26203,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>03ab72a1-9192-457b-8cf0-dddb5d67f0f8</Id>
+          <Id>33792e8d-bb6c-4bda-ae11-61693ec9f5a8</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24920,7 +26243,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ceb5c264-6930-49a8-8a81-88ac2e1e23f4</Id>
+          <Id>042c73f5-bb9f-4f0d-934a-e3e6e0454b91</Id>
           <ActionType>StartDictation</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -24997,6 +26320,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -25013,7 +26337,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>e2c1aa18-e0d0-49ff-be7b-ec4428ee516f</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>8452138a-c1b3-4564-98d0-70a8c8e5d288</Id>
+      <Id>a5261eb3-8090-45fa-9897-981201a00278</Id>
       <CommandString>Mark [all; community goal; conflict; democracy; economy; economic; expansion; health; security; starport; starport status; starport status update;] [articles; news; reports;] as read</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -25025,7 +26349,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b4b9eef5-0575-4881-8561-afe444d1ecd0</Id>
+          <Id>25209203-d14a-4a12-a54b-859af323e6f1</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25060,7 +26384,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>85feb8c5-f346-4bed-bb1c-cf2198444e73</Id>
+          <Id>3a08fd73-7fed-4def-815e-00698b71ab54</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25098,7 +26422,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>94be6d8f-3c77-4161-b4de-a1bf7a958f69</Id>
+          <Id>3fdeebf7-b12a-426c-802a-20dde3aeb791</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25133,7 +26457,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>63db61e3-b9fd-4953-b7ba-f7d24397f7f8</Id>
+          <Id>42f7394b-9a07-46f6-86a9-1d84ec5c50ec</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25171,7 +26495,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>54f36c93-ed03-4394-b107-6467896f76bf</Id>
+          <Id>6c074305-0055-4ef7-b5cb-6c61b3f67eb5</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25206,7 +26530,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>93f43a4a-ad52-44d2-98c7-948eaa325da2</Id>
+          <Id>db7be7ef-74e1-459a-958e-6db61ebeaf5d</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25244,7 +26568,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d26df5f6-1492-43e2-81a4-4621ab7a59f3</Id>
+          <Id>55a0fdac-01bf-4694-807d-bbb51fd2841e</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>1</Duration>
           <Delay>0</Delay>
@@ -25271,7 +26595,7 @@
           <ConditionExpressions>
             <ArrayOfConditionStruct>
               <ConditionStruct>
-                <Id>50aedd77-6fe7-4c7a-8215-6d36c076e873</Id>
+                <Id>eff57ac7-04fd-409a-b683-0a3e51c89c80</Id>
                 <ConditionStartType>1</ConditionStartType>
                 <ConditionStartNameFrom>{LASTSPOKENCMD}</ConditionStartNameFrom>
                 <ConditionStartValueType>0</ConditionStartValueType>
@@ -25286,7 +26610,7 @@
             </ArrayOfConditionStruct>
             <ArrayOfConditionStruct>
               <ConditionStruct>
-                <Id>8f767da9-e372-4029-9e81-72b4d2d78880</Id>
+                <Id>dedb407a-085d-467b-9acd-8ab1cd7a20d3</Id>
                 <ConditionStartType>1</ConditionStartType>
                 <ConditionStartNameFrom>{LASTSPOKENCMD}</ConditionStartNameFrom>
                 <ConditionStartValueType>0</ConditionStartValueType>
@@ -25310,7 +26634,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e0ae075d-c2d4-4729-b0ca-4cd0bb39354c</Id>
+          <Id>47fcddc9-6e7f-463c-98cf-c27fdd1d9f1f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25348,7 +26672,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>abbe7fd6-d6f6-4f1a-9c8f-ed2b794bcf02</Id>
+          <Id>6dfe029b-b0b3-4d5e-bc62-4b0ae151a2cd</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25383,7 +26707,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e43fe11a-4e16-43bf-937f-5ecd0976513a</Id>
+          <Id>6b6477e3-3ac2-4e4f-9740-520c7956aabe</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25421,7 +26745,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>641bf1e0-70e9-4c3a-aebd-a863d127c87f</Id>
+          <Id>dda1ed6a-7d3f-4aef-ac76-6a1b8e4a8609</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25456,7 +26780,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>12326842-96e7-4633-b186-27436669cc76</Id>
+          <Id>3c39fafd-46cd-4581-8156-7d5f3f0c6bfb</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25494,7 +26818,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b4b2156e-fde0-4f66-ba10-70f7c51d6e8e</Id>
+          <Id>98eb8ad6-62b6-4158-a344-57bfb52ed0f7</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25529,7 +26853,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>74445db2-6229-4992-af8b-4b8bcac48431</Id>
+          <Id>6e681327-3e30-4154-9eeb-b5fc7dd34b4a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25567,7 +26891,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>32128695-8bf6-4081-b350-aabaa00e3d78</Id>
+          <Id>7ba4617b-e7d2-4e54-ad6f-0ae4791e1645</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25602,7 +26926,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f3ea0bbe-6de6-42d4-87d4-4b24e1ad745c</Id>
+          <Id>150bfd7d-5f5d-46fa-821a-58b7b968b2ff</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25640,7 +26964,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>afd26f36-f2f0-4c3b-b995-f86ea6d19554</Id>
+          <Id>e4780615-0a13-42db-a063-f9e45456f430</Id>
           <ActionType>ConditionElse</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25672,7 +26996,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c856d549-e5c8-4a46-8430-ebb6bb78d60f</Id>
+          <Id>2a4a1239-bf37-4865-b302-c330c5b3075a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25710,7 +27034,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f04a9b67-b2ee-4c5e-902d-bcaa902726a4</Id>
+          <Id>cab32907-85a6-4611-a49d-a2859cd0dc85</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25742,7 +27066,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0206303f-64a5-4f0d-9bf0-74346016cbf8</Id>
+          <Id>d86e661f-2dc6-432b-ba80-914f46654081</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25780,7 +27104,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8486d09f-6848-4158-bef4-d71e75962997</Id>
+          <Id>17242d8f-4cec-4347-9808-45e22e93cdc6</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25820,7 +27144,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2afbb28e-a988-42dd-8f36-595ff22811f5</Id>
+          <Id>55643b8f-7a41-4c88-8ac8-5ecdf7595cf1</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25858,7 +27182,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cef9f03a-5122-4828-be7d-66053974b141</Id>
+          <Id>99d66310-eb50-4016-997f-a1e874a04d3a</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -25943,6 +27267,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -25959,7 +27284,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>a19b1350-2338-43cd-a0de-8bac45b59b1f</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>bd578d00-0e15-4cca-a30f-d765bfdac960</Id>
+      <Id>bef64646-290f-4504-a644-2f976e3724aa</Id>
       <CommandString>[Note;Comment] ends;End [note;comment]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -25971,7 +27296,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d0ffe68a-1538-41ef-af7b-529db5ef2a4e</Id>
+          <Id>d7ff269e-11e4-4ad7-84ef-063ff442a5ab</Id>
           <ActionType>StopDictation</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26003,7 +27328,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5cb17c12-8440-4539-a87e-628c852ef2da</Id>
+          <Id>f717d84f-751c-47ff-8e8c-b2a63e896c9e</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26041,7 +27366,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>900cabbf-4187-4792-a50f-7ed974df8791</Id>
+          <Id>55aa07b2-61b0-472c-8842-13f6d32c813a</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26081,7 +27406,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>855f77b2-e9c4-4cc9-849b-514d246bd0ec</Id>
+          <Id>02ccabfc-c7c5-4032-97bf-37e58393c460</Id>
           <ActionType>Say</ActionType>
           <Duration>1</Duration>
           <Delay>0</Delay>
@@ -26114,7 +27439,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0b0bd2e3-5b53-446b-9af3-91bdfb8d6d16</Id>
+          <Id>beca1943-87ef-4d9f-be78-6d9380d7ca53</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26152,7 +27477,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9aa98bbe-16ba-48e9-91f0-1f7494283493</Id>
+          <Id>8de6107b-18cd-4ff5-9ed2-bb758715aa8c</Id>
           <ActionType>ClearDictation</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26184,7 +27509,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>45700b3d-c875-4dfa-bc92-aa59b865fe87</Id>
+          <Id>1dfdb771-e42f-413d-851d-83a8a5e6d112</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26269,6 +27594,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -26285,7 +27611,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>e5a29c81-05dd-4c11-9917-1768ba5c5b7d</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>6dc0d852-1cbb-4497-91dc-726a52e146e6</Id>
+      <Id>fe54d247-7dc9-4df3-a5ee-2d9771f416b5</Id>
       <CommandString>Please repeat that;What was that?;Could you say that again?;Say that again</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -26297,7 +27623,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>68ffdb00-5e97-4d53-9e88-3155f403c004</Id>
+          <Id>24b13abd-0190-4fe8-8790-d5afeee7f1a0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26335,7 +27661,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d0b527cb-66fb-40f9-ae7a-1e1a6b1ee8e9</Id>
+          <Id>7929e691-4e3d-4bbc-a7f2-df72033772fc</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26420,6 +27746,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -26436,7 +27763,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>545d0d59-b85c-4e9d-b192-fd789a6d0a61</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>4f9cb07d-9dc6-4ae7-9e55-882d40f6403e</Id>
+      <Id>fa2438dd-49f8-485e-91a1-653d8ccf3650</Id>
       <CommandString>[Please;] [run;start] pre [flight;launch] [checks;diagnostics]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -26448,7 +27775,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6f08ccfe-4e99-4965-b80e-0bb8b7e7d843</Id>
+          <Id>c81580eb-27a4-4330-88ce-f55374321b17</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26486,7 +27813,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>67ecc89e-2c8e-4101-b10c-e5d8aa73d12e</Id>
+          <Id>8dd4a573-fda2-4277-bf9b-6cf7fc862459</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26526,7 +27853,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7ff827d7-cd38-4144-8e2f-6ee1d5d524b1</Id>
+          <Id>fd149b3a-d491-4962-b194-f6662b4ec814</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26564,7 +27891,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>aca9da19-fcf3-4f69-83ab-2f361bb319ed</Id>
+          <Id>aeaa023e-e32c-4644-99ef-e534a8655695</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26604,7 +27931,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bd9500b8-1c87-4be7-9e41-cca7fcb64ad5</Id>
+          <Id>6f8c7819-6d15-427a-8cd5-b6f22c2063b0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26642,7 +27969,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ffa40a04-81e2-419f-95d5-ccd5a005467e</Id>
+          <Id>8f6df138-8bed-4d7d-b21b-97938a552039</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26682,7 +28009,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>60d9da3a-492d-4047-abb3-b95cfcb6ef08</Id>
+          <Id>cadb7f24-6bd8-4fea-9a40-afe8c168d33b</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26720,7 +28047,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cf423368-7f61-45f0-b0f6-46ebbb84cc2c</Id>
+          <Id>b1a594d9-03da-45d0-89df-e8f99495389b</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26760,7 +28087,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e2d3e4c0-b949-4d86-9227-131b441225b9</Id>
+          <Id>aa9362e2-4df0-4b2e-bd74-82ab4e46ce5a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26798,7 +28125,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>09c416f0-56d4-4e90-b4e3-f659426c089f</Id>
+          <Id>276741f2-813a-40c1-bf55-0a255a01ee1f</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26883,6 +28210,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -26899,7 +28227,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>a605849d-68ee-4e28-876d-0f38df759371</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>e5e389dc-e1fa-4b58-8f57-5c43d4a88ae9</Id>
+      <Id>d7fbfe7f-98dc-4e1d-8edf-23b7c2404109</Id>
       <CommandString>Read the latest community goal [news;]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -26911,7 +28239,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>25992798-006b-434c-8a18-3af7bd942a85</Id>
+          <Id>ad564905-6328-49fe-a288-50920d75c557</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26949,7 +28277,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bb8ed25f-b5e8-4cb8-98f1-ed8fdfee54fe</Id>
+          <Id>5763b052-0aad-41dd-98e7-2895b1a405c5</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -26987,7 +28315,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ccd8b553-bb32-42fc-8587-ef72d18790aa</Id>
+          <Id>8b5ed964-0893-48f8-8ee3-babccd236f25</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27027,7 +28355,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f2a4273e-2232-4f12-a431-a1c28705190b</Id>
+          <Id>87479c1e-9301-477b-928e-4adadcc6e56c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27065,7 +28393,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>54c6d1d9-f67c-440e-937c-214c207936ce</Id>
+          <Id>26522fa8-01ea-411e-8b8c-be57455772d8</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27150,6 +28478,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -27166,7 +28495,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>5fa9738e-027a-4385-99fc-073fdab9bcc0</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>3ff77d47-b3c4-48ce-aa1d-dc10abbce39e</Id>
+      <Id>fd8add02-1d61-4c86-94af-700242755acc</Id>
       <CommandString>Read the latest conflict [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -27178,7 +28507,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>749e63aa-53d0-44b0-8ecd-d3de4afc1b02</Id>
+          <Id>3a4190a8-a7fe-4674-8a6f-9ee0c91edd64</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27216,7 +28545,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ae00c1fa-e71d-407e-b559-7714040b6324</Id>
+          <Id>bc8e1126-8bb0-492c-bb8b-188f89a2701d</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27254,7 +28583,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6796dba0-3c9f-4b04-b029-d1221e4ee795</Id>
+          <Id>47e58895-48ba-478f-a9cb-aabba75b2354</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27294,7 +28623,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d167bc4c-5375-4d32-8c4f-35d95da369a8</Id>
+          <Id>710982ae-afdf-4e69-a230-8bd0f42c433b</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27332,7 +28661,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>367a55cf-a62c-4ad8-a7d3-d1c2f18a5594</Id>
+          <Id>7d02b3e7-f93e-4709-af93-c4dc5d84a93d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27417,6 +28746,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -27433,7 +28763,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>3b02a23e-bf63-40ff-a542-d341a1835900</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>963316ea-a0b2-441b-a1ad-ae8db6d1745f</Id>
+      <Id>9ddfde47-2ae5-4be8-8a40-8eca4deb06c2</Id>
       <CommandString>Read the latest democracy [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -27445,7 +28775,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fdf759bc-256f-4dfd-ac33-66c3b079757e</Id>
+          <Id>0f17b203-5952-4e7c-959e-8272727845a5</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27483,7 +28813,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>941bd79b-0220-4902-948e-3a159d46966d</Id>
+          <Id>da18797b-d881-4746-83fa-f27cea7b977c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27521,7 +28851,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>60d28d17-19fb-4f77-93eb-b7908cf2e8f0</Id>
+          <Id>bc2c08d7-ea20-4181-8980-a2672614924f</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27561,7 +28891,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>793df4e6-84bc-4fe2-a26c-a38a9e3913f3</Id>
+          <Id>cc149f18-6cc2-4708-a0e8-ee9bd72180a5</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27599,7 +28929,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a52f7680-ee65-4044-a3ce-8c0b1e6732ba</Id>
+          <Id>55b3d47a-ed46-4f15-80a9-93309db1fe19</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27684,6 +29014,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -27700,7 +29031,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0a5358c0-de0f-4601-95f5-28966ca7b285</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>a1c20e54-9955-45a9-8511-47a6708a7687</Id>
+      <Id>d93bf030-fe05-4edb-94f0-e5550a70bb21</Id>
       <CommandString>Read the latest economy [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -27712,7 +29043,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a0bb0338-459a-48d4-b654-335571da1c81</Id>
+          <Id>b16b092d-8ca2-4e2b-b4e6-55f0e15dfb79</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27750,7 +29081,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>adfc09bb-cb4d-410f-90a9-a4feeae8969b</Id>
+          <Id>13dc8e08-8623-4d2d-a84e-c17972107275</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27788,7 +29119,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3b15955b-6b65-4399-8bf5-63e35641c207</Id>
+          <Id>ef738a11-655f-49d6-91c6-7aa832d3a1ee</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27828,7 +29159,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fbfaa0df-56d0-41bf-8388-d9904e753f43</Id>
+          <Id>9957bebc-563c-4d45-8ba0-19cfbd6108d6</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27866,7 +29197,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6334788b-8307-4528-8f91-607df38c27c3</Id>
+          <Id>e207d725-1de2-4811-bbb8-371e97b00424</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -27951,6 +29282,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -27967,7 +29299,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>358f0216-f7e3-445a-8fb4-d74833e1f96f</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>5e8b0313-a8f0-49bc-b35d-e4a4c80d004f</Id>
+      <Id>9d0bb46f-263d-4f3f-b337-70a51b25773e</Id>
       <CommandString>Read the latest expansion [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -27979,7 +29311,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>68172f70-5ebd-42ae-938d-21d0acdc5097</Id>
+          <Id>d139a85e-6aa4-4b29-b665-bd76ad04f03b</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28017,7 +29349,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9c3873c8-16ac-4bad-a39b-cb0bd30f0edb</Id>
+          <Id>161ace8a-84ad-4483-a816-a18d5a57ac97</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28055,7 +29387,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ec18802f-b3cf-43fb-a8d7-4a3bbea6570b</Id>
+          <Id>89ae8280-1c86-4014-a9d7-9e42523f5735</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28095,7 +29427,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c996c1a8-eea0-43d2-aaac-0fe46cd128f8</Id>
+          <Id>414b39d7-b663-4b39-9cca-6b65b4b10135</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28133,7 +29465,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6c07650e-a311-4909-bfa8-3599444037d8</Id>
+          <Id>e4fb9fbb-2048-4592-9be6-1d78a3906e7d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28218,6 +29550,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -28234,7 +29567,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>578921e1-f137-401b-afac-cabd6901c742</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>715e7148-6d5a-4931-b5c2-4f4c7518ac61</Id>
+      <Id>1e9b1f45-cfb7-4204-a4f0-f4330fccfcfa</Id>
       <CommandString>Read the latest health [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -28246,7 +29579,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>31d6994c-2dfc-4142-b3e8-27b3a9d67de3</Id>
+          <Id>6e8502d8-2dfc-4ee6-bcff-ba31771d7bd8</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28284,7 +29617,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f70ed82e-c9c2-42ef-b809-5f818b6c0bbc</Id>
+          <Id>aef5a3e4-3045-4932-af24-7dc04c238931</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28322,7 +29655,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a13e5aaf-6fa6-40e3-a821-47a8a501802f</Id>
+          <Id>49a20028-6be9-4940-9cf9-a0fdf15a29de</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28362,7 +29695,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>409cdd7a-d152-4273-a156-012344b3f908</Id>
+          <Id>ac1f1f9f-896d-44ee-83d2-405451e28304</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28400,7 +29733,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3029370a-97c5-4668-972c-28c3a48aa0db</Id>
+          <Id>5d37d32a-35f3-4f25-a86a-c7a9adb96245</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28485,6 +29818,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -28501,7 +29835,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>8e087f38-59a3-402b-ad4b-6fa9f29e16b4</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>236a259e-9a30-4bb2-bc22-dfc42ad31121</Id>
+      <Id>3d7ddfd4-5805-44f0-afc5-7e4ff0c4a14b</Id>
       <CommandString>Read the latest news</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -28513,7 +29847,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>872cd8f9-a2db-4843-b7e4-64c5f39cf67a</Id>
+          <Id>25c34e95-a009-4454-bacd-1eee23460081</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28551,7 +29885,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9e877032-94d5-47a2-88ec-7162e8fdb160</Id>
+          <Id>fa2139cf-025d-49ad-81ae-fed8a048e7e5</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28636,6 +29970,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -28652,7 +29987,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>757d4c37-4d33-4bef-b573-d73263d7bd09</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>3b62530a-d652-43de-8408-e81ef806e48a</Id>
+      <Id>3c4d4e52-5d0f-4569-bc80-2bd7bef730e2</Id>
       <CommandString>Read the latest security [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -28664,7 +29999,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>af7798e9-f601-41bc-a3da-36fd15b0bfa0</Id>
+          <Id>4f193598-538a-4588-9157-02e71fa9f76a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28702,7 +30037,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>344f8b87-dc12-47cf-b5ad-5b4e088d1f66</Id>
+          <Id>6f6755cc-c374-4855-9861-1434948e147a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28740,7 +30075,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1a661a65-3c2d-4115-9077-4339fc98ae94</Id>
+          <Id>eb23e539-b39b-45f6-90ae-ed919c00b341</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28780,7 +30115,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4d11f458-9817-4fae-a223-813f360b64f9</Id>
+          <Id>a98664bb-5743-4ea5-9e56-d17c85db5f7c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28818,7 +30153,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>50636c3a-f751-41ed-80c0-8897242b7158</Id>
+          <Id>8f45e235-9e74-4592-9a44-43afdfb763ac</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28903,6 +30238,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -28919,7 +30255,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>2b2b514a-204a-4d70-a4d6-63e909de58c5</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>843f96d2-7d7c-4994-bf82-cb5fa9aa70fe</Id>
+      <Id>3a83c48c-71a6-4095-9bde-45a715b38d02</Id>
       <CommandString>Read the latest starport status [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -28931,7 +30267,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>12fe7f6a-5949-495b-9a8d-6ac8a234a3a8</Id>
+          <Id>7671a13d-c528-4cd8-a491-97487a08ab6a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -28969,7 +30305,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>69dbc001-f7a2-4775-b81a-20cc94ca197c</Id>
+          <Id>1f20041a-ae32-418f-946a-0893d1b5dc68</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29007,7 +30343,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>424aeb59-1572-4272-bad4-ea3c64d2a9d9</Id>
+          <Id>4dee3fbb-4fc6-4513-9c1d-fa9455b40115</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29047,7 +30383,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>89e242f1-7cba-47c6-ab19-3e677bb89178</Id>
+          <Id>150c9c05-9625-4ea2-938b-36cd6278b17c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29085,7 +30421,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>358a4a9d-5e9f-49ef-8eae-a9a765454927</Id>
+          <Id>3843c121-fd11-44c5-81b1-7c3a7915ffa2</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29170,6 +30506,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -29186,7 +30523,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>1a19d54e-5a0f-45c7-98e7-64fed2519a69</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>0ab2a42d-cf6d-4296-860e-2cab69f1361d</Id>
+      <Id>f7ba3678-cef2-46a5-b732-1270f0a657ec</Id>
       <CommandString>Read the next news</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -29198,7 +30535,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>95901bf4-dfb4-4b18-ab09-4f08bdf614ec</Id>
+          <Id>7baea31a-0b6e-4dc4-81dd-80b042333517</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29236,7 +30573,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0da4e822-0a35-4399-99d0-d0f10a6da4c6</Id>
+          <Id>249989be-e5eb-4410-bc34-6c0bd170fd34</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29321,6 +30658,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -29337,7 +30675,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>b65a74eb-d695-488d-8ff9-d024a7e99f59</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>e15bfc32-da21-4f54-96ed-f66e2b137001</Id>
+      <Id>73083b1e-5f9d-4fff-a263-71687261da60</Id>
       <CommandString>Read the [next;oldest] community goal [news;]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -29349,7 +30687,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0aacd4e3-66ac-4ab5-bdd3-812abd7e6377</Id>
+          <Id>34f81be7-1456-45c4-b9a6-53cbeea712db</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29387,7 +30725,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9fee39f2-3dd3-4b6f-b20c-d0f44c6ea629</Id>
+          <Id>eb034cf4-9435-4086-ae6d-3083e95c0d62</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29425,7 +30763,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ae3c970b-fb2e-4871-967c-511f0fdd8cd7</Id>
+          <Id>1b8a4f23-f39b-4b11-a355-085c047729eb</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29465,7 +30803,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d9fc346b-ba97-4cd0-bf00-dd12114247ad</Id>
+          <Id>beafd52b-1b6d-44f6-8c0b-16a663ada60a</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29503,7 +30841,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>acf02468-ec95-4311-85bf-c275e208c50b</Id>
+          <Id>cf0fd934-fa44-4e3e-ab65-39ff138df72c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29588,6 +30926,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -29604,7 +30943,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0bf89e7a-174b-451c-aca4-2cc5cdb35a9c</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>56cfb097-320a-4b10-b06c-f32a8fe8fb71</Id>
+      <Id>85d384fb-220c-4d98-ad3b-65d3815c7ad0</Id>
       <CommandString>Read the [next;oldest] conflict [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -29616,7 +30955,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2371be38-9a1c-46a7-a177-09d9aa2a1bbf</Id>
+          <Id>02e85a1e-6aad-4342-8f10-55bffe6d48b4</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29654,7 +30993,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c87ca262-11ba-4326-acec-701582310d81</Id>
+          <Id>73d79ca7-e3e1-4251-9f41-637a8f995064</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29692,7 +31031,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7ac4425e-4948-44f2-ab4e-84b1055b1128</Id>
+          <Id>37db00b9-c1e2-4412-9a10-37359d3f0ec0</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29732,7 +31071,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>994f23a3-0eef-483e-94cf-4c93dd62b827</Id>
+          <Id>2fd39c70-5dc3-462b-abd5-c1bfa2fe77fe</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29770,7 +31109,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>5033c194-cfe0-45ac-8632-38fdc53089aa</Id>
+          <Id>f9df3262-5c82-4345-a440-c6009b219321</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29855,6 +31194,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -29871,7 +31211,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>7d5bc575-ca5a-4dce-bec5-41f5a0dcd3b3</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>b3c8b46b-33b0-425c-9c33-b68bd1bdd599</Id>
+      <Id>3eb086e2-0304-4247-9b39-320399364e45</Id>
       <CommandString>Read the [next;oldest] democracy [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -29883,7 +31223,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2a397a32-bf11-4357-816c-795c08f33a7c</Id>
+          <Id>7a6a7b1f-41de-49d6-b774-8658c532d728</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29921,7 +31261,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>0b731d98-5b39-49bb-ad02-5c4572944365</Id>
+          <Id>a549483b-defe-475a-9e0a-d44e9a56c797</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29959,7 +31299,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2144a4ef-8ce6-405e-b64b-5156255b7ee2</Id>
+          <Id>30b4099d-2c4b-42d6-88cb-7e0244091d8c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -29999,7 +31339,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>454bb230-6d7d-4289-962a-77279e62ab37</Id>
+          <Id>3e76f7e4-f978-4c76-803f-f7d13919376f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30037,7 +31377,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>fb1aa6b7-1326-42bd-bd6c-ff478b273621</Id>
+          <Id>72a98fd2-414d-4953-ad8b-0aebd1eb728b</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30122,6 +31462,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -30138,7 +31479,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>b8a35c3a-11a8-4082-9372-932a581d8df6</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>bb47ae3b-6fc3-4a25-9997-60222798c558</Id>
+      <Id>6852b9b7-0ca4-43d7-87a1-3ffcfe1da201</Id>
       <CommandString>Read the [next;oldest] economy [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -30150,7 +31491,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c8bec5f6-32ce-4e42-be51-35ace6e21942</Id>
+          <Id>f6ba435c-803f-49fe-87a0-031b0f4a8236</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30188,7 +31529,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3782e695-143a-4049-8e93-ca150960d75b</Id>
+          <Id>3be0eba2-b465-47dc-85f3-b8114519b993</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30226,7 +31567,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>329c70c3-432c-48ae-90a5-09601c99780e</Id>
+          <Id>18a99926-6907-4261-a06d-579b4781fa2d</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30266,7 +31607,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cec1f37c-71c6-4cd4-89b4-d09779e4b9ae</Id>
+          <Id>5992c420-d1f6-48f5-92cc-f0ff211b8201</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30304,7 +31645,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1c49524c-9eef-49be-b1a9-5a9bf0b9e8c3</Id>
+          <Id>1f356c6e-e104-4ce5-822d-aebccb89fd45</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30389,6 +31730,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -30405,7 +31747,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>02073776-de4b-49d2-9efe-d56d4054a33c</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>7d1f7036-518c-47e5-9d8d-5d0e2fcc8f4d</Id>
+      <Id>11a6f0d1-802c-4052-9604-96cd30161428</Id>
       <CommandString>Read the [next;oldest] expansion [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -30417,7 +31759,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c379f3bc-55da-4ead-ad68-57fe82e4f5b8</Id>
+          <Id>4a9218bb-134a-4fe5-9243-dbb00a53171e</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30455,7 +31797,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>89c12577-094d-4815-8a30-d626bc3aac58</Id>
+          <Id>31995cc4-35f0-43a8-991d-98310c138743</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30493,7 +31835,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>de723133-b2f5-4529-9b9c-11dfe9ac4904</Id>
+          <Id>646fb447-7c96-4720-8f44-9d47f0b48a7e</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30533,7 +31875,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b087d927-2263-4068-98bb-1a98650068c1</Id>
+          <Id>8cc35044-5ac3-4e13-862c-1e947a8056bf</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30571,7 +31913,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f2a624a5-f095-48ed-a4ce-4edf2722c248</Id>
+          <Id>e8923d2e-9865-4d7e-a446-6d6c644b67ca</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30656,6 +31998,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -30672,7 +32015,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>1c414bee-e1b7-4b91-bffd-162f27e9ea12</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>0b81d17d-de7d-45aa-9eeb-fcb8499ee9d6</Id>
+      <Id>e595f6e3-22c4-4118-b46e-b66acbb11d22</Id>
       <CommandString>Read the [next;oldest] health [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -30684,7 +32027,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ffed6eb5-c3a9-4b5b-8255-c922463d64f0</Id>
+          <Id>1928d365-03f4-4bdc-850a-6f869bf4059d</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30722,7 +32065,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>d0d134bb-d0c4-4904-a68a-a67b7ce16012</Id>
+          <Id>6b1d721e-06dd-43a0-ac11-1c0e3def23d0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30760,7 +32103,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>86c6b02e-39c7-4680-9821-ab562094213f</Id>
+          <Id>a8e01e55-aea3-41b9-8e8b-201e458b4b88</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30800,7 +32143,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e943262e-3829-4a0f-a037-e95b5ad08c4c</Id>
+          <Id>c8fffeb8-66c1-46c8-91c3-0312d8f14439</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30838,7 +32181,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>13b999c0-a10b-428b-b4ef-381f3c4bd87d</Id>
+          <Id>d579b4ba-a201-441d-bd09-a0f49858583f</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30923,6 +32266,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -30939,7 +32283,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>50caf5b9-1af7-49a3-a459-ecad0f0af5c7</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>af350306-d6b2-4a33-8cf4-4e40ebf066ee</Id>
+      <Id>c53475a7-fa20-4f69-81e2-18d110a4f67c</Id>
       <CommandString>Read the [next;oldest] security [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -30951,7 +32295,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>51b47fcd-bb9d-4869-bda8-902c9f4dbe4f</Id>
+          <Id>d9bcd638-1c38-4ea8-bdbc-d56d5d9fa73f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -30989,7 +32333,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>638b8e60-894a-48b4-8c4e-8d55cae63f86</Id>
+          <Id>eedd0ec1-266b-4d2a-b3a4-27882de1451f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31027,7 +32371,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>378cb07a-88c2-4183-b8dd-87f4e00bdbb0</Id>
+          <Id>789928ef-cfb8-40bc-8b90-bc7c33557452</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31067,7 +32411,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>857b3179-c155-4ed5-a327-4ae3b0d4289e</Id>
+          <Id>4263a94a-7feb-4035-a3f8-c5fdb21a63cc</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31105,7 +32449,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>32538ec4-4ad4-4074-b919-513a1536c585</Id>
+          <Id>fe66bbac-d824-45f2-ac27-5980d65b20e3</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31190,6 +32534,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -31206,7 +32551,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>084207c7-3bea-4116-8342-a4bdc7c928d1</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>ab41df48-e39d-4a68-99f8-f6fecd1fa73e</Id>
+      <Id>4a7989e4-c19f-4e12-bebb-1d198b57c417</Id>
       <CommandString>Read the [next;oldest] starport status [news;report]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -31218,7 +32563,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>675e5fa2-4ea2-4b1f-b47b-bb9796c3c92a</Id>
+          <Id>7814923e-5d6c-4aec-b540-622c8d849b44</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31256,7 +32601,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>82db2e57-6eff-45d2-a9d9-64a36d2c45fe</Id>
+          <Id>deec08ba-8fc4-46fd-beb8-26af70d0259b</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31294,7 +32639,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a4003f16-6e99-4129-944a-042c83ec3f12</Id>
+          <Id>19430feb-c326-4462-a905-04ff3cb7cca9</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31334,7 +32679,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ac273c03-8b0f-4c1a-a171-aedadaeeb4a9</Id>
+          <Id>587675a9-8e17-4bc7-8771-9ee37826aaa6</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31372,7 +32717,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>23f29fa1-4c40-4cff-b79d-e0226a9b5162</Id>
+          <Id>9e74215f-8d83-465e-893c-d8d858d68ba2</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31457,6 +32802,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -31473,7 +32819,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>33d26373-391d-4521-b868-f99397be8995</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>03481bb8-8bfd-4d85-9e70-64d31ab1545b</Id>
+      <Id>61ce8115-2900-4874-938e-d6ae2c130239</Id>
       <CommandString>Remind me of [the;that] landing pad;Which landing pad?;Which landing pad [is;was] it?;[please;] repeat [the;] landing pad;Where's that landing pad</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -31485,7 +32831,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>cd0eaafd-85c2-4ffa-93bf-ee97be32f431</Id>
+          <Id>e9e7b9d1-fa1f-4b3e-ac97-d0b24a4bf4b7</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31523,7 +32869,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e9890e5c-b163-4da4-b819-d41351902014</Id>
+          <Id>f4787f3b-8bb4-4627-a259-c339e00df6c4</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31608,6 +32954,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -31624,7 +32971,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>127f5da4-6f65-41e6-aeaf-5281dd79e804</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>b2d70136-dcb2-434e-a782-390d1feea738</Id>
+      <Id>ac5d40f4-f333-485d-997b-3c4e5267ce18</Id>
       <CommandString>[Remove;Clear] [note;comment] [on;about;for] this system</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -31636,7 +32983,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>aaab7adb-244a-4100-8584-d9b60e46f928</Id>
+          <Id>c8a87ebf-7bee-4af6-8118-7cda4e4d06ff</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31671,7 +33018,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4b57976a-2f6d-40d6-a97b-b5dbda37eebd</Id>
+          <Id>9f485ed3-e36b-4ce4-bcfa-6d9a048cb304</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31709,7 +33056,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>673fec42-81ac-4720-8e8a-4468e7cddb40</Id>
+          <Id>ebe1c86d-167a-455e-8985-591b71efc20a</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31749,7 +33096,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>863ed8a3-d510-4cd7-87ec-b6914c5a944e</Id>
+          <Id>0f36026b-5bda-4172-a15f-8fd63d22d0b1</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31781,7 +33128,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>bc4b4906-51af-4984-87e5-8743a528dea5</Id>
+          <Id>fd8bc1b4-ba89-429a-808b-f425c1829d0c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31819,7 +33166,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6e2875e1-df58-40b5-8ce0-8c118a017746</Id>
+          <Id>63cea9c8-9c6b-46db-bfa5-51de42c1dd1f</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31859,7 +33206,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2945af57-1c52-415e-b878-a616bb433942</Id>
+          <Id>f69bf092-3207-4e6d-b7d3-0a56b54ef1a7</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31897,7 +33244,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ac105dbb-89f2-4406-ba15-71ae5141eaef</Id>
+          <Id>0e30e831-5f8d-48a5-a5be-333a3372fabe</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -31982,6 +33329,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -31998,7 +33346,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>fba4927c-b8bb-4738-aff6-f505ce3e12c4</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>937322e3-d092-4b72-a402-51e1efea1255</Id>
+      <Id>754d6e6b-4a89-4baf-90be-dee3382b8b16</Id>
       <CommandString>Ship [discount;discounts] report;Report on ship discounts</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32010,7 +33358,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3e6fa59b-093c-4a44-8a64-89adfbfd0711</Id>
+          <Id>0c156cce-6eff-4298-a3af-0e6fd6238e8d</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32048,7 +33396,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>084786c6-45de-4808-917c-9f92576ee47a</Id>
+          <Id>9672f1ec-d54b-490d-8313-8e84051a4535</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32133,6 +33481,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32149,7 +33498,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>dec18419-74e6-45f7-aedf-9af58857d5be</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>d201db57-ea86-49a8-8103-66444284b24c</Id>
+      <Id>a9a6af88-d837-4852-a6c7-74759fa0fbac</Id>
       <CommandString>Shut up;That's enough</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32161,7 +33510,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b7cdef66-2029-46f2-a5e5-537dd90be01a</Id>
+          <Id>7dd597f9-dd8f-4f24-b05a-42e7caad8419</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32237,7 +33586,7 @@
       <MouseUpOnly>false</MouseUpOnly>
       <MousePassThru>true</MousePassThru>
       <joystickExclusive>false</joystickExclusive>
-      <lastEditedAction>00000000-0000-0000-0000-000000000000</lastEditedAction>
+      <lastEditedAction>b1a61c43-92c3-414f-bcab-60f35125f9db</lastEditedAction>
       <UseProfileProcessOverride>false</UseProfileProcessOverride>
       <ProfileProcessOverrideActiveWindow>false</ProfileProcessOverrideActiveWindow>
       <RepeatIfKeysDown>false</RepeatIfKeysDown>
@@ -32246,6 +33595,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32262,7 +33612,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>7bce5e11-22bb-413a-b270-29a381c1860c</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>598950f6-da32-4f9f-8ddc-4d7666f6bbd3</Id>
+      <Id>5198be0a-3c4e-4d06-b23c-1a6827659510</Id>
       <CommandString>System report</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32274,7 +33624,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f019ce84-bc14-4ea0-b9a4-85e05d753fd7</Id>
+          <Id>bb91e73a-4159-428c-8e59-425c4b18598c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32312,7 +33662,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ed2d891d-09c2-4c4c-b5c4-b87621b0e36f</Id>
+          <Id>58ac224f-83cf-4b23-b4ae-79682614b508</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32397,6 +33747,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32413,7 +33764,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0d00185d-9403-4346-b1db-2493c1944847</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>b3d3f7bf-5f31-4530-8102-4c1f2afa2ec8</Id>
+      <Id>0661fa76-559d-422b-b0c7-cabd63d8b069</Id>
       <CommandString>Tell me [more;] about [that;the] [planet;body]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32425,7 +33776,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e14a9dc9-a681-4878-b6af-60d27c82ca57</Id>
+          <Id>9517020f-73ca-4f7a-be3c-70184d4568f5</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32463,7 +33814,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>77d2994d-a8e9-42bb-bed1-b392505aa69a</Id>
+          <Id>793de500-b2bc-4e6c-8232-ca6121570ad4</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32548,6 +33899,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32564,7 +33916,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>01e2fab2-c491-4cb2-8192-5bab5b2f3b5a</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>197df9ba-7bdb-4efb-9eea-63b7d904333d</Id>
+      <Id>cecb0016-a8c5-4d07-a17c-ec4cbc284c96</Id>
       <CommandString>Tell me [more;] about [that;the] star</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32576,7 +33928,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7d081910-cbac-4929-b58e-f7d5cc5381af</Id>
+          <Id>73e7a457-affd-4abb-9cfa-1974f5108a58</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32614,7 +33966,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1c306983-aaf2-4834-a141-898b0286b5fa</Id>
+          <Id>3e10160d-8625-4b78-9144-74d5cd4112e9</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32699,6 +34051,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32715,7 +34068,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>42f9a016-e18b-436a-bddc-457dbdcf3c69</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>0b4e3c70-a8f9-4fe9-becf-b980e5ca7305</Id>
+      <Id>be3cf137-6b67-494d-928d-869f4c47a696</Id>
       <CommandString>Tell me [more;] about [that;the] system</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32727,7 +34080,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8cf95907-5623-4386-9068-62549fb1c393</Id>
+          <Id>007ec7b5-f75f-40b2-904b-a480564c6a73</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32765,7 +34118,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>deb003d4-2287-4662-bf20-d0923574361e</Id>
+          <Id>3f127628-2452-4c70-98ed-bc9aa72db326</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32850,6 +34203,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -32866,7 +34220,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0e777c0a-80f2-4cfe-aaa9-e5a1a5fb16ba</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>36a555c8-3403-4d2a-930d-07d33fc55cdd</Id>
+      <Id>7a4963c6-ecda-4a6a-a669-e3d5ca1845db</Id>
       <CommandString>Tell me [more;] about this system</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -32878,7 +34232,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>258e2d42-1809-439a-b87d-06ce1c12b7ea</Id>
+          <Id>8db17734-ea10-4439-9379-750dfe223aaa</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32916,7 +34270,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a22529ac-478c-4ac0-9737-bf5ee73737c7</Id>
+          <Id>cea1a9cb-abd2-48d6-b253-8e5f2c1d15d8</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32954,7 +34308,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7253b090-1667-4272-a608-00ea2e5d64c0</Id>
+          <Id>c2472186-41c5-43c5-9195-4fa3bedbeacb</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -32994,7 +34348,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4484c8e3-6790-4798-a289-73c3087299ba</Id>
+          <Id>d81d54b8-c175-4198-b5cc-b879c6c714ca</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33032,7 +34386,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8ba88a8e-518e-4178-9191-fe6960e32601</Id>
+          <Id>1a677645-2556-425e-8760-2104fe7f276e</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33108,7 +34462,7 @@
       <MouseUpOnly>false</MouseUpOnly>
       <MousePassThru>true</MousePassThru>
       <joystickExclusive>false</joystickExclusive>
-      <lastEditedAction>e7d4dc7d-282b-4f3b-bf68-9bf016f633c5</lastEditedAction>
+      <lastEditedAction>00000000-0000-0000-0000-000000000000</lastEditedAction>
       <UseProfileProcessOverride>false</UseProfileProcessOverride>
       <ProfileProcessOverrideActiveWindow>false</ProfileProcessOverrideActiveWindow>
       <RepeatIfKeysDown>false</RepeatIfKeysDown>
@@ -33117,6 +34471,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -33133,7 +34488,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>223ab24d-cddd-48e8-a32b-70271a7e8ce9</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>9b899cb6-b9e7-40b0-ab16-e9e1a870bb56</Id>
+      <Id>93be6612-e36c-4a80-9080-1ce6d3a94d85</Id>
       <CommandString>Tell me [more;about it]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -33145,7 +34500,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>a86f043e-a9a3-4462-8694-380c3d24d723</Id>
+          <Id>f5ca5b41-ec0f-4acf-ae15-f4c9bb7d32cb</Id>
           <ActionType>ConditionStart</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33180,12 +34535,12 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>81743c65-27b8-4033-ad14-664d04b90fe6</Id>
+          <Id>13367ff9-61dd-4854-b67a-51958a4d4e28</Id>
           <ActionType>ExecuteCommand</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
           <KeyCodes />
-          <Context>b3d3f7bf-5f31-4530-8102-4c1f2afa2ec8</Context>
+          <Context>0661fa76-559d-422b-b0c7-cabd63d8b069</Context>
           <X>1</X>
           <Y>0</Y>
           <Z>0</Z>
@@ -33213,7 +34568,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>31bb6ac7-e414-42a6-a8a9-0d97c48b045b</Id>
+          <Id>46e75321-4b01-425c-8924-6a7bd7eb701d</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33248,12 +34603,12 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ec498020-40bb-4caa-b9f3-a12d30b5775d</Id>
+          <Id>82400479-9bef-4c9f-8955-9381ca43c763</Id>
           <ActionType>ExecuteCommand</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
           <KeyCodes />
-          <Context>197df9ba-7bdb-4efb-9eea-63b7d904333d</Context>
+          <Context>cecb0016-a8c5-4d07-a17c-ec4cbc284c96</Context>
           <X>1</X>
           <Y>0</Y>
           <Z>0</Z>
@@ -33281,7 +34636,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>205f5659-2e36-4470-a957-b5af2f47f37a</Id>
+          <Id>09e8b661-e274-4d21-b092-5fe568d0c8e6</Id>
           <ActionType>ConditionElseIf</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33316,12 +34671,12 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f042782e-0215-4eb2-9248-46a1099e2f85</Id>
+          <Id>7faf48e6-473b-468c-b285-f7ea250352b5</Id>
           <ActionType>ExecuteCommand</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
           <KeyCodes />
-          <Context>0b4e3c70-a8f9-4fe9-becf-b980e5ca7305</Context>
+          <Context>be3cf137-6b67-494d-928d-869f4c47a696</Context>
           <X>1</X>
           <Y>0</Y>
           <Z>0</Z>
@@ -33349,7 +34704,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b5fc0229-3d3b-4e47-8e73-73a6d89a20d7</Id>
+          <Id>70bf3a85-b5f1-46be-9b4d-5d2d6a06682b</Id>
           <ActionType>ConditionEnd</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33381,7 +34736,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>8960bc53-70d8-4ada-bc58-17b3d0f1caf5</Id>
+          <Id>16c306b3-a515-4d08-bdd8-3bdeb1558d2c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33419,7 +34774,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>f5027675-c05a-410d-93ea-86c5bb6c8973</Id>
+          <Id>4d5c40b7-3a59-46ca-9e26-312840882dbb</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33504,6 +34859,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -33520,7 +34876,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>2391477c-5358-4163-8a07-6129103a975c</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>68c2d0f0-fd5b-4feb-9b8e-4ad74b195325</Id>
+      <Id>c947a7de-2d9c-4285-b829-ab84fbed8c3d</Id>
       <CommandString>What do I need for [system focused power distributor grade 1;system focused power distributor grade 3;system focused power distributor grade 2;shielded kill warrant scanner grade 1;shielded kill warrant scanner grade 3;shielded kill warrant scanner grade 2;shielded kill warrant scanner grade 5;shielded kill warrant scanner grade 4;ammo capacity point defence grade 3;specialised shield cell bank grade 1;specialised shield cell bank grade 3;specialised shield cell bank grade 2;fast scan detailed surface scanner grade 1;fast scan detailed surface scanner grade 3;fast scan detailed surface scanner grade 2;fast scan detailed surface scanner grade 5;fast scan detailed surface scanner grade 4;long range detailed surface scanner grade 1;long range detailed surface scanner grade 3;long range detailed surface scanner grade 2;long range detailed surface scanner grade 5;long range detailed surface scanner grade 4;lightweight life support grade 1;lightweight life support grade 3;lightweight life support grade 2;lightweight life support grade 4;shielded heat sink launcher grade 1;shielded heat sink launcher grade 3;shielded heat sink launcher grade 2;shielded heat sink launcher grade 5;shielded heat sink launcher grade 4;blast resistant hull reinforcement grade 1;blast resistant hull reinforcement grade 3;blast resistant hull reinforcement grade 2;blast resistant hull reinforcement grade 5;blast resistant hull reinforcement grade 4;rapid charge shield cell bank grade 1;rapid charge shield cell bank grade 3;rapid charge shield cell bank grade 2;heavy duty hull reinforcement grade 1;heavy duty hull reinforcement grade 3;heavy duty hull reinforcement grade 2;heavy duty hull reinforcement grade 5;heavy duty hull reinforcement grade 4;wide angle kill warrant scanner grade 1;wide angle kill warrant scanner grade 3;wide angle kill warrant scanner grade 2;wide angle kill warrant scanner grade 5;wide angle kill warrant scanner grade 4;resistance augmented shield booster grade 1;resistance augmented shield booster grade 3;resistance augmented shield booster grade 2;resistance augmented shield booster grade 5;resistance augmented shield booster grade 4;blast resistant shield booster grade 1;blast resistant shield booster grade 3;blast resistant shield booster grade 2;blast resistant shield booster grade 5;blast resistant shield booster grade 4;lightweight heat sink launcher grade 1;lightweight heat sink launcher grade 3;lightweight heat sink launcher grade 2;lightweight heat sink launcher grade 5;lightweight heat sink launcher grade 4;lightweight sensors grade 1;lightweight sensors grade 3;lightweight sensors grade 2;lightweight sensors grade 5;lightweight sensors grade 4;lightweight frame shift wake scanner grade 1;lightweight frame shift wake scanner grade 3;lightweight frame shift wake scanner grade 2;lightweight frame shift wake scanner grade 5;lightweight frame shift wake scanner grade 4;shielded refinery grade 1;shielded refinery grade 3;shielded refinery grade 2;shielded refinery grade 4;armoured power distributor grade 1;armoured power distributor grade 3;armoured power distributor grade 2;armoured power distributor grade 5;armoured power distributor grade 4;kinetic resistant hull reinforcement grade 1;kinetic resistant hull reinforcement grade 3;kinetic resistant hull reinforcement grade 2;kinetic resistant hull reinforcement grade 5;kinetic resistant hull reinforcement grade 4;long range frame shift drive interdictor grade 1;long range frame shift drive interdictor grade 3;long range frame shift drive interdictor grade 2;reinforced shield generator grade 1;reinforced shield generator grade 3;reinforced shield generator grade 2;reinforced shield generator grade 5;reinforced shield generator grade 4;ammo capacity chaff launcher grade 3;faster boot sequence frame shift drive grade 1;faster boot sequence frame shift drive grade 3;faster boot sequence frame shift drive grade 2;faster boot sequence frame shift drive grade 5;faster boot sequence frame shift drive grade 4;reinforced frame shift wake scanner grade 1;reinforced frame shift wake scanner grade 3;reinforced frame shift wake scanner grade 2;reinforced frame shift wake scanner grade 5;reinforced frame shift wake scanner grade 4;shielded point defence grade 1;shielded point defence grade 3;shielded point defence grade 2;shielded point defence grade 5;shielded point defence grade 4;lightweight point defence grade 1;lightweight point defence grade 3;lightweight point defence grade 2;lightweight point defence grade 5;lightweight point defence grade 4;reinforced thrusters grade 1;reinforced thrusters grade 3;reinforced thrusters grade 2;reinforced thrusters grade 5;reinforced thrusters grade 4;ammo capacity heat sink launcher grade 3;reinforced prospector limpet controller grade 1;reinforced prospector limpet controller grade 3;reinforced prospector limpet controller grade 2;reinforced prospector limpet controller grade 5;reinforced prospector limpet controller grade 4;fast scan kill warrant scanner grade 1;fast scan kill warrant scanner grade 3;fast scan kill warrant scanner grade 2;fast scan kill warrant scanner grade 5;fast scan kill warrant scanner grade 4;reinforced kill warrant scanner grade 1;reinforced kill warrant scanner grade 3;reinforced kill warrant scanner grade 2;reinforced kill warrant scanner grade 5;reinforced kill warrant scanner grade 4;lightweight bulkheads grade 1;lightweight bulkheads grade 3;lightweight bulkheads grade 2;lightweight bulkheads grade 5;lightweight bulkheads grade 4;long range weapon grade 1;long range weapon grade 3;long range weapon grade 2;long range weapon grade 5;long range weapon grade 4;dirty thrusters grade 1;dirty thrusters grade 3;dirty thrusters grade 2;dirty thrusters grade 5;dirty thrusters grade 4;shielded life support grade 1;shielded life support grade 3;shielded life support grade 2;shielded life support grade 4;shielded frame shift drive grade 1;shielded frame shift drive grade 3;shielded frame shift drive grade 2;shielded frame shift drive grade 5;shielded frame shift drive grade 4;reinforced electronic counter measures grade 1;reinforced electronic counter measures grade 3;reinforced electronic counter measures grade 2;reinforced electronic counter measures grade 5;reinforced electronic counter measures grade 4;lightweight kill warrant scanner grade 1;lightweight kill warrant scanner grade 3;lightweight kill warrant scanner grade 2;lightweight kill warrant scanner grade 5;lightweight kill warrant scanner grade 4;wide angle detailed surface scanner grade 1;wide angle detailed surface scanner grade 3;wide angle detailed surface scanner grade 2;wide angle detailed surface scanner grade 5;wide angle detailed surface scanner grade 4;reinforced fuel transfer limpet controller grade 1;reinforced fuel transfer limpet controller grade 3;reinforced fuel transfer limpet controller grade 2;reinforced fuel transfer limpet controller grade 5;reinforced fuel transfer limpet controller grade 4;reinforced point defence grade 1;reinforced point defence grade 3;reinforced point defence grade 2;reinforced point defence grade 5;reinforced point defence grade 4;long range cargo scanner grade 1;long range cargo scanner grade 3;long range cargo scanner grade 2;long range cargo scanner grade 5;long range cargo scanner grade 4;kinetic resistant shield generator grade 1;kinetic resistant shield generator grade 3;kinetic resistant shield generator grade 2;kinetic resistant shield generator grade 5;kinetic resistant shield generator grade 4;shielded auto field mainentance unit grade 1;shielded auto field mainentance unit grade 3;shielded auto field mainentance unit grade 2;shielded auto field mainentance unit grade 4;thermal resistant hull reinforcement grade 1;thermal resistant hull reinforcement grade 3;thermal resistant hull reinforcement grade 2;thermal resistant hull reinforcement grade 5;thermal resistant hull reinforcement grade 4;reinforced heat sink launcher grade 1;reinforced heat sink launcher grade 3;reinforced heat sink launcher grade 2;reinforced heat sink launcher grade 5;reinforced heat sink launcher grade 4;double shot weapon grade 1;double shot weapon grade 3;double shot weapon grade 2;double shot weapon grade 5;double shot weapon grade 4;engine focused power distributor grade 1;engine focused power distributor grade 3;engine focused power distributor grade 2;shielded power distributor grade 1;shielded power distributor grade 3;shielded power distributor grade 2;shielded power distributor grade 5;shielded power distributor grade 4;long range kill warrant scanner grade 1;long range kill warrant scanner grade 3;long range kill warrant scanner grade 2;long range kill warrant scanner grade 5;long range kill warrant scanner grade 4;reinforced cargo scanner grade 1;reinforced cargo scanner grade 3;reinforced cargo scanner grade 2;reinforced cargo scanner grade 5;reinforced cargo scanner grade 4;shielded prospector limpet controller grade 1;shielded prospector limpet controller grade 3;shielded prospector limpet controller grade 2;shielded prospector limpet controller grade 5;shielded prospector limpet controller grade 4;wide angle wake scanner grade 1;wide angle wake scanner grade 3;wide angle wake scanner grade 2;wide angle wake scanner grade 5;wide angle wake scanner grade 4;wide angle sensors grade 1;wide angle sensors grade 3;wide angle sensors grade 2;wide angle sensors grade 5;wide angle sensors grade 4;clean thrusters grade 1;clean thrusters grade 3;clean thrusters grade 2;clean thrusters grade 5;clean thrusters grade 4;lightweight prospector limpet controller grade 1;lightweight prospector limpet controller grade 3;lightweight prospector limpet controller grade 2;lightweight prospector limpet controller grade 5;lightweight prospector limpet controller grade 4;kinetic resistant bulkheads grade 1;kinetic resistant bulkheads grade 3;kinetic resistant bulkheads grade 2;kinetic resistant bulkheads grade 5;kinetic resistant bulkheads grade 4;blast resistant bulkheads grade 1;blast resistant bulkheads grade 3;blast resistant bulkheads grade 2;blast resistant bulkheads grade 5;blast resistant bulkheads grade 4;lightweight hull reinforcement grade 1;lightweight hull reinforcement grade 3;lightweight hull reinforcement grade 2;lightweight hull reinforcement grade 5;lightweight hull reinforcement grade 4;weapon focused power distributor grade 1;weapon focused power distributor grade 3;weapon focused power distributor grade 2;low emissions power distributor grade 1;low emissions power distributor grade 3;low emissions power distributor grade 2;focused weapon grade 1;focused weapon grade 3;focused weapon grade 2;focused weapon grade 5;focused weapon grade 4;sturdy weapon grade 1;sturdy weapon grade 3;sturdy weapon grade 2;sturdy weapon grade 5;sturdy weapon grade 4;high capacity weapon grade 1;high capacity weapon grade 3;high capacity weapon grade 2;high capacity weapon grade 5;high capacity weapon grade 4;lightweight electronic counter measures grade 1;lightweight electronic counter measures grade 3;lightweight electronic counter measures grade 2;lightweight electronic counter measures grade 5;lightweight electronic counter measures grade 4;shielded electronic counter measures grade 1;shielded electronic counter measures grade 3;shielded electronic counter measures grade 2;shielded electronic counter measures grade 5;shielded electronic counter measures grade 4;shielded hatch breaker limpet controller grade 1;shielded hatch breaker limpet controller grade 3;shielded hatch breaker limpet controller grade 2;shielded hatch breaker limpet controller grade 5;shielded hatch breaker limpet controller grade 4;lightweight cargo scanner grade 1;lightweight cargo scanner grade 3;lightweight cargo scanner grade 2;lightweight cargo scanner grade 5;lightweight cargo scanner grade 4;overcharged weapon grade 1;overcharged weapon grade 3;overcharged weapon grade 2;overcharged weapon grade 5;overcharged weapon grade 4;lightweight collector limpet controller grade 1;lightweight collector limpet controller grade 3;lightweight collector limpet controller grade 2;lightweight collector limpet controller grade 5;lightweight collector limpet controller grade 4;lightweight weapon grade 1;lightweight weapon grade 3;lightweight weapon grade 2;lightweight weapon grade 5;lightweight weapon grade 4;shielded chaff launcher grade 1;shielded chaff launcher grade 3;shielded chaff launcher grade 2;shielded chaff launcher grade 5;shielded chaff launcher grade 4;lightweight chaff launcher grade 1;lightweight chaff launcher grade 3;lightweight chaff launcher grade 2;lightweight chaff launcher grade 5;lightweight chaff launcher grade 4;high charge capacity power distributor grade 1;high charge capacity power distributor grade 3;high charge capacity power distributor grade 2;high charge capacity power distributor grade 5;high charge capacity power distributor grade 4;rapid fire weapon grade 1;rapid fire weapon grade 3;rapid fire weapon grade 2;rapid fire weapon grade 5;rapid fire weapon grade 4;shielded cargo scanner grade 1;shielded cargo scanner grade 3;shielded cargo scanner grade 2;shielded cargo scanner grade 5;shielded cargo scanner grade 4;thermal resistant bulkheads grade 1;thermal resistant bulkheads grade 3;thermal resistant bulkheads grade 2;thermal resistant bulkheads grade 5;thermal resistant bulkheads grade 4;reinforced hatch breaker limpet controller grade 1;reinforced hatch breaker limpet controller grade 3;reinforced hatch breaker limpet controller grade 2;reinforced hatch breaker limpet controller grade 5;reinforced hatch breaker limpet controller grade 4;fast scan cargo scanner grade 1;fast scan cargo scanner grade 3;fast scan cargo scanner grade 2;fast scan cargo scanner grade 5;fast scan cargo scanner grade 4;heavy duty bulkheads grade 1;heavy duty bulkheads grade 3;heavy duty bulkheads grade 2;heavy duty bulkheads grade 5;heavy duty bulkheads grade 4;heavy duty shield booster grade 1;heavy duty shield booster grade 3;heavy duty shield booster grade 2;heavy duty shield booster grade 5;heavy duty shield booster grade 4;reinforced collector limpet controller grade 1;reinforced collector limpet controller grade 3;reinforced collector limpet controller grade 2;reinforced collector limpet controller grade 5;reinforced collector limpet controller grade 4;charge enhanced power distributor grade 1;charge enhanced power distributor grade 3;charge enhanced power distributor grade 2;charge enhanced power distributor grade 5;charge enhanced power distributor grade 4;reinforced chaff launcher grade 1;reinforced chaff launcher grade 3;reinforced chaff launcher grade 2;reinforced chaff launcher grade 5;reinforced chaff launcher grade 4;long range wake scanner grade 1;long range wake scanner grade 3;long range wake scanner grade 2;long range wake scanner grade 5;long range wake scanner grade 4;expanded capture arc frame shift drive interdictor grade 1;expanded capture arc frame shift drive interdictor grade 3;expanded capture arc frame shift drive interdictor grade 2;expanded capture arc frame shift drive interdictor grade 4;shielded collector limpet controller grade 1;shielded collector limpet controller grade 3;shielded collector limpet controller grade 2;shielded collector limpet controller grade 5;shielded collector limpet controller grade 4;increased range frame shift drive grade 1;increased range frame shift drive grade 3;increased range frame shift drive grade 2;increased range frame shift drive grade 5;increased range frame shift drive grade 4;kinetic resistant shield booster grade 1;kinetic resistant shield booster grade 3;kinetic resistant shield booster grade 2;kinetic resistant shield booster grade 5;kinetic resistant shield booster grade 4;lightweight fuel transfer limpet controller grade 1;lightweight fuel transfer limpet controller grade 3;lightweight fuel transfer limpet controller grade 2;lightweight fuel transfer limpet controller grade 5;lightweight fuel transfer limpet controller grade 4;wide angle cargo scanner grade 1;wide angle cargo scanner grade 3;wide angle cargo scanner grade 2;wide angle cargo scanner grade 5;wide angle cargo scanner grade 4;thermal resistant shield generator grade 1;thermal resistant shield generator grade 3;thermal resistant shield generator grade 2;thermal resistant shield generator grade 5;thermal resistant shield generator grade 4;shielded fuel transfer limpet controller grade 1;shielded fuel transfer limpet controller grade 3;shielded fuel transfer limpet controller grade 2;shielded fuel transfer limpet controller grade 5;shielded fuel transfer limpet controller grade 4;long range sensors grade 1;long range sensors grade 3;long range sensors grade 2;long range sensors grade 5;long range sensors grade 4;short range weapon grade 1;short range weapon grade 3;short range weapon grade 2;short range weapon grade 5;short range weapon grade 4;shielded frame shift wake scanner grade 1;shielded frame shift wake scanner grade 3;shielded frame shift wake scanner grade 2;shielded frame shift wake scanner grade 5;shielded frame shift wake scanner grade 4;fast scan wake scanner grade 1;fast scan wake scanner grade 3;fast scan wake scanner grade 2;fast scan wake scanner grade 5;fast scan wake scanner grade 4;overcharged power distributor grade 1;overcharged power distributor grade 3;overcharged power distributor grade 2;overcharged power distributor grade 5;overcharged power distributor grade 4;lightweight hatch breaker limpet controller grade 1;lightweight hatch breaker limpet controller grade 3;lightweight hatch breaker limpet controller grade 2;lightweight hatch breaker limpet controller grade 5;lightweight hatch breaker limpet controller grade 4;thermal resistant shield booster grade 1;thermal resistant shield booster grade 3;thermal resistant shield booster grade 2;thermal resistant shield booster grade 5;thermal resistant shield booster grade 4;efficient weapon grade 1;efficient weapon grade 3;efficient weapon grade 2;efficient weapon grade 5;efficient weapon grade 4;shielded fuel scoop grade 1;shielded fuel scoop grade 3;shielded fuel scoop grade 2;shielded fuel scoop grade 4;enhanced low power shield generator grade 1;enhanced low power shield generator grade 3;enhanced low power shield generator grade 2;enhanced low power shield generator grade 5;enhanced low power shield generator grade 4;reinforced life support grade 1;reinforced life support grade 3;reinforced life support grade 2;reinforced life support grade 4
 ]</CommandString>
       <ActionSequence>
@@ -33533,7 +34889,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2836392c-7ca5-4ae6-9237-22cbeb7a2d20</Id>
+          <Id>422ace1a-11db-47a0-b164-4da8d5b75424</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33571,7 +34927,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>6593706b-1558-4a91-a8c1-e142b0d1d57a</Id>
+          <Id>d1347deb-e2e5-49f5-b5c4-214b5d351d3c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33609,7 +34965,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>87e4226c-6856-4fe9-a7c2-cbe741f8aa94</Id>
+          <Id>15ec956a-7fd5-44e8-b36a-8a9c99c881c6</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33647,7 +35003,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7598ffd6-4698-4941-bc90-4b441963fb7f</Id>
+          <Id>89ab7886-6058-4e35-b3ad-d144ccb94ff5</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33687,7 +35043,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9b08e7f4-064a-4006-98e2-c32d99025fbe</Id>
+          <Id>b82054c1-74e7-4d71-8958-636c6c0b3299</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33725,7 +35081,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>61355757-c306-4b11-a077-2a2acc929994</Id>
+          <Id>8677398a-552f-4a2c-b5b6-963995a8bcf6</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33810,6 +35166,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -33826,7 +35183,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>1612022e-0a73-45b8-a8bc-93a0d537ef15</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>cb15b8e0-1843-4f73-8d03-963c04769dff</Id>
+      <Id>a3d01e3d-456a-480c-8803-5495588c7d9e</Id>
       <CommandString>What is the state of that system?;What state is that system in?</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -33838,7 +35195,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4c0046a6-2a74-457f-b251-3f5eaa706619</Id>
+          <Id>d1c8246f-8f78-4bd9-a733-9b143a604c72</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33876,7 +35233,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>ba316454-14bc-4991-9530-175f24ab37e8</Id>
+          <Id>408d9823-c9b2-48d0-aebb-a6d7075a011c</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -33961,6 +35318,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -33977,7 +35335,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>8cde9f23-0988-4672-b72f-f74a035209c1</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>3984cb6d-f3ae-4f91-8663-1c710665f20e</Id>
+      <Id>c4392cc3-b8ea-45bc-b6ce-8de39396de0d</Id>
       <CommandString>What use is [aberrant shield pattern analysis;abnormal compact emission data;adaptive encryptors capture;anomalous bulk scan data;anomalous fsd telemetry;antimony;arsenic;atypical disrupted wake echoes;atypical encryption archives;basic conductors;biotech conductors;cadmiun;carbon;chemical distillery;chemical manipulators;chemical processors;chemical storage units;chromium;classified scan databanks;classified scan fragment;compact composites;compound shielding;conductive ceramics;conductive components;conductive polymers;configurable components;core dynamics composites;cracked industrial firmware;crystal shards;datamined wake exceptions;decoded emission data;distorted shield cycle recordings;divergent scan data;eccentric hyperspace trajectories;electrochemical arrays;exceptional scrambled emission data;exquisite focus crystals;filament composites;flawed focus crystals;focus crystals;galvanising alloys;germanium;grid resistors;heat conduction wiring;heat dispersion plate;heat exchangers;heat resistant ceramics;heat vanes;high density composites;hybrid capacitors;imperial shielding;improvised components;inconsistent shield soak analysis;iron;irregular emission data;manganese;mechanical components;mechanical equipment;mechanical scrap;mercury;military grade alloys;military supercapacitors;modified consumer firmware;modified embedded firmware;molybdenum;nickel;niobium;open symmetric keys;peculiar shield frequency data;pharmaceutical isolators;phase alloys;phosphorus;polonium;polymer capacitors;precipitated alloys;proprietary composites;proto heat radiators;proto light alloys;proto radiolic alloys;refined focus crystals;ruthenium;salvaged alloys;security firmware patch;selenium;shield emitters;shielding sensors;specialised legacy firmware;strange wake solutions;sulphur;tagged encryption codes;technetium;tellurium;tempered alloys;thermic alloys;tin;tungsten;unexpected emission data;unidentified scan archives;unknown fragment;untypical shield scans;unusual encrypted files;vanadium;worn shield emitters;yttrium;zinc;zirconium]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -33989,7 +35347,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2259e778-59b3-4e51-8c5a-aaab9243006d</Id>
+          <Id>c073b861-ed11-426f-9ee9-d20d5bae30fd</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34027,7 +35385,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>93c5fe58-9bbf-423e-bd02-79213e91622e</Id>
+          <Id>f1749898-a257-4031-a13f-baa4a93f2d06</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34065,7 +35423,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>2f4364af-72cf-44da-a02e-1c776309e876</Id>
+          <Id>fc61f8be-4275-4653-ae33-d2efd4d587a0</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34103,7 +35461,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>69c1fd4e-bbb1-45b1-ac6a-9e0031b500b0</Id>
+          <Id>8af524a2-190e-49c9-895e-0ae646fca8c4</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34143,7 +35501,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>75e51694-60a9-4812-9b19-577484e81427</Id>
+          <Id>93f7945b-f1b1-45cb-b0d3-08599f547c87</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34181,7 +35539,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>e536dbe4-6d79-4ef1-82c7-a4d77bbcedbc</Id>
+          <Id>90af0e3b-b2b1-4877-890f-0fc62a7e9b30</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34266,6 +35624,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -34282,7 +35641,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>f8df5902-ec52-4466-b493-7afd80c903fe</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>ad985f8f-6a79-4209-8a6f-12d7c4faa511</Id>
+      <Id>1109c72c-db66-4368-9d3f-924246d664ea</Id>
       <CommandString>Where can I obtain [aberrant shield pattern analysis;abnormal compact emission data;adaptive encryptors capture;anomalous bulk scan data;anomalous fsd telemetry;antimony;arsenic;atypical disrupted wake echoes;atypical encryption archives;basic conductors;biotech conductors;cadmiun;carbon;chemical distillery;chemical manipulators;chemical processors;chemical storage units;chromium;classified scan databanks;classified scan fragment;compact composites;compound shielding;conductive ceramics;conductive components;conductive polymers;configurable components;core dynamics composites;cracked industrial firmware;crystal shards;datamined wake exceptions;decoded emission data;distorted shield cycle recordings;divergent scan data;eccentric hyperspace trajectories;electrochemical arrays;exceptional scrambled emission data;exquisite focus crystals;filament composites;flawed focus crystals;focus crystals;galvanising alloys;germanium;grid resistors;heat conduction wiring;heat dispersion plate;heat exchangers;heat resistant ceramics;heat vanes;high density composites;hybrid capacitors;imperial shielding;improvised components;inconsistent shield soak analysis;iron;irregular emission data;manganese;mechanical components;mechanical equipment;mechanical scrap;mercury;military grade alloys;military supercapacitors;modified consumer firmware;modified embedded firmware;molybdenum;nickel;niobium;open symmetric keys;peculiar shield frequency data;pharmaceutical isolators;phase alloys;phosphorus;polonium;polymer capacitors;precipitated alloys;proprietary composites;proto heat radiators;proto light alloys;proto radiolic alloys;refined focus crystals;ruthenium;salvaged alloys;security firmware patch;selenium;shield emitters;shielding sensors;specialised legacy firmware;strange wake solutions;sulphur;tagged encryption codes;technetium;tellurium;tempered alloys;thermic alloys;tin;tungsten;unexpected emission data;unidentified scan archives;unknown fragment;untypical shield scans;unusual encrypted files;vanadium;worn shield emitters;yttrium;zinc;zirconium]</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -34294,7 +35653,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>331389be-cadd-4a8f-9024-1dcb8af2b96c</Id>
+          <Id>27f782c2-eab8-4e00-bb88-1a4c5e0d773f</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34332,7 +35691,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>7c9cbdcd-6f1f-4742-a104-05340e73df9c</Id>
+          <Id>7bc0c1de-57bb-48b0-82ec-320f939beb04</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34370,7 +35729,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>9edbe4ca-3af9-42fb-8984-34aa74946d65</Id>
+          <Id>08085ca8-6bec-438f-a08c-d8cd6aa5693b</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34408,7 +35767,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>4100914c-b1d1-4ca4-bc81-62502becdce4</Id>
+          <Id>b69ace83-7dbb-41a1-8359-5e684a1dd2a1</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34448,7 +35807,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1d5a67b0-ed81-4aa4-a01f-7fbac3775e0a</Id>
+          <Id>cf20e2ef-ca3b-4536-80f0-fc5ff594b568</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34486,7 +35845,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>c4d4e378-7a4c-4eec-ba0b-5b64f904ac22</Id>
+          <Id>b5f5040a-eb29-41f4-8d59-f2b811d71729</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34571,6 +35930,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -34587,7 +35947,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>423c43c8-4128-4b5e-8f07-7cd2f642f22a</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>0fc6efc9-4c73-4a49-ac5f-64c3d63ea3d0</Id>
+      <Id>c29c3ab5-875e-4c7c-80dd-6861d683b7f7</Id>
       <CommandString>[Which;What] materials can I discard?</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -34599,7 +35959,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>b7cbd3ef-ccba-4718-ad3c-67f33ea79286</Id>
+          <Id>89f335ed-400c-4a73-8849-5431f326f88c</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34637,7 +35997,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>15bac6f9-f751-4400-89f4-91bf4c69cee1</Id>
+          <Id>a47db583-6389-41dc-87eb-44eb7eddc71a</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34722,6 +36082,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -34738,7 +36099,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>0dbd0adc-82e1-4962-91a1-ac2512f071d0</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>6d8366cb-55a7-4417-a3b7-0c3c86ce3951</Id>
+      <Id>62feeec8-5a9d-44af-9230-59ebfe3986aa</Id>
       <CommandString>[Which;What] materials do I need?</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -34750,7 +36111,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>3cfb075e-b737-4424-af2e-141633ff3ea8</Id>
+          <Id>b6ca66ed-ce03-4ce0-ae8c-b8ea40a6e2f8</Id>
           <ActionType>TextSet</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34788,7 +36149,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>00fd6d67-1196-47fc-be0b-58800f4960da</Id>
+          <Id>d4f56d3a-0a84-4d95-a618-e68542842347</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34873,6 +36234,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
     <Command>
       <Referrer xsi:nil="true" />
@@ -34889,7 +36251,7 @@
       <IsOverride>false</IsOverride>
       <BaseId>71b72aa6-7e1b-4643-b486-c009bc6c28de</BaseId>
       <OriginId>00000000-0000-0000-0000-000000000000</OriginId>
-      <Id>7a9a5bc5-dd26-456a-9022-b4bc1ba7fff7</Id>
+      <Id>0c9d2944-3ea0-4d2d-b497-72f95fa94e39</Id>
       <CommandString>You may talk</CommandString>
       <ActionSequence>
         <CommandAction>
@@ -34901,7 +36263,7 @@
           <ConditionSkip>false</ConditionSkip>
           <IsSuffixAction>false</IsSuffixAction>
           <DecimalTransient1>0</DecimalTransient1>
-          <Id>1d28b3fd-f326-42e6-a351-bb99a149b4ff</Id>
+          <Id>0a85b5f5-a7fa-4a5e-b06b-d3c3cbfab042</Id>
           <ActionType>ExternalInvoke</ActionType>
           <Duration>0</Duration>
           <Delay>0</Delay>
@@ -34977,7 +36339,7 @@
       <MouseUpOnly>false</MouseUpOnly>
       <MousePassThru>true</MousePassThru>
       <joystickExclusive>false</joystickExclusive>
-      <lastEditedAction>998f8ce2-0aa6-461c-b41f-438056702247</lastEditedAction>
+      <lastEditedAction>5608960e-3f56-4104-9ebf-59528fffd56f</lastEditedAction>
       <UseProfileProcessOverride>false</UseProfileProcessOverride>
       <ProfileProcessOverrideActiveWindow>false</ProfileProcessOverrideActiveWindow>
       <RepeatIfKeysDown>false</RepeatIfKeysDown>
@@ -34986,6 +36348,7 @@
       <AH>0</AH>
       <CL>0</CL>
       <HasMB>false</HasMB>
+      <UseVariableHotkey>false</UseVariableHotkey>
     </Command>
   </Commands>
   <OverrideGlobal>false</OverrideGlobal>
@@ -35016,7 +36379,7 @@
   <GlobalJoystickButton2>0</GlobalJoystickButton2>
   <GlobalJoystickNumber2>0</GlobalJoystickNumber2>
   <ReferencedProfile>2471cabe-7a67-4d3f-85dd-1547b06dd6b8</ReferencedProfile>
-  <ExportVAVersion>1.7.2.19</ExportVAVersion>
+  <ExportVAVersion>1.7.3</ExportVAVersion>
   <ExportOSVersionMajor>6</ExportOSVersionMajor>
   <ExportOSVersionMinor>2</ExportOSVersionMinor>
   <OverrideConfidence>false</OverrideConfidence>
@@ -35032,7 +36395,7 @@
   <EnableProfileSwitch>false</EnableProfileSwitch>
   <CategoryGroups />
   <GroupCategory>true</GroupCategory>
-  <LastEditedCommand>79f8292e-6884-4389-a57a-622e0f8c6460</LastEditedCommand>
+  <LastEditedCommand>5c6eb8c0-6adf-4b64-871c-655372604bc1</LastEditedCommand>
   <IS>0</IS>
   <IO>0</IO>
   <ReferencedProfiles />
@@ -35040,4 +36403,7 @@
   <BE>0</BE>
   <UnloadCommandEnabled>false</UnloadCommandEnabled>
   <UnloadCommandId xsi:nil="true" />
+  <BlockExternal>false</BlockExternal>
+  <AuthorID xsi:nil="true" />
+  <ProductID xsi:nil="true" />
 </Profile>

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -70,14 +70,24 @@ namespace EddiVoiceAttackResponder
                 // (we can only use event handlers with classes which are always constructed - nullable objects will be updated via responder events)
                 EDDI.Instance.State.CollectionChanged += (s, e) => setDictionaryValues(EDDI.Instance.State, "state", ref vaProxy);
                 SpeechService.Instance.PropertyChanged += (s, e) => setSpeaking(SpeechService.Instance.eddiSpeaking, ref vaProxy);
-                ((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor")).InventoryUpdatedEvent += (s, e) =>
+
+                CargoMonitor cargoMonitor = (CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor");
+                cargoMonitor.InventoryUpdatedEvent += (s, e) =>
                 {
-                    setCargo((CargoMonitor)EDDI.Instance.ObtainMonitor("Cargo monitor"), ref vaProxy);
+                    setCargo(cargoMonitor, ref vaProxy);
                 };
-                ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).ShipyardUpdatedEvent += (s, e) =>
+
+                ShipMonitor shipMonitor = (ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor");
+                shipMonitor.ShipyardUpdatedEvent += (s, e) =>
                 {
-                    setShipValues(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), "Ship", ref vaProxy);
-                    setShipyardValues(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).shipyard?.ToList(), ref vaProxy);
+                    setShipValues(shipMonitor?.GetCurrentShip(), "Ship", ref vaProxy);
+                    setShipyardValues(shipMonitor?.shipyard?.ToList(), ref vaProxy);
+                };
+
+                StatusMonitor statusMonitor = (StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor");
+                statusMonitor.StatusUpdatedEvent += (s, e) =>
+                {
+                    setStatusValues(statusMonitor?.currentStatus, "Status", ref vaProxy);
                 };
 
                 // Display instance information if available

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -18,6 +18,17 @@ namespace EddiVoiceAttackResponder
 {
     public class VoiceAttackVariables
     {
+        // These are reference values for nullable items we monitor to determine whether VoiceAttack values need to be updated
+        private static StarSystem CurrentStarSystem { get; set; } = new StarSystem();
+        private static StarSystem HomeStarSystem { get; set; } = new StarSystem();
+        private static StarSystem LastStarSystem { get; set; } = new StarSystem();
+        private static StarSystem NextStarSystem { get; set; } = new StarSystem();
+        private static StarSystem SquadronStarSystem { get; set; } = new StarSystem();
+        private static Body CurrentStellarBody { get; set; } = new Body();
+        private static Station CurrentStation { get; set; } = new Station();
+        private static Status Status { get; set; } = new Status();
+        private static Commander Commander { get; set; } = new Commander();
+
         public static void setEventValues(dynamic vaProxy, Event theEvent, List<string> setKeys)
         {
             foreach (string key in Events.VARIABLES[theEvent.type].Keys)
@@ -222,6 +233,113 @@ namespace EddiVoiceAttackResponder
         /// <summary>Set all values</summary>
         public static void setStandardValues(ref dynamic vaProxy)
         {
+            // Update our nullable primary objects only if they don't match the state of the EDDI instance.	
+            // (For objects that are always constructed, we prefer using event handlers).
+            try
+            {
+                if (EDDI.Instance.CurrentStarSystem != CurrentStarSystem)
+                {
+                    setStarSystemValues(EDDI.Instance.CurrentStarSystem, "System", ref vaProxy);
+                    CurrentStarSystem = EDDI.Instance.CurrentStarSystem;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set current system", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.LastStarSystem != LastStarSystem)
+                {
+                    setStarSystemValues(EDDI.Instance.LastStarSystem, "Last system", ref vaProxy);
+                    LastStarSystem = EDDI.Instance.LastStarSystem;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set last system", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.NextStarSystem != NextStarSystem)
+                {
+                    setStarSystemValues(EDDI.Instance.NextStarSystem, "Next system", ref vaProxy);
+                    NextStarSystem = EDDI.Instance.NextStarSystem;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set last system", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.SquadronStarSystem != SquadronStarSystem)
+                {
+                    setStarSystemValues(EDDI.Instance.SquadronStarSystem, "Squadron system", ref vaProxy);
+                    SquadronStarSystem = EDDI.Instance.SquadronStarSystem;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set last system", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.CurrentStellarBody != CurrentStellarBody)
+                {
+                    setDetailedBodyValues(EDDI.Instance.CurrentStellarBody, "Body", ref vaProxy);
+                    CurrentStellarBody = EDDI.Instance.CurrentStellarBody;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set stellar body", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.CurrentStation != CurrentStation)
+                {
+                    setStationValues(EDDI.Instance.CurrentStation, "Last station", ref vaProxy);
+                    CurrentStation = EDDI.Instance.CurrentStation;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set last station", ex);
+            }
+
+            try
+            {
+                if (((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus != Status)
+                {
+                    setStatusValues(((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus, "Status", ref vaProxy);
+                    Status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set current status", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.Cmdr != Commander)
+                {
+                    setCommanderValues(EDDI.Instance.Cmdr, ref vaProxy);
+                    Commander = EDDI.Instance.Cmdr;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set commander values", ex);
+            }
+
+            // On every event...	
             // Set miscellaneous values
             try
             {
@@ -286,7 +404,7 @@ namespace EddiVoiceAttackResponder
         }
 
         /// <summary>Set values for a station</summary>
-        protected static void setStationValues(Station station, string prefix, ref dynamic vaProxy)
+        private static void setStationValues(Station station, string prefix, ref dynamic vaProxy)
         {
             Logging.Debug("Setting station information");
 
@@ -310,7 +428,7 @@ namespace EddiVoiceAttackResponder
             Logging.Debug("Set station information");
         }
 
-        protected static void setCommanderValues(Commander cmdr, ref dynamic vaProxy)
+        private static void setCommanderValues(Commander cmdr, ref dynamic vaProxy)
         {
             try
             {
@@ -365,7 +483,7 @@ namespace EddiVoiceAttackResponder
                 vaProxy.SetText(prefix + " model", ship?.model);
                 vaProxy.SetText(prefix + " model (spoken)", ship?.SpokenModel());
 
-                if (ShipMonitor.Instance.GetCurrentShip() != null && EDDI.Instance.Cmdr != null && EDDI.Instance.Cmdr.name != null)
+                if (((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip() != null && EDDI.Instance.Cmdr != null && EDDI.Instance.Cmdr.name != null)
                 {
                     vaProxy.SetText(prefix + " callsign", ship == null ? null : ship.manufacturer + " " + EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant());
                     vaProxy.SetText(prefix + " callsign (spoken)", ship == null ? null : ship.SpokenManufacturer() + " " + Translations.ICAO(EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant()));
@@ -549,11 +667,11 @@ namespace EddiVoiceAttackResponder
                     setShipValues(StoredShip, "Stored ship " + currentStoredShip, ref vaProxy);
                     currentStoredShip++;
                 }
-                vaProxy.SetInt("Stored ship entries", ShipMonitor.Instance?.shipyard.Count);
+                vaProxy.SetInt("Stored ship entries", ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.shipyard.Count);
             }
         }
 
-        protected static void setStarSystemValues(StarSystem system, string prefix, ref dynamic vaProxy)
+        private static void setStarSystemValues(StarSystem system, string prefix, ref dynamic vaProxy)
         {
             if (system == null)
             {
@@ -630,7 +748,7 @@ namespace EddiVoiceAttackResponder
             Logging.Debug("Set body information (" + prefix + ")");
         }
 
-        protected static void setDetailedBodyValues(Body body, string prefix, ref dynamic vaProxy)
+        private static void setDetailedBodyValues(Body body, string prefix, ref dynamic vaProxy)
         {
             Logging.Debug("Setting current stellar body information");
             vaProxy.SetDecimal(prefix + " EDDB id", body?.EDDBID);
@@ -702,7 +820,7 @@ namespace EddiVoiceAttackResponder
             }
         }
 
-        protected static void setStatusValues(Status status, string prefix, ref dynamic vaProxy)
+        private static void setStatusValues(Status status, string prefix, ref dynamic vaProxy)
         {
             if (status == null)
             {

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -26,7 +26,6 @@ namespace EddiVoiceAttackResponder
         private static StarSystem SquadronStarSystem { get; set; } = new StarSystem();
         private static Body CurrentStellarBody { get; set; } = new Body();
         private static Station CurrentStation { get; set; } = new Station();
-        private static Status Status { get; set; } = new Status();
         private static Commander Commander { get; set; } = new Commander();
 
         public static void setEventValues(dynamic vaProxy, Event theEvent, List<string> setKeys)
@@ -311,19 +310,6 @@ namespace EddiVoiceAttackResponder
             catch (Exception ex)
             {
                 Logging.Error("Failed to set last station", ex);
-            }
-
-            try
-            {
-                if (((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus != Status)
-                {
-                    setStatusValues(((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus, "Status", ref vaProxy);
-                    Status = ((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor")).currentStatus;
-                }
-            }
-            catch (Exception ex)
-            {
-                Logging.Error("Failed to set current status", ex);
             }
 
             try
@@ -820,7 +806,7 @@ namespace EddiVoiceAttackResponder
             }
         }
 
-        private static void setStatusValues(Status status, string prefix, ref dynamic vaProxy)
+        protected static void setStatusValues(Status status, string prefix, ref dynamic vaProxy)
         {
             if (status == null)
             {


### PR DESCRIPTION
Removes `Instance` properties from monitors (I found that these were not generating true singletons, and consequently were not achieving their end purpose).
Scales back event handling of VA variables no non-nullable types only exceptions were being generated from trying to subscribe to null objects).