### PR TITLE
Speech responder priorities

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -371,7 +371,7 @@ namespace EddiCompanionAppService
                 if (CurrentState != State.Authorized)
                 {
                     // No luck; give up
-                    SpeechService.Instance.Say(null, Properties.CapiResources.frontier_api_lost, false);
+                    SpeechService.Instance.Say(null, Properties.CapiResources.frontier_api_lost, false, 0);
                     Logout();
                 }
                 else
@@ -383,7 +383,7 @@ namespace EddiCompanionAppService
 
                     {
                         // No luck with a relogin; give up
-                        SpeechService.Instance.Say(null, Properties.CapiResources.frontier_api_lost, false);
+                        SpeechService.Instance.Say(null, Properties.CapiResources.frontier_api_lost, false, 0);
                         Logout();
                         throw new EliteDangerousCompanionAppException("Failed to obtain data from Frontier server (" + CurrentState + ")");
                     }

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -11,11 +11,19 @@ Full details of the variables available for each noted event, and VoiceAttack in
     * Updated the Spanish default speech personality.
   * Ship monitor
     * Fixed a lock-up that could occur when opening the ship monitor from VoiceAttack
+  * Speech responder
+    * Implemented speech priorities as follows:
+      * 1 - high priority, interrupts other speech
+      * 2 - high priority
+      * 3 - standard priority
+      * 4 - low priority
+      * 5 - low priority, interruptible by any higher priority speech
   * VoiceAttack responder
     * Improved event responsiveness
     * Reduced CPU utilization 
     * Restored missing home system variables 
     * Revised VoiceAttack integration documents with updated guidance on accessing home and squadron variables.
+    * Documented methods for using speech priorities with `say` and `speech` plugin functions. 
 
 ### 3.3.6
   * Frontier API

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -264,7 +264,7 @@ namespace Eddi
                         if (!FromVA)
                         {
                             string message = String.Format(Properties.EddiResources.mandatory_upgrade, spokenVersion);
-                            SpeechService.Instance.Say(null, message, false);
+                            SpeechService.Instance.Say(null, message, false, 0);
                         }
                         UpgradeRequired = true;
                         UpgradeLocation = info.url;
@@ -279,7 +279,7 @@ namespace Eddi
                         if (!FromVA)
                         {
                             string message = String.Format(Properties.EddiResources.update_available, spokenVersion);
-                            SpeechService.Instance.Say(null, message, false);
+                            SpeechService.Instance.Say(null, message, false, 0);
                         }
                         UpgradeAvailable = true;
                         UpgradeLocation = info.url;
@@ -289,7 +289,7 @@ namespace Eddi
             }
             catch (Exception ex)
             {
-                SpeechService.Instance.Say(null, Properties.EddiResources.update_server_unreachable, false);
+                SpeechService.Instance.Say(null, Properties.EddiResources.update_server_unreachable, false, 0);
                 Logging.Warn("Failed to access " + Constants.EDDI_SERVER_URL, ex);
             }
         }
