### PR TITLE
Correct VoiceAttack description text to match VoiceAttack's redesigned UI

### DIFF
--- a/VoiceAttackResponder/Properties/VoiceAttack.Designer.cs
+++ b/VoiceAttackResponder/Properties/VoiceAttack.Designer.cs
@@ -97,7 +97,7 @@ namespace EddiVoiceAttackResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Once VoiceAttack is installed you will need to enable plugin support. To do so you must click on the Settings icon (a spanner) in the top-right corner of the VoiceAttack and check the &apos;Enable plugin support&apos; option and restart VoiceAttack. You should see a message in the VoiceAttack window along the lines of &apos;Plugin EDDI 2.0.0 initialized&apos;..
+        ///   Looks up a localized string similar to Once VoiceAttack is installed you will need to enable plugin support. To do so you must click on the Settings icon (a spanner) in the bottom-right corner of the VoiceAttack window and check the &apos;Enable plugin support&apos; option and restart VoiceAttack. You should see a message in the VoiceAttack window along the lines of &apos;Plugin EDDI 2.0.0 initialized&apos;..
         /// </summary>
         public static string p3 {
             get {

--- a/VoiceAttackResponder/Properties/VoiceAttack.resx
+++ b/VoiceAttackResponder/Properties/VoiceAttack.resx
@@ -130,7 +130,7 @@
     <value>EDDI will only work with versions of VoiceAttack 1.5.12.22 and higher. Note that this a beta release.</value>
   </data>
   <data name="p3" xml:space="preserve">
-    <value>Once VoiceAttack is installed you will need to enable plugin support. To do so you must click on the Settings icon (a spanner) in the top-right corner of the VoiceAttack and check the 'Enable plugin support' option and restart VoiceAttack. You should see a message in the VoiceAttack window along the lines of 'Plugin EDDI 2.0.0 initialized'.</value>
+    <value>Once VoiceAttack is installed you will need to enable plugin support. To do so you must click on the Settings icon (a spanner) in the bottom-right corner of the VoiceAttack window and check the 'Enable plugin support' option and restart VoiceAttack. You should see a message in the VoiceAttack window along the lines of 'Plugin EDDI 2.0.0 initialized'.</value>
   </data>
   <data name="p4" xml:space="preserve">
     <value>At this point you can integrate EDDI's variables with your own VoiceAttack scripts. For example, your commander's name is stored in the 'Name' text variable so to access it you just use '{TXT:Name}' in your own commands. There are variables for your commander, your ships, the current star system and station you are at, and more. A full list of variables is available </value>


### PR DESCRIPTION
Note: The Brazilian translation already references correct information and should be preserved in / restored after this merging.