### PR TITLE
VoiceAttack event handling reworked to minimize delays

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,11 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### Development
+  * VoiceAttack responder
+    * Improved event responsiveness
+    * Reduced CPU utilization 
+
 ### 3.3.6
   * Frontier API
     * Fixed missing client ID in 3.3.5

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,6 +3,8 @@
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
 ### Development
+  * Ship monitor
+    * Fixed a lock-up that could occur when opening the ship monitor from VoiceAttack
   * VoiceAttack responder
     * Improved event responsiveness
     * Reduced CPU utilization 

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -8,6 +8,8 @@ Full details of the variables available for each noted event, and VoiceAttack in
   * VoiceAttack responder
     * Improved event responsiveness
     * Reduced CPU utilization 
+    * Restored missing home system variables 
+    * Revised VoiceAttack integration documents with updated guidance on accessing home and squadron variables.
 
 ### 3.3.6
   * Frontier API

--- a/ShipMonitor/ConfigurationWindow.xaml.cs
+++ b/ShipMonitor/ConfigurationWindow.xaml.cs
@@ -110,14 +110,24 @@ namespace EddiShipMonitor
 
         private void shipsUpdated(object sender, DataTransferEventArgs e)
         {
-            // Update the ship monitor's information
-            shipMonitor()?.Save();
+            // Update the ship monitor's 'PhoneticName' information
+            if (e.OriginalSource is TextBlock)
+            {
+                var dg = (DataGrid)e.Source;
+                if (dg.SelectedItem is Ship)
+                {
+                    shipMonitor()?.Save();
+                }
+            }
         }
 
         private void shipsUpdated(object sender, SelectionChangedEventArgs e)
         {
-            // Update the ship monitor's information
-            shipMonitor()?.Save();
+            // Update the ship monitor's 'Role' information
+            if (e.RemovedItems.Count > 0)
+            {
+                shipMonitor()?.Save();
+            }
         }
     }
 

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Utilities;
 using EddiStarMapService;
+using System.Threading.Tasks;
 
 namespace EddiVoiceAttackResponder
 {
@@ -81,7 +82,7 @@ namespace EddiVoiceAttackResponder
                 shipMonitor.ShipyardUpdatedEvent += (s, e) =>
                 {
                     setShipValues(shipMonitor?.GetCurrentShip(), "Ship", ref vaProxy);
-                    setShipyardValues(shipMonitor?.shipyard?.ToList(), ref vaProxy);
+                    Task.Run(() => setShipyardValues(shipMonitor?.shipyard?.ToList(), ref vaProxy));
                 };
 
                 StatusMonitor statusMonitor = (StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor");

--- a/VoiceAttackResponder/VoiceAttackResponder.cs
+++ b/VoiceAttackResponder/VoiceAttackResponder.cs
@@ -16,10 +16,7 @@ namespace EddiVoiceAttackResponder
 
         protected virtual void OnEvent(EventArgs @eventArgs, Event @event)
         {
-            if (RaiseEvent != null)
-            {
-                RaiseEvent(@eventArgs, @event);
-            }
+            RaiseEvent?.Invoke(@eventArgs, @event);
         }
 
         public string ResponderName()
@@ -47,16 +44,15 @@ namespace EddiVoiceAttackResponder
             Logging.Info("Started VoiceAttack responder");
         }
 
-        public void Handle(Event theEvent)
+        public void Handle(Event @event)
         {
-            if (theEvent.fromLoad)
+            if (@event.fromLoad)
             {
                 return;
             }
 
-            Logging.Debug("Received event " + JsonConvert.SerializeObject(theEvent));
-            VoiceAttackPlugin.EventQueue.Add(theEvent);
-            OnEvent(new EventArgs(), theEvent);
+            Logging.Debug("Received event " + JsonConvert.SerializeObject(@event));
+            OnEvent(EventArgs.Empty, @event);
         }
 
         public bool Start()

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -26,6 +26,7 @@ namespace EddiVoiceAttackResponder
         private static StarSystem SquadronStarSystem { get; set; } = new StarSystem();
         private static Body CurrentStellarBody { get; set; } = new Body();
         private static Station CurrentStation { get; set; } = new Station();
+        private static Station HomeStation { get; set; } = new Station();
         private static Commander Commander { get; set; } = new Commander();
         private static List<Ship> vaShipyard { get; set; } = new List<Ship>();
 
@@ -271,7 +272,7 @@ namespace EddiVoiceAttackResponder
             }
             catch (Exception ex)
             {
-                Logging.Error("Failed to set last system", ex);
+                Logging.Error("Failed to set next system", ex);
             }
 
             try