@@ -303,11 +303,11 @@ namespace Eddi
                 if (UpgradeLocation != null)
                 {
                     Logging.Info("Downloading upgrade from " + UpgradeLocation);
-                    SpeechService.Instance.Say(null, Properties.EddiResources.downloading_upgrade, true);
+                    SpeechService.Instance.Say(null, Properties.EddiResources.downloading_upgrade, true, 0);
                     string updateFile = Net.DownloadFile(UpgradeLocation, @"EDDI-update.exe");
                     if (updateFile == null)
                     {
-                        SpeechService.Instance.Say(null, Properties.EddiResources.download_failed, true);
+                        SpeechService.Instance.Say(null, Properties.EddiResources.download_failed, true, 0);
                     }
                     else
                     {
@@ -317,7 +317,7 @@ namespace Eddi
                         Logging.Info("Downloaded update to " + updateFile);
                         Logging.Info("Path is " + Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
                         File.SetAttributes(updateFile, FileAttributes.Normal);
-                        SpeechService.Instance.Say(null, Properties.EddiResources.starting_upgrade, true);
+                        SpeechService.Instance.Say(null, Properties.EddiResources.starting_upgrade, true, 0);
                         Logging.Info("Starting upgrade.");
 
                         Process.Start(updateFile, @"/closeapplications /restartapplications /silent /log /nocancel /noicon /dir=""" + Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + @"""");
@@ -326,7 +326,7 @@ namespace Eddi
             }
             catch (Exception ex)
             {
-                SpeechService.Instance.Say(null, Properties.EddiResources.upgrade_failed, true);
+                SpeechService.Instance.Say(null, Properties.EddiResources.upgrade_failed, true, 0);
                 Logging.Error("Upgrade failed", ex);
             }
         }
@@ -2066,13 +2066,13 @@ namespace Eddi
                 {
                     string msg = string.Format(Properties.EddiResources.problem_load_monitor_file, dir.FullName);
                     Logging.Error(msg, flex);
-                    SpeechService.Instance.Say(null, msg, false);
+                    SpeechService.Instance.Say(null, msg, false, 0);
                 }
                 catch (Exception ex)
                 {
                     string msg = string.Format(Properties.EddiResources.problem_load_monitor, $"{file.Name}.\n{ex.Message} {ex.InnerException?.Message ?? ""}");
                     Logging.Error(msg, ex);
-                    SpeechService.Instance.Say(null, msg, false);
+                    SpeechService.Instance.Say(null, msg, false, 0);
                 }
             }
             return monitors;

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -860,13 +860,13 @@ namespace Eddi
             if (oldState == CompanionAppService.State.AwaitingCallback && 
                 newState == CompanionAppService.State.Authorized)
             {
-                SpeechService.Instance.Say(null, string.Format(Properties.EddiResources.frontier_api_ok, EDDI.Instance.Cmdr.name), false);
-                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_close_browser, false);
+                SpeechService.Instance.Say(null, string.Format(Properties.EddiResources.frontier_api_ok, EDDI.Instance.Cmdr.name), false, 0);
+                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_close_browser, false, 0);
             }
             else if (oldState == CompanionAppService.State.LoggedOut &&
                 newState == CompanionAppService.State.AwaitingCallback)
             {
-                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_please_authenticate, false);
+                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_please_authenticate, false, 0);
             }
         }
 
@@ -933,10 +933,10 @@ namespace Eddi
             {
                 // Logout from the companion app and start again
                 CompanionAppService.Instance.Logout();
-                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_reset, false);
+                SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_reset, false, 0);
                 if (fromVA)
                 {
-                    SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_cant_login_from_va, false);
+                    SpeechService.Instance.Say(null, Properties.EddiResources.frontier_api_cant_login_from_va, false, 0);
                 }
             }
         }
@@ -973,7 +973,7 @@ namespace Eddi
             Ship testShip = ShipDefinitions.FromModel((string)ttsTestShipDropDown.SelectedItem);
             testShip.health = 100;
             string message = String.Format(Properties.EddiResources.voice_test_ship, ShipDefinitions.FromModel((string)ttsTestShipDropDown.SelectedItem).SpokenModel());
-            SpeechService.Instance.Say(testShip, message, false);
+            SpeechService.Instance.Say(testShip, message, false, 0);
         }
 
         private void ttsTestDamagedVoiceButtonClicked(object sender, RoutedEventArgs e)
@@ -981,7 +981,7 @@ namespace Eddi
             Ship testShip = ShipDefinitions.FromModel((string)ttsTestShipDropDown.SelectedItem);
             testShip.health = 20;
             string message = String.Format(Properties.EddiResources.voice_test_damage, ShipDefinitions.FromModel((string)ttsTestShipDropDown.SelectedItem).SpokenModel());
-            SpeechService.Instance.Say(testShip, message, false);
+            SpeechService.Instance.Say(testShip, message, false, 0);
         }
 
         private void disableSsmlUpdated(object sender, RoutedEventArgs e)

--- a/Events/Event.cs
+++ b/Events/Event.cs
@@ -5,18 +5,18 @@ namespace EddiEvents
 {
     public abstract class Event
     {
-        /// <summary>
-        /// The raw event from which this event was obtained.  This is optional
-        /// </summary>
+        /// <summary> The raw event from which this event was obtained.  This is optional </summary>
         [JsonProperty("raw")]
         public string raw { get; set; }
 
         [JsonProperty("timestamp")]
         public DateTime timestamp { get; private set; }
 
+        /// <summary> The EDDI event triggered by this event.</summary>
         [JsonProperty("type")]
         public string type { get; private set; }
 
+        /// <summary> Whether this event was triggered during the initial journal load at launch or later.</summary>
         [JsonProperty("fromLoad")]
         public bool fromLoad { get; set; }
 

--- a/ShipMonitor/ConfigurationWindow.xaml.cs
+++ b/ShipMonitor/ConfigurationWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace EddiShipMonitor
                 ? ship.name 
                 : $@"<phoneme alphabet=""ipa"" ph=""{ship.phoneticname}"">{ship.name}</phoneme>";
             string message = String.Format(Properties.ShipMonitor.ship_ready, nameToSpeak);
-            SpeechService.Instance.Say(ship, message, false);
+            SpeechService.Instance.Say(ship, message, false, 0);
         }
 
         private void exportShip(object sender, RoutedEventArgs e)

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -19,22 +19,72 @@
                     <CheckBox x:Name="subtitlesCheckbox" VerticalAlignment="Center" Margin="5, 0" Checked="subtitlesEnabled" Unchecked="subtitlesDisabled"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" >
-                    <TextBlock Margin="5" TextWrapping="Wrap" Text="{x:Static resx:SpeechResponder.subs_only}"></TextBlock>
+                    <TextBlock Margin="5" TextWrapping="Wrap" Text="{x:Static resx:SpeechResponder.subs_only}"/>
                     <CheckBox x:Name="subtitlesOnlyCheckbox" Margin="0" VerticalAlignment="Center" Checked="subtitlesOnlyEnabled" Unchecked="subtitlesOnlyDisabled"/>
                 </StackPanel>
             </StackPanel>
-            <TextBlock x:Name="defaultText" VerticalAlignment="Top" DockPanel.Dock="Left" Grid.Column="1" TextWrapping="Wrap" Width="Auto" Text="{x:Static resx:SpeechResponder.default_is_read_only}"/>
+            <RichTextBox x:Name="speechResponderHelp" DockPanel.Dock="Left" Grid.Column="1" Width="Auto" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
+                <FlowDocument Background="#FFE5E5E5">
+                    <Paragraph>
+                        <TextBlock TextWrapping="Wrap">
+                            <Run Text="{x:Static resx:SpeechResponder.speechResponderHelp}"/>
+                            <Hyperlink Click="SpeechResponderHelp_Click">
+                                <Run Text="{x:Static resx:SpeechResponder.speechResponderHelpHere}"/>
+                            </Hyperlink>
+                        </TextBlock>
+                    </Paragraph>
+                </FlowDocument>
+            </RichTextBox>
         </Grid>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5, 0">
             <TextBlock VerticalAlignment="Center" Text="{x:Static resx:SpeechResponder.active_personality}" />
             <ComboBox Margin="5,0" ItemsSource="{Binding Personalities}" SelectedValue="{Binding Personality, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" SelectionChanged="personalityChanged" />
             <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding Personality.Description}"/>
         </StackPanel>
-        <UniformGrid DockPanel.Dock="Bottom" Rows="1" Margin="0">
-            <Button Margin="10" HorizontalAlignment="Center" Click="newScriptClicked" IsEnabled="{Binding Path=Personality.IsEditable}" Content="{x:Static resx:SpeechResponder.button_new}"></Button>
-            <Button Margin="10" HorizontalAlignment="Center" Click="copyPersonalityClicked" Content="{x:Static resx:SpeechResponder.button_copy}"></Button>
-            <Button Margin="10" HorizontalAlignment="Center" Click="deletePersonalityClicked" IsEnabled="{Binding Path=Personality.IsEditable}" Content="{x:Static resx:SpeechResponder.button_delete}"></Button>
-        </UniformGrid>
+        <Grid DockPanel.Dock="Bottom" Margin="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="0" Click="copyPersonalityClicked" Content="{x:Static resx:SpeechResponder.button_copy}"></Button>
+            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="1" Click="newScriptClicked" Content="{x:Static resx:SpeechResponder.button_new}">
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}">
+                        <Setter Property="Visibility"  Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="False">
+                                <Setter Property="Visibility"  Value="Hidden" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="2" Click="deletePersonalityClicked" IsEnabled="{Binding Path=Personality.IsEditable}" Content="{x:Static resx:SpeechResponder.button_delete}">
+                <Button.Style>
+                    <Style TargetType="{x:Type Button}">
+                        <Setter Property="Visibility"  Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="False">
+                                <Setter Property="Visibility"  Value="Hidden" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+            <TextBlock x:Name="defaultText" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.Column="1" Grid.ColumnSpan="2" TextWrapping="Wrap" Width="Auto" Margin="10, 0" Text="{x:Static resx:SpeechResponder.default_is_read_only}" FontWeight="Bold" FontStyle="Italic" FontSize="13">
+                <TextBlock.Style>
+                    <Style TargetType="{x:Type TextBlock}">
+                        <Setter Property="Visibility"  Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="True">
+                                <Setter Property="Visibility"  Value="Hidden" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </Grid>
         <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding Personality.Scripts}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending" />

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -50,13 +50,17 @@
                 <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ComboBox IsEnabled="{Binding Path=Value.Responder}" SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Path=Value.Priorities}" SelectionChanged="eddiScriptsUpdated">
+                            <ComboBox SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Path=Value.Priorities}" SelectionChanged="eddiScriptsUpdated">
                                 <ComboBox.Style>
                                     <Style TargetType="{x:Type ComboBox}">
                                         <Setter Property="Opacity"  Value="1" />
+                                        <Setter Property="IsEnabled"  Value="{Binding Path=Value.Responder}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Path=Value.Responder}" Value="False">
                                                 <Setter Property="Opacity"  Value="0" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsEditable}" Value="False">
+                                                <Setter Property="IsEnabled"  Value="False" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:EddiSpeechResponder"
              xmlns:resx="clr-namespace:EddiSpeechResponder.Properties"
              mc:Ignorable="d" 
@@ -44,6 +44,24 @@
                             <Border IsEnabled="{Binding Path=Value.Responder}">
                                 <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding Path=Value.Enabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsEditable}" Checked="eddiScriptsUpdated" Unchecked="eddiScriptsUpdated" />
                             </Border>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <ComboBox IsEnabled="{Binding Path=Value.Responder}" SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Path=Value.Priorities}" SelectionChanged="eddiScriptsUpdated">
+                                <ComboBox.Style>
+                                    <Style TargetType="{x:Type ComboBox}">
+                                        <Setter Property="Opacity"  Value="1" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Path=Value.Responder}" Value="False">
+                                                <Setter Property="Opacity"  Value="0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ComboBox.Style>
+                            </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -71,7 +71,6 @@ namespace EddiSpeechResponder
                 if (personality.Name == configuration.Personality)
                 {
                     Personality = personality;
-                    personalityDefaultTxt(personality);
                     break;
                 }
             }
@@ -193,7 +192,6 @@ namespace EddiSpeechResponder
         {
             if (Personality != null)
             {
-                personalityDefaultTxt(Personality);
                 SpeechResponderConfiguration configuration = SpeechResponderConfiguration.FromFile();
                 configuration.Personality = Personality.Name;
                 configuration.ToFile();
@@ -295,22 +293,10 @@ namespace EddiSpeechResponder
             EDDI.Instance.Reload("Speech responder");
         }
 
-        private void personalityDefaultTxt(Personality personality)
+        private void SpeechResponderHelp_Click(object sender, RoutedEventArgs e)
         {
-            if (personality.IsDefault)
-            {
-                defaultText.Text = Properties.SpeechResponder.default_is_read_only;
-                defaultText.FontWeight = FontWeights.Bold;
-                defaultText.FontStyle = FontStyles.Italic;
-                defaultText.FontSize = 13;
-            }
-            else
-            {
-                defaultText.Text = Properties.SpeechResponder.warning_triggered;
-                defaultText.FontWeight = FontWeights.Normal;
-                defaultText.FontStyle = FontStyles.Italic;
-                defaultText.FontSize = 13;
-            }
+            MarkdownWindow speechResponderHelpWindow = new MarkdownWindow("speechResponderHelp.md");
+            speechResponderHelpWindow.Show();
         }
     }
 }

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -87,6 +87,27 @@ namespace EddiSpeechResponder
             updateScriptsConfiguration();
         }
 
+        private void eddiScriptsUpdated(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count > 0)
+            {
+                if (e.Source is ComboBox comboBox)
+                {
+                    if (comboBox.DataContext is KeyValuePair<string, Script> kvScript)
+                    {
+                        if (kvScript.Value.Responder)
+                        {
+                            comboBox.Visibility = Visibility.Visible;
+                        }
+                    }
+                }
+            }
+            if (e.RemovedItems.Count > 0)
+            {
+                updateScriptsConfiguration();
+            }
+        }
+
         private void editScript(object sender, RoutedEventArgs e)
         {
             Script script = ((KeyValuePair<string, Script>)((Button)e.Source).DataContext).Value;

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -89,19 +89,6 @@ namespace EddiSpeechResponder
 
         private void eddiScriptsUpdated(object sender, SelectionChangedEventArgs e)
         {
-            if (e.AddedItems.Count > 0)
-            {
-                if (e.Source is ComboBox comboBox)
-                {
-                    if (comboBox.DataContext is KeyValuePair<string, Script> kvScript)
-                    {
-                        if (kvScript.Value.Responder)
-                        {
-                            comboBox.Visibility = Visibility.Visible;
-                        }
-                    }
-                }
-            }
             if (e.RemovedItems.Count > 0)
             {
                 updateScriptsConfiguration();

--- a/SpeechResponder/EddiSpeechResponder.csproj
+++ b/SpeechResponder/EddiSpeechResponder.csproj
@@ -78,6 +78,9 @@
     <Compile Include="CopyPersonalityWindow.xaml.cs">
       <DependentUpon>CopyPersonalityWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="MarkdownWindow.xaml.cs">
+      <DependentUpon>MarkdownWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\SpeechResponder.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -91,9 +94,6 @@
     </Compile>
     <Compile Include="EditScriptWindow.xaml.cs">
       <DependentUpon>EditScriptWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="HelpWindow.xaml.cs">
-      <DependentUpon>HelpWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Personality.cs" />
     <Compile Include="SpeechResponderConfiguration.cs" />
@@ -170,6 +170,9 @@
     <None Include="eddi.pt-BR.json" />
     <None Include="eddi.ru.json" />
     <None Include="packages.config" />
+    <None Include="SpeechResponderHelp.md">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Variables.md">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -179,6 +182,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="CopyPersonalityWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="MarkdownWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
@@ -195,10 +202,6 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="ConfigurationWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="HelpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -114,7 +114,7 @@ namespace EddiSpeechResponder
 
         private void helpButtonClick(object sender, RoutedEventArgs e)
         {
-            HelpWindow helpWindow = new HelpWindow();
+            MarkdownWindow helpWindow = new MarkdownWindow("Help.md");
             helpWindow.Show();
         }
 

--- a/SpeechResponder/MarkdownWindow.xaml
+++ b/SpeechResponder/MarkdownWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="EddiSpeechResponder.HelpWindow"
+﻿<Window x:Class="EddiSpeechResponder.MarkdownWindow"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/SpeechResponder/MarkdownWindow.xaml.cs
+++ b/SpeechResponder/MarkdownWindow.xaml.cs
@@ -7,11 +7,11 @@ using Utilities;
 namespace EddiSpeechResponder
 {
     /// <summary>
-    /// Interaction logic for HelpWindow.xaml
+    /// Interaction logic for opening a generic SpeechResponder project markdown 
     /// </summary>
-    public partial class HelpWindow : Window
+    public partial class MarkdownWindow : Window
     {
-        public HelpWindow()
+        public MarkdownWindow(string fileName)
         {
             InitializeComponent();
 
@@ -20,11 +20,11 @@ namespace EddiSpeechResponder
             try
             {
                 DirectoryInfo dir = new DirectoryInfo(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-                markdown = Files.Read(dir.FullName + @"\Help.md");
+                markdown = Files.Read(dir.FullName + @"\" + fileName);
             }
             catch (Exception ex)
             {
-                Logging.Error("Failed to find variables.md", ex);
+                Logging.Error("Failed to find " + fileName, ex);
                 markdown = "";
             }
             string html = CommonMark.CommonMarkConverter.Convert(markdown);

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -250,6 +250,15 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Priority.
+        /// </summary>
+        public static string header_priority {
+            get {
+                return ResourceManager.GetString("header_priority", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Help.
         /// </summary>
         public static string help_button {

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -196,7 +196,7 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its &apos;Test&apos; and &apos;View&apos; buttons are disabled..
+        ///   Looks up a localized string similar to Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its &apos;Test&apos; and &apos;View&apos; buttons are disabled. Event-based scripts can be disabled or re-prioritized but not deleted..
         /// </summary>
         public static string desc {
             get {
@@ -295,6 +295,24 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Read about the speech responder&apos;s functions.
+        /// </summary>
+        public static string speechResponderHelp {
+            get {
+                return ResourceManager.GetString("speechResponderHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to here..
+        /// </summary>
+        public static string speechResponderHelpHere {
+            get {
+                return ResourceManager.GetString("speechResponderHelpHere", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Write text copies of speech to the file %APPDATA%\EDDI\speechresponder.out.
         /// </summary>
         public static string subs {
@@ -345,15 +363,6 @@ namespace EddiSpeechResponder.Properties {
         public static string view_script_title {
             get {
                 return ResourceManager.GetString("view_script_title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Scripts which are triggered by an event can be disabled but not deleted..
-        /// </summary>
-        public static string warning_triggered {
-            get {
-                return ResourceManager.GetString("warning_triggered", resourceCulture);
             }
         }
     }

--- a/SpeechResponder/Properties/SpeechResponder.de.resx
+++ b/SpeechResponder/Properties/SpeechResponder.de.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -211,8 +211,5 @@
   </data>
   <data name="view_script_title" xml:space="preserve">
     <value>Script ansehen</value>
-  </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>Scripte, die durch ein Ereignis angestoßen werden, können abgeschaltet aber nicht gelöscht werden.</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.es.resx
+++ b/SpeechResponder/Properties/SpeechResponder.es.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -211,8 +211,5 @@
   </data>
   <data name="view_script_title" xml:space="preserve">
     <value>Ver Script</value>
-  </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>Los scripts que se lanzan con cada evento, pueden ser deshabilitados pero no borrados.</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.fr.resx
+++ b/SpeechResponder/Properties/SpeechResponder.fr.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -211,8 +211,5 @@
   </data>
   <data name="view_script_title" xml:space="preserve">
     <value>Voir Script</value>
-  </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>Les scripts lancés par des événements ne peuvent pas être effacés mais vous pouvez les désactiver.</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.hu.resx
+++ b/SpeechResponder/Properties/SpeechResponder.hu.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -163,9 +163,6 @@
   <data name="delete_script_message" xml:space="preserve">
     <value>Biztos benne, hogy törölni szeretné a "{0}" szkriptet?</value>
   </data>
-  <data name="desc" xml:space="preserve">
-    <value>Szkriptelt beszélt szöveggel rendelkező eseményre való reagálás, az eseményre jellemző információ alapján történik. Alapértelmezetten nincs minden eseménynél szkriptelt reagálás. Ha a szkript üres, akkor a hozzá tartozó 'teszt' és 'megtekintés' gombok le vannak tiltva.</value>
-  </data>
   <data name="edit_script" xml:space="preserve">
     <value>Szerkesztés</value>
   </data>
@@ -211,8 +208,5 @@
   </data>
   <data name="view_script_title" xml:space="preserve">
     <value>Szkript megtekintése</value>
-  </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>Szkriptek amik egy eseményre aktíválódnak. Csak letiltani lehet, törölni nem.</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.ja.resx
+++ b/SpeechResponder/Properties/SpeechResponder.ja.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -211,8 +211,5 @@
   </data>
   <data name="view_script_title" xml:space="preserve">
     <value>スクリプトを表示</value>
-  </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>イベントによってトリガされるスクリプトは無効にできますが、削除はできません。</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -164,7 +164,7 @@
     <value>Are you sure you want to delete the "{0}" script ?</value>
   </data>
   <data name="desc" xml:space="preserve">
-    <value>Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its 'Test' and 'View' buttons are disabled.</value>
+    <value>Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its 'Test' and 'View' buttons are disabled. Event-based scripts can be disabled or re-prioritized but not deleted.</value>
   </data>
   <data name="edit_script" xml:space="preserve">
     <value>Edit</value>
@@ -212,10 +212,13 @@
   <data name="view_script_title" xml:space="preserve">
     <value>View Script</value>
   </data>
-  <data name="warning_triggered" xml:space="preserve">
-    <value>Scripts which are triggered by an event can be disabled but not deleted.</value>
-  </data>
   <data name="header_priority" xml:space="preserve">
     <value>Priority</value>
+  </data>
+  <data name="speechResponderHelp" xml:space="preserve">
+    <value>Read about the speech responder's functions</value>
+  </data>
+  <data name="speechResponderHelpHere" xml:space="preserve">
+    <value>here.</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -215,4 +215,7 @@
   <data name="warning_triggered" xml:space="preserve">
     <value>Scripts which are triggered by an event can be disabled but not deleted.</value>
   </data>
+  <data name="header_priority" xml:space="preserve">
+    <value>Priority</value>
+  </data>
 </root>

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using EddiSpeechService;
+using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace EddiSpeechResponder
@@ -12,7 +14,7 @@ namespace EddiSpeechResponder
         [JsonProperty("enabled")]
         private bool enabled;
         [JsonProperty("priority")]
-        private int priority = 3;
+        public int priority = 3;
         [JsonProperty("responder")]
         private bool responder;
         [JsonProperty("script")]
@@ -69,6 +71,15 @@ namespace EddiSpeechResponder
             get { return script != null; }
         }
 
+        [JsonIgnore]
+        public IList<int> Priorities {
+            get { return priorities; }
+            set { if (priorities != value) { priorities = value; OnPropertyChanged("Priorities"); }; }
+        }
+
+        [JsonIgnore]
+        private IList<int> priorities;
+
         public Script(string name, string description, bool responder, string script, int priority = 3, bool Default = false)
         {
             Name = name;
@@ -78,6 +89,12 @@ namespace EddiSpeechResponder
             Priority = priority;
             Enabled = true;
             this.Default = Default;
+
+            Priorities = new List<int>();
+            for (int i = 1; i <= SpeechService.Instance.speechQueues.Count - 1; i++)
+            {
+                if (i > 0) { Priorities.Add(i); }
+            }
         }
 
         protected void OnPropertyChanged(string name)

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -198,7 +198,6 @@ namespace EddiSpeechResponder
                 }
             }
 
-
             if (statusMonitor?.currentStatus.gui_focus == "fss mode" && statusMonitor?.lastStatus.gui_focus != "fss mode")
             {
                 // Beginning with Elite Dangerous v. 3.3, the primary star scan is delivered via a Scan with 
@@ -256,7 +255,7 @@ namespace EddiSpeechResponder
                 }
                 if (sayOutLoud && !(subtitles && subtitlesOnly))
                 {
-                    SpeechService.Instance.Say(ship, speech, (wait == null ? true : (bool)wait), (priority == null ? resolver.priority(scriptName) : (int)priority), voice);
+                    SpeechService.Instance.Say(ship, speech, (wait == null ? true : (bool)wait), (priority == null ? resolver.priority(scriptName) : (int)priority), voice, false, theEvent?.type);
                 }
             }
         }

--- a/SpeechResponder/SpeechResponderHelp.md
+++ b/SpeechResponder/SpeechResponderHelp.md
@@ -1,0 +1,40 @@
+# Speech responder
+
+The speech responder reponds to events with scripted speech based on the information in the event. Not all events have scripted responses, and if a script response is empty, its 'Test' and 'View' buttons are disabled. The default personality is not editable. 
+
+Speech generated from the speech responder can optionally be written to a file, either in addition to or in place of voiced speech. 
+
+## Personalities
+
+A collection of scripts is called a "Personality". If you would like to make edits from the default personality, please make a copy and assign a new name to your custom personality.
+
+You may also use personalities shared by the community. To use a shared personality, you will need to save a copy of it to EDDI's configuration files, located at: `%appdata%\EDDI\personalities`.
+
+## Scripts
+
+EDDI's speech responder uses Cottle for scripting. Cottle has a number of great features, including:
+
+* Ability to set and update variables, including arrays
+* Loops
+* Conditionals
+* Subroutines
+
+Information on how to write Cottle scripts is available at http://r3c.github.io/cottle/#toc-2, and EDDI's default scripts use a lot of the functions available. EDDI also uses a number of custom functions, documented in-app when editing a script via the `Help` button. 
+
+Variables made available for scripting are in-app when editing a script via the `Variables` button. Standard variables appear at the top of the page. Additional event-specific variables are appended to the bottom of the page for applicable events and are documented in the wiki at https://github.com/EDCD/EDDI/wiki/Events.
+
+The speech responder contains both event-based and non-event-based scripts.
+
+### Event-based scripts
+
+Event-based scripts can be disabled but cannot be deleted. They can also be assigned to differing priorities, as noted below:
+* 1 - high priority, interrupts other speech
+* 2 - high priority
+* 3 - default priority
+* 4 - low priority
+* 5 - low priority, interruptible by any higher priority speech
+
+### Non-event-based scripts 
+
+Non-event-based scripts must be invoked, either by using a function call from another script or via the VoiceAttack plugin. Since they must be invoked they can be deleted but can neither be disabled nor assigned to new priorities. If invoked by another script, they will take on the priority of the invoking script. If invoked from VoiceAttack, they will use the default priority unless a new priority is assigned via the VoiceAttack plugin, as documented in https://github.com/EDCD/EDDI/wiki/VoiceAttack-Integration. 
+

--- a/SpeechService/EddiSpeech.cs
+++ b/SpeechService/EddiSpeech.cs
@@ -1,0 +1,26 @@
+﻿using EddiDataDefinitions;
+
+namespace EddiSpeechService
+{
+    public class EddiSpeech
+    {
+        public string message { get; private set; }
+        public bool wait { get; private set; }
+        public Ship ship { get; private set; }
+        public int priority { get; private set; }
+        public string voice { get; private set; }
+        public bool radio { get; private set; }
+        public string eventType { get; private set; }
+
+        public EddiSpeech(string message, bool wait, Ship ship = null, int priority = 3, string voice = null, bool radio = false, string eventType = null)
+        {
+            this.message = message;
+            this.wait = wait;
+            this.ship = ship;
+            this.priority = priority;
+            this.voice = voice;
+            this.radio = radio;
+            this.eventType = eventType;
+        }
+    }
+}

--- a/SpeechService/EddiSpeechService.csproj
+++ b/SpeechService/EddiSpeechService.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EddiSpeech.cs" />
     <Compile Include="ExtendedDurationWaveSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Phonetics.Designer.cs">

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -761,6 +761,10 @@ namespace EddiSpeechService
             while (speechPriority3.TryDequeue(out EddiSpeech result)) { };
             while (speechPriority4.TryDequeue(out EddiSpeech result)) { };
             while (speechPriority5.TryDequeue(out EddiSpeech result)) { };
+            if (activeSpeechPriority > 0)
+            {
+                StopCurrentSpeech();
+            }
         }
     }
 }

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -24,6 +24,7 @@ namespace EddiSpeechService
     /// <summary>Provide speech services with a varying amount of alterations to the voice</summary>
     public class SpeechService : INotifyPropertyChanged, IDisposable
     {
+        private const float ActiveSpeechFadeOutMilliseconds = 250;
         private SpeechServiceConfiguration configuration;
 
         private static readonly object activeSpeechLock = new object();
@@ -578,6 +579,7 @@ namespace EddiSpeechService
                 if (activeSpeech != null && activeSpeechPriority > 0)
                 {
                     Logging.Debug("Stopping active speech");
+                    FadeOutCurrentSpeech();
                     activeSpeech.Stop();
                     Logging.Debug("Disposing of active speech");
                     activeSpeech.Dispose();
@@ -585,6 +587,16 @@ namespace EddiSpeechService
                     Logging.Debug("Stopped current speech");
                     eddiSpeaking = false;
                 }
+            }
+        }
+
+        public void FadeOutCurrentSpeech()
+        {
+            float fadePer10Milliseconds = (activeSpeech.Volume / ActiveSpeechFadeOutMilliseconds) * 10;
+            while (activeSpeech.Volume > 0)
+            {
+                activeSpeech.Volume -= fadePer10Milliseconds;
+                Thread.Sleep(10);
             }
         }
 

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -592,11 +592,14 @@ namespace EddiSpeechService
 
         public void FadeOutCurrentSpeech()
         {
-            float fadePer10Milliseconds = (activeSpeech.Volume / ActiveSpeechFadeOutMilliseconds) * 10;
-            while (activeSpeech.Volume > 0)
+            if (activeSpeech?.PlaybackState == PlaybackState.Playing)
             {
-                activeSpeech.Volume -= fadePer10Milliseconds;
-                Thread.Sleep(10);
+                float fadePer10Milliseconds = (activeSpeech.Volume / ActiveSpeechFadeOutMilliseconds) * 10;
+                while (activeSpeech.Volume > 0)
+                {
+                    activeSpeech.Volume -= fadePer10Milliseconds;
+                    Thread.Sleep(10);
+                }
             }
         }
 

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -728,8 +728,8 @@ namespace EddiSpeechService
 
         private EddiSpeech checkSpeechPriority (EddiSpeech speech)
         {
-            // Lowest priority is spoken first
-            if (speech.priority < activeSpeechPriority)
+            // Priority 0 speech (system messages) and priority 1 speech and will interrupt current speech
+            if (speech.priority <= 1)
             {
                 Logging.Debug("About to StopCurrentSpeech");
                 StopCurrentSpeech();

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -30,7 +30,7 @@ namespace EddiSpeechService
         private ISoundOut activeSpeech;
         private int activeSpeechPriority;
 
-        protected static List<ConcurrentQueue<EddiSpeech>> speechQueues;
+        public List<ConcurrentQueue<EddiSpeech>> speechQueues { get; private set; }
 
         private static readonly object synthLock = new object();
         public static SpeechSynthesizer synth { get; private set; }
@@ -52,7 +52,7 @@ namespace EddiSpeechService
             }
         }
 
-        private static void PrepareSpeechQueues()
+        private void PrepareSpeechQueues()
         {
             speechQueues = new List<ConcurrentQueue<EddiSpeech>>();
 
@@ -84,7 +84,7 @@ namespace EddiSpeechService
                         {
                             Logging.Debug("No Speech service instance: creating one");
                             instance = new SpeechService();
-                            PrepareSpeechQueues();
+                            instance.PrepareSpeechQueues();
                         }
                     }
                 }

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -98,7 +98,7 @@ namespace UnitTests
         public void TestClearSpeechQueue()
         {
             EddiSpeech speech = new EddiSpeech("Priority 3", true, null, 3);
-            List<ConcurrentQueue<EddiSpeech>> speechQueues = (List<ConcurrentQueue<EddiSpeech>>)speechService.GetFieldOrProperty("speechQueues", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            List<ConcurrentQueue<EddiSpeech>> speechQueues = (List<ConcurrentQueue<EddiSpeech>>)speechService.GetFieldOrProperty("speechQueues");
             Assert.IsTrue(speechQueues.ElementAtOrDefault(speech.priority) != null);
 
             speechQueues[speech.priority].Enqueue(speech);
@@ -116,7 +116,7 @@ namespace UnitTests
             EddiSpeech speech2 = new EddiSpeech("Refueled", true, null, 3, null, false, "Ship refueled");
             EddiSpeech speech3 = new EddiSpeech("Scanned", true, null, 3, null, false, "Body scan");
 
-            List<ConcurrentQueue<EddiSpeech>> speechQueues = (List<ConcurrentQueue<EddiSpeech>>)speechService.GetFieldOrProperty("speechQueues", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            List<ConcurrentQueue<EddiSpeech>> speechQueues = (List<ConcurrentQueue<EddiSpeech>>)speechService.GetFieldOrProperty("speechQueues");
             Assert.IsTrue(speechQueues.ElementAtOrDefault(3) != null);
             speechQueues[speech1.priority].Enqueue(speech1);
             speechQueues[speech2.priority].Enqueue(speech2);

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -112,9 +112,9 @@ namespace UnitTests
         [TestMethod]
         public void TestFilterSpeechQueue()
         {
-            EddiSpeech speech1 = new EddiSpeech("Jumped", true, null, 3, null, false, "FSDJump");
+            EddiSpeech speech1 = new EddiSpeech("Jumped", true, null, 3, null, false, "FSD engaged");
             EddiSpeech speech2 = new EddiSpeech("Refueled", true, null, 3, null, false, "Ship refueled");
-            EddiSpeech speech3 = new EddiSpeech("Scanned", true, null, 3, null, false, "Scan");
+            EddiSpeech speech3 = new EddiSpeech("Scanned", true, null, 3, null, false, "Body scan");
 
             List<ConcurrentQueue<EddiSpeech>> speechQueues = (List<ConcurrentQueue<EddiSpeech>>)speechService.GetFieldOrProperty("speechQueues", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
             Assert.IsTrue(speechQueues.ElementAtOrDefault(3) != null);
@@ -124,12 +124,12 @@ namespace UnitTests
 
             Assert.AreEqual(3, speechQueues[3].Count);
 
-            speechService.Invoke("ClearSpeechOfType", new object[] { "Scan" });
+            speechService.Invoke("ClearSpeechOfType", new object[] { "Body scan" });
 
             Assert.AreEqual(2, speechQueues[3].Count);
             if (speechQueues[3].TryDequeue(out EddiSpeech result1))
             {
-                Assert.AreEqual("FSDJump", result1.eventType);
+                Assert.AreEqual("FSD engaged", result1.eventType);
             }
             if (speechQueues[3].TryDequeue(out EddiSpeech result2))
             {

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EddiSpeechService;
+using CSCore.SoundOut;
+using Rollbar;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class SpeechUnitTests
+    {
+        PrivateObject speechService = new PrivateObject(SpeechService.Instance);
+
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+        }
+
+        [TestMethod]
+        public void TestSpeechPriorityIfInOrder()
+        {
+            EddiSpeech speech1 = new EddiSpeech("Priority 1", true, null, 1);
+            EddiSpeech speech2 = new EddiSpeech("Priority 3", true, null, 3);
+
+            speechService.Invoke("enqueueSpeech", new object[] { speech1 });
+            speechService.Invoke("enqueueSpeech", new object[] { speech2 });
+
+            EddiSpeech result1 = (EddiSpeech)speechService.Invoke("dequeueSpeech", new object[] { });
+            EddiSpeech result2 = (EddiSpeech)speechService.Invoke("dequeueSpeech", new object[] { });
+
+            Assert.IsNotNull(result1);
+            Assert.IsNotNull(result2);
+
+            // Speech should be output in order of priority
+            Assert.AreEqual("Priority 1", result1.message);
+            Assert.AreEqual("Priority 3", result2.message);
+        }
+
+        [TestMethod]
+        public void TestSpeechPriorityIfOutOfOrder()
+        {
+            EddiSpeech speech1 = new EddiSpeech("Priority 3", true, null, 3);
+            EddiSpeech speech2 = new EddiSpeech("Priority 1", true, null, 1);
+
+            speechService.Invoke("enqueueSpeech", new object[] { speech1 });
+            speechService.Invoke("enqueueSpeech", new object[] { speech2 });
+
+            EddiSpeech result1 = (EddiSpeech)speechService.Invoke("dequeueSpeech", new object[] { });
+            EddiSpeech result2 = (EddiSpeech)speechService.Invoke("dequeueSpeech", new object[] { });
+
+            Assert.IsNotNull(result1);
+            Assert.IsNotNull(result2);
+
+            // Speech should be output in order of priority
+            Assert.AreEqual("Priority 1", result1.message);
+            Assert.AreEqual("Priority 3", result2.message);
+        }
+
+        [TestMethod]
+        public void TestActiveSpeechPriority()
+        {
+            EddiSpeech speech1 = new EddiSpeech("Priority 3", true, null, 3);
+            EddiSpeech speech2 = new EddiSpeech("Priority 1", true, null, 1);
+            speechService.SetFieldOrProperty("activeSpeech", (ISoundOut)speechService.Invoke("GetSoundOut", new object[] { }));
+            speechService.SetFieldOrProperty("activeSpeechPriority", speech1.priority);
+
+            Assert.IsNotNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
+            speechService.Invoke("checkSpeechPriority", new object[] { speech2 });
+
+            // If our new speech is more urgent, active speech should be purged to make room for the new speech
+            Assert.IsNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
+        }
+    }
+}

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -60,15 +60,34 @@ namespace UnitTests
         [TestMethod]
         public void TestActiveSpeechPriority()
         {
-            EddiSpeech speech1 = new EddiSpeech("Priority 3", true, null, 3);
-            EddiSpeech speech2 = new EddiSpeech("Priority 1", true, null, 1);
+            EddiSpeech speech1 = new EddiSpeech("Priority 5", true, null, 5);
+            EddiSpeech speech2 = new EddiSpeech("Priority 4", true, null, 4);
+            EddiSpeech speech3 = new EddiSpeech("Priority 2", true, null, 2);
+            EddiSpeech speech4 = new EddiSpeech("Priority 1", true, null, 1);
+
+            // Set up priority 5 speech
             speechService.SetFieldOrProperty("activeSpeech", (ISoundOut)speechService.Invoke("GetSoundOut", new object[] { }));
             speechService.SetFieldOrProperty("activeSpeechPriority", speech1.priority);
-
             Assert.IsNotNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
-            speechService.Invoke("checkSpeechPriority", new object[] { speech2 });
+            Assert.AreEqual(5, (int)speechService.GetFieldOrProperty("activeSpeechPriority"));
 
-            // If our new speech is more urgent, active speech should be purged to make room for the new speech
+            // Check that priority 5 speech IS interrupted by priority 4 speech.
+            speechService.Invoke("checkSpeechInterrupt", new object[] { speech2 });
+            Assert.IsNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
+
+            // Set up priority 4 speech
+            speechService.SetFieldOrProperty("activeSpeech", (ISoundOut)speechService.Invoke("GetSoundOut", new object[] { }));
+            speechService.SetFieldOrProperty("activeSpeechPriority", speech2.priority);
+            Assert.IsNotNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
+            Assert.AreEqual(4, (int)speechService.GetFieldOrProperty("activeSpeechPriority"));
+
+            // Check that priority 4 speech IS NOT interrupted by priority 2 speech.
+            speechService.Invoke("checkSpeechInterrupt", new object[] { speech3 });
+            Assert.IsNotNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
+            Assert.AreEqual(4, (int)speechService.GetFieldOrProperty("activeSpeechPriority"));
+
+            // Check that priority 4 speech IS interrupted by priority 1 speech.
+            speechService.Invoke("checkSpeechInterrupt", new object[] { speech4 });
             Assert.IsNull((ISoundOut)speechService.GetFieldOrProperty("activeSpeech"));
         }
     }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="DataDefinitionTests.cs" />
     <Compile Include="GeneratorTests.cs" />
     <Compile Include="MissionMonitorTests.cs" />
+    <Compile Include="SpeechUnitTests.cs" />
     <Compile Include="StatusMonitorTests.cs" />
     <Compile Include="JournalMonitorTests.cs" />
     <Compile Include="BodyScanTests.cs" />

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -117,20 +117,20 @@ namespace EddiVoiceAttackResponder
                 {
                     vaProxy.WriteToLog("Please shut down VoiceAttack and run EDDI standalone to upgrade", "red");
                     string msg = Properties.VoiceAttack.run_eddi_standalone;
-                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false);
+                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false, 0);
                 }
                 else if (EDDI.Instance.UpgradeAvailable)
                 {
                     vaProxy.WriteToLog("Please shut down VoiceAttack and run EDDI standalone to upgrade", "orange");
                     string msg = Properties.VoiceAttack.run_eddi_standalone;
-                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false);
+                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false, 0);
                 }
 
                 if (EDDI.Instance.Motd != null)
                 {
                     vaProxy.WriteToLog("Message from EDDI: " + EDDI.Instance.Motd, "black");
                     string msg = String.Format(Eddi.Properties.EddiResources.msg_from_eddi, EDDI.Instance.Motd);
-                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false);
+                    SpeechService.Instance.Say(((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip(), msg, false, 0);
                 }
 
                 // Set the initial values from the main EDDI objects

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -762,7 +762,8 @@ namespace EddiVoiceAttackResponder
             try
             {
                 EDDI.Instance.State["speechresponder_quiet"] = true;
-                SpeechService.Instance.ClearAllPendingSpeech();
+                SpeechService.Instance.ClearSpeech();
+                SpeechService.Instance.StopCurrentSpeech();
             }
             catch (Exception e)
             {

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -762,6 +762,7 @@ namespace EddiVoiceAttackResponder
             try
             {
                 EDDI.Instance.State["speechresponder_quiet"] = true;
+                SpeechService.Instance.ClearAllPendingSpeech();
             }
             catch (Exception e)
             {

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -307,7 +307,9 @@ EDDI's VoiceAttack plugin allows you to access its features in your own profile.
 
 ## say
 
-This function uses EDDI's voice to read a script.  The script should be a text variable with the name 'Script'.
+This function uses EDDI's voice to read a script.  
+- The script should be a text variable with the name 'Script'. 
+- The script priority is an optional integer variable with the name 'Priority'.
 
 If you want to use a different voice to the standard one then you can set the name of the voice you want to use in a text variable with the name 'Voice'.  Note that when you set this variable it will continue to be used until you unset it, at which point EDDI will use the voice configured in its text-to-speech settings.
 
@@ -315,7 +317,9 @@ To use this function in your own commands use the 'Execute an external plugin fu
 
 ## speech
 
-This function uses EDDI's voice to read a Speech Responder script.  The name of the script should be a text variable with the name 'Script'.
+This function uses EDDI's voice to read a Speech Responder script.  
+- The name of the script should be a text variable with the name 'Script'.
+- The script priority is an optional integer variable with the name 'Priority'.
 
 If you want to use a different voice to the standard one then you can set the name of the voice you want to use in a text variable with the name 'Voice'.  Note that when you set this variable it will continue to be used until you unset it, at which point EDDI will use the voice configured in its text-to-speech settings.
 


### PR DESCRIPTION
Resolved #1192 and de-couples the speech responder so that it shall longer bottlenecks event processing. Adds the ability to prioritize speech, with priority 1 speech being spoken before priority 2, 2 before 3, etc. Additionally, priority 1 speech will interrupt lower priority speech and priority 5 speech is interruptible by any higher priority speech.