@@ -284,7 +285,20 @@ namespace EddiVoiceAttackResponder
             }
             catch (Exception ex)
             {
-                Logging.Error("Failed to set last system", ex);
+                Logging.Error("Failed to set squadron system", ex);
+            }
+
+            try
+            {
+                if (EDDI.Instance.HomeStarSystem != HomeStarSystem)
+                {
+                    setStarSystemValues(EDDI.Instance.HomeStarSystem, "Home system", ref vaProxy);
+                    HomeStarSystem = EDDI.Instance.HomeStarSystem;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set home system", ex);
             }
 
             try
@@ -297,7 +311,7 @@ namespace EddiVoiceAttackResponder
             }
             catch (Exception ex)
             {
-                Logging.Error("Failed to set stellar body", ex);
+                Logging.Error("Failed to set current stellar body", ex);
             }
 
             try
@@ -312,6 +326,20 @@ namespace EddiVoiceAttackResponder
             {
                 Logging.Error("Failed to set last station", ex);
             }
+
+            try
+            {
+                if (EDDI.Instance.HomeStation != HomeStation)
+                {
+                    setStationValues(EDDI.Instance.HomeStation, "Home station", ref vaProxy);
+                    HomeStation = EDDI.Instance.HomeStation;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to set home station", ex);
+            }
+
 
             try
             {

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -25,9 +25,6 @@ EDDI makes a large number of values available to augment your existing scripts. 
 ## Commander Variables
 
   * {TXT:Name}: the name of the commander
-  * {TXT:Home system}: the name of the home system of the commander, set from EDDI configuration
-  * {TXT:Home system (spoken)}: the name of the home system of the commander, set from EDDI configuration as would be spoken
-  * {TXT:Home station}: the name of the home station of the commander in the home system, set from EDDI configuration
   * {INT:Combat rating}: the combat rating of the commander, with 0 being Harmless and 8 being Elite
   * {TXT:Combat rank}: the combat rank of the commander, from Harmless to Elite
   * {INT:Trade rating}: the trade rating of the commander, with 0 being Penniless and 8 being Elite
@@ -213,47 +210,19 @@ EDDI makes a large number of values available to augment your existing scripts. 
 
 ### Last System Variables
 
-  * {TXT:Last system name}: the name of the last system
-  * {TXT:Last system name (spoken)}: the name of the last system as would be spoken
-  * {INT:Last system visits}: the number of times the commander has visited the last system (whilst the plugin has been active)
-  * {DATE:Last system previous visit}: the last time the commander visited the last system (empty if this is their first visit)
-  * {DEC:Last system population}: the population of the last system
-  * {TXT:Last system population}: the population of the last system as would be spoken (e.g. "nearly 12 and a half billion")
-  * {TXT:Last system allegiance}: the allegiance of the last system ("Federation", "Empire", "Alliance", "Independant" or empty)
-  * {TXT:Last system government}: the government of the last system (e.g. "Democracy")
-  * {TXT:Last system faction}: the primary faction of the last system (e.g. "The Pilots' Federation")
-  * {TXT:Last system primary economy}: the primary economy of the last system (e.g. "Industrial")
-  * {TXT:Last system state}: the overall state of the last system (e.g. "Boom")
-  * {TXT:Last system security}: the security level in the last system ("High", "Medium", "Low", "None" or empty)
-  * {TXT:Last system power}: the name of the power that controls the last system (e.g. "Felicia Winters")
-  * {TXT:Last system power (spoken)}: the name of the power that controls the last system as would be spoken
-  * {TXT:Last system power state}: the state of the power in the last system (e.g. "Expansion")
-  * {TXT:Last system rank}: the rank of the Commander in the last system (e.g. "Duke" if an Empire system, "Admiral" if a Federation system)
-  * {DEC:Last system X} the X co-ordinate of the last system
-  * {DEC:Last system Y} the Y co-ordinate of the last system
-  * {DEC:Last system Z} the Z co-ordinate of the last system
+  * Like "Current System Variables", except prefixed with `Last system` rather than `System`
 
 ### Next System Variables
 
-  * {TXT:Next system name}: the name of the next system
-  * {TXT:Next system name (spoken)}: the name of the next system as would be spoken
-  * {INT:Next system visits}: the number of times the commander has visited the next system (whilst the plugin has been active)
-  * {DATE:Next system previous visit}: the next time the commander visited the next system (empty if this is their first visit)
-  * {DEC:Next system population}: the population of the next system
-  * {TXT:Next system population}: the population of the next system as would be spoken (e.g. "nearly 12 and a half billion")
-  * {TXT:Next system allegiance}: the allegiance of the next system ("Federation", "Empire", "Alliance", "Independant" or empty)
-  * {TXT:Next system government}: the government of the next system (e.g. "Democracy")
-  * {TXT:Next system faction}: the primary faction of the next system (e.g. "The Pilots' Federation")
-  * {TXT:Next system primary economy}: the primary economy of the next system (e.g. "Industrial")
-  * {TXT:Next system state}: the overall state of the next system (e.g. "Boom")
-  * {TXT:Next system security}: the security level in the next system ("High", "Medium", "Low", "None" or empty)
-  * {TXT:Next system power}: the name of the power that controls the next system (e.g. "Felicia Winters")
-  * {TXT:Next system power (spoken)}: the name of the power that controls the next system as would be spoken
-  * {TXT:Next system power state}: the state of the power in the next system (e.g. "Expansion")
-  * {TXT:Next system rank}: the rank of the Commander in the next system (e.g. "Duke" if an Empire system, "Admiral" if a Federation system)
-  * {DEC:Next system X} the X co-ordinate of the next system
-  * {DEC:Next system Y} the Y co-ordinate of the next system
-  * {DEC:Next system Z} the Z co-ordinate of the next system
+  * Like "Current System Variables", except prefixed with `Next system` rather than `System`
+
+### Home System Variables
+
+  * Like "Current System Variables", except prefixed with `Home system` rather than `System`
+
+### Squadron System Variables
+
+  * Like "Current System Variables", except prefixed with `Squadron system` rather than `System`
 
 ## Current Station Variables
 
@@ -298,6 +267,10 @@ EDDI makes a large number of values available to augment your existing scripts. 
   * {BOOL:Last station has black market}: true if this station has a black market
   * {BOOL:Last station has outfitting}: true if this station has outfitting
   * {BOOL:Last station has shipyard}: true if this station has a shipyard
+
+### Home Station Variables
+
+  * Like "Current Station Variables", except prefixed with `Home station` rather than `Last station`
 
 ## Shipyard Variables
 


### PR DESCRIPTION
Revises the VoiceAttack event handler to mimic the way events are handled in EDDI.cs.

Fixes #1155 - Significant performance improvement.
Fixes #1182 - a ship monitor lock up that can occur when opening the ship monitor from VA.

I also noticed significant delays from writing shipyard data. These changes minimize those delays by setting VA shipyard variables in the background and only for ships that have been changed.
