### PR TITLE
Prevent unit tests from writing to permanent storage

### DIFF
--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -276,7 +276,7 @@ namespace EddiShipMonitor
             }
         }
 
-        private void handleCommanderContinuedEvent(CommanderContinuedEvent @event, bool writeConfig = true)
+        private void handleCommanderContinuedEvent(CommanderContinuedEvent @event)
         {
             if (!inFighter(@event.ship) && !inBuggy(@event.ship))
             {
@@ -288,7 +288,7 @@ namespace EddiShipMonitor
                     ship = ShipDefinitions.FromEDModel(@event.ship);
                     ship.LocalId = (int)@event.shipid;
                     ship.Role = Role.MultiPurpose;
-                    AddShip(ship, writeConfig);
+                    AddShip(ship);
                 }
                 setShipName(ship, @event.shipname);
                 setShipIdent(ship, @event.shipident);
@@ -296,11 +296,11 @@ namespace EddiShipMonitor
                 {
                     ship.fueltanktotalcapacity = (decimal?)@event.fuelcapacity;
                 }
-                if (writeConfig) { writeShips(); }                
+                writeShips();                
             }
         }
 
-        private void handleShipPurchasedEvent(ShipPurchasedEvent @event, bool writeConfig = true)
+        private void handleShipPurchasedEvent(ShipPurchasedEvent @event)
         {
             // We don't have a ship ID for the new ship at this point so just handle what we did with our old ship
             if (@event.storedshipid != null)
@@ -312,26 +312,26 @@ namespace EddiShipMonitor
                     // Set location of stored ship to the current system
                     storedShip.starsystem = EDDI.Instance?.CurrentStarSystem?.name;
                     storedShip.station = EDDI.Instance?.CurrentStation?.name;
-                    if (writeConfig) { writeShips(); }
+                    writeShips();
                 }
             }
             else if (@event.soldshipid != null)
             {
                 // We sold a ship - remove it
-                RemoveShip(@event.soldshipid, writeConfig);
+                RemoveShip(@event.soldshipid);
             }
         }
 
-        private void handleShipDeliveredEvent(ShipDeliveredEvent @event, bool writeConfig = true)
+        private void handleShipDeliveredEvent(ShipDeliveredEvent @event)
         {
             // Set this is our current ship
-            SetCurrentShip(@event.shipid, @event.ship, writeConfig);
+            SetCurrentShip(@event.shipid, @event.ship);
         }
 
-        private void handleShipSwappedEvent(ShipSwappedEvent @event, bool writeConfig = true)
+        private void handleShipSwappedEvent(ShipSwappedEvent @event)
         {
             // Update our current ship
-            SetCurrentShip(@event.shipid, @event.ship, writeConfig);
+            SetCurrentShip(@event.shipid, @event.ship);
 
             if (@event.storedshipid != null)
             {
@@ -342,19 +342,18 @@ namespace EddiShipMonitor
                     // Set location of stored ship to the current sstem
                     storedShip.starsystem = EDDI.Instance?.CurrentStarSystem?.name;
                     storedShip.station = EDDI.Instance?.CurrentStation?.name;
-                    if (writeConfig) { writeShips(); }
+                    writeShips();
                 }
             }
             else if (@event.soldshipid != null)
             {
                 // We sold a ship - remove it
-                RemoveShip(@event.soldshipid, writeConfig);
+                RemoveShip(@event.soldshipid);
             }
-
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleShipRenamedEvent(ShipRenamedEvent @event, bool writeConfig = true)
+        private void handleShipRenamedEvent(ShipRenamedEvent @event)
         {
             Ship ship = GetShip(@event.shipid);
             if (ship != null)
@@ -362,20 +361,20 @@ namespace EddiShipMonitor
                 setShipName(ship, @event.name);
                 setShipIdent(ship, @event.ident);
             }
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleShipSoldEvent(ShipSoldEvent @event, bool writeConfig = true)
+        private void handleShipSoldEvent(ShipSoldEvent @event)
         {
-            RemoveShip(@event.shipid, writeConfig);
+            RemoveShip(@event.shipid);
         }
 
-        private void handleShipSoldOnRebuyEvent(ShipSoldOnRebuyEvent @event, bool writeConfig = true)
+        private void handleShipSoldOnRebuyEvent(ShipSoldOnRebuyEvent @event)
         {
-            RemoveShip(@event.shipid, writeConfig);
+            RemoveShip(@event.shipid);
         }
 
-        private void handleShipLoadoutEvent(ShipLoadoutEvent @event, bool writeConfig = true)
+        private void handleShipLoadoutEvent(ShipLoadoutEvent @event)
         {
             if (!inFighter(@event.ship) && !inBuggy(@event.ship))
             {
@@ -384,7 +383,7 @@ namespace EddiShipMonitor
                 // Update the global variable
                 EDDI.Instance.CurrentShip = ship;
 
-                AddShip(ship, writeConfig);
+                AddShip(ship);
             }
         }
 
@@ -510,7 +509,7 @@ namespace EddiShipMonitor
             return ship;
         }
 
-        private void handleStoredShipsEvent(StoredShipsEvent @event, bool writeConfig = true)
+        private void handleStoredShipsEvent(StoredShipsEvent @event)
         {
             if (@event.shipyard != null)
             {
@@ -523,7 +522,7 @@ namespace EddiShipMonitor
                     if (shipInYard == null)
                     {
                         shipInEvent.Role = Role.MultiPurpose;
-                        AddShip(shipInEvent, writeConfig);
+                        AddShip(shipInEvent);
                     }
 
                     // Update ship in the shipyard to latest data
@@ -559,20 +558,20 @@ namespace EddiShipMonitor
                 }
                 _RemoveShips(idsToRemove);
 
-                if (writeConfig) { writeShips(); }
+                writeShips();
             }
         }
 
-        private void handleStoredModulesEvent(StoredModulesEvent @event, bool writeConfig = true)
+        private void handleStoredModulesEvent(StoredModulesEvent @event)
         {
             if (@event.storedmodules != null)
             {
                 storedmodules = @event.storedmodules;
-                if (writeConfig) { writeShips(); }
+                writeShips();
             }
         }
 
-        private void handleShipRebootedEvent(ShipRebootedEvent @event, bool writeConfig = true)
+        private void handleShipRebootedEvent(ShipRebootedEvent @event)
         {
             Ship ship = GetCurrentShip();
             if (ship == null)
@@ -643,74 +642,74 @@ namespace EddiShipMonitor
             }
         }
 
-        private void handleShipAFMURepairedEvent(ShipAfmuRepairedEvent @event, bool writeConfig = true)
+        private void handleShipAFMURepairedEvent(ShipAfmuRepairedEvent @event)
         {
             // This doesn't give us enough information at present to do anything useful
         }
 
-        private void handleShipRepairedEvent(ShipRepairedEvent @event, bool writeConfig = true)
+        private void handleShipRepairedEvent(ShipRepairedEvent @event)
         {
             // This doesn't give us enough information at present to do anything useful
         }
 
-        private void handleShipRepairDroneEvent(ShipRepairDroneEvent @event, bool writeConfig = true)
+        private void handleShipRepairDroneEvent(ShipRepairDroneEvent @event)
         {
             // This doesn't give us enough information at present to do anything useful
         }
 
-        private void handleShipRefuelledEvent(ShipRefuelledEvent @event, bool writeConfig = true)
+        private void handleShipRefuelledEvent(ShipRefuelledEvent @event)
         {
             // We do not keep track of current fuel level so nothing to do here
         }
 
-        private void handleShipRestockedEvent(ShipRestockedEvent @event, bool writeConfig = true)
+        private void handleShipRestockedEvent(ShipRestockedEvent @event)
         {
             // TODO
         }
 
-        private void handleShipRepurchasedEvent(ShipRepurchasedEvent @event, bool writeConfig = true)
+        private void handleShipRepurchasedEvent(ShipRepurchasedEvent @event)
         {
             // We don't do anything here as this is followed by a full ship loadout event
         }
 
-        private void handleModulePurchasedEvent(ModulePurchasedEvent @event, bool writeConfig = true)
+        private void handleModulePurchasedEvent(ModulePurchasedEvent @event)
         {
             Ship ship = GetShip(@event.shipid) ?? @event.shipDefinition;
             ship.LocalId = ship.LocalId == 0 ? (int)@event.shipid : ship.LocalId;
             AddModule(ship, @event.slot, @event.buymodule);
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModuleRetrievedEvent(ModuleRetrievedEvent @event, bool writeConfig = true)
+        private void handleModuleRetrievedEvent(ModuleRetrievedEvent @event)
         {
             Ship ship = GetShip(@event.shipid) ?? @event.shipDefinition;
             ship.LocalId = ship.LocalId == 0 ? (int)@event.shipid : ship.LocalId;
             AddModule(ship, @event.slot, @event.module);
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModuleSoldEvent(ModuleSoldEvent @event, bool writeConfig = true)
+        private void handleModuleSoldEvent(ModuleSoldEvent @event)
         {
             Ship ship = GetShip(@event.shipid) ?? @event.shipDefinition;
             ship.LocalId = ship.LocalId == 0 ? (int)@event.shipid : ship.LocalId;
             RemoveModule(ship, @event.slot);
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModuleSoldFromStorageEvent(ModuleSoldFromStorageEvent @event, bool writeConfig = true)
+        private void handleModuleSoldFromStorageEvent(ModuleSoldFromStorageEvent @event)
         {
             // We don't do anything here as the ship object is unaffected
         }
 
-        private void handleModuleStoredEvent(ModuleStoredEvent @event, bool writeConfig = true)
+        private void handleModuleStoredEvent(ModuleStoredEvent @event)
         {
             Ship ship = GetShip(@event.shipid) ?? @event.shipDefinition;
             ship.LocalId = ship.LocalId == 0 ? (int)@event.shipid : ship.LocalId;
             RemoveModule(ship, @event.slot, @event.replacementmodule);
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModulesStoredEvent(ModulesStoredEvent @event, bool writeConfig = true)
+        private void handleModulesStoredEvent(ModulesStoredEvent @event)
         {
             Ship ship = GetShip(@event.shipid) ?? @event.shipDefinition;
             ship.LocalId = ship.LocalId == 0 ? (int)@event.shipid : ship.LocalId;
@@ -718,10 +717,10 @@ namespace EddiShipMonitor
             {
                 RemoveModule(ship, slot);
             }
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModuleSwappedEvent(ModuleSwappedEvent @event, bool writeConfig = true)
+        private void handleModuleSwappedEvent(ModuleSwappedEvent @event)
         {
             Ship ship = GetShip(@event.shipid);
 
@@ -807,15 +806,15 @@ namespace EddiShipMonitor
                     }
                 }
             }
-            if (writeConfig) { writeShips(); }
+            writeShips();
         }
 
-        private void handleModuleTransferEvent(ModuleTransferEvent @event, bool writeConfig = true)
+        private void handleModuleTransferEvent(ModuleTransferEvent @event)
         {
             // We don't do anything here as the ship object is unaffected
         }
 
-        private void handleModuleInfoEvent(ModuleInfoEvent @event, bool writeConfig = true)
+        private void handleModuleInfoEvent(ModuleInfoEvent @event)
         {
             Ship ship = GetCurrentShip();
             if (ship != null)
@@ -924,12 +923,12 @@ namespace EddiShipMonitor
                             }
                         }
                     }
-                    if (writeConfig) { writeShips(); }
+                    writeShips();
                 }
             }
         }
 
-        private void handleJumpedEvent(JumpedEvent @event, bool writeConfig = true)
+        private void handleJumpedEvent(JumpedEvent @event)
         {
             if (@event.boostused is null)
             {
@@ -938,28 +937,28 @@ namespace EddiShipMonitor
                 {
                     ship.maxfuel = @event.fuelused;
                     ship.maxjump = @event.distance;
-                    if (writeConfig) { writeShips(); }
+                    writeShips();
                 }
             }
         }
 
-        private void handleBountyIncurredEvent(BountyIncurredEvent @event, bool writeConfig = true)
+        private void handleBountyIncurredEvent(BountyIncurredEvent @event)
         {
             Ship ship = GetCurrentShip();
             if (ship != null)
             {
                 ship.hot = true;
-                if (writeConfig) { writeShips(); }
+                writeShips();
             }
         }
 
-        private void handleBountyPaidEvent(BountyPaidEvent @event, bool writeConfig = true)
+        private void handleBountyPaidEvent(BountyPaidEvent @event)
         {
             Ship ship = GetShip(@event.shipid);
             if (ship != null)
             {
                 ship.hot = false;
-                if (writeConfig) { writeShips(); }
+                writeShips();
             }
         }
 
@@ -1094,7 +1093,7 @@ namespace EddiShipMonitor
             }
         }
 
-        private void AddShip(Ship ship, bool writeShip = true)
+        private void AddShip(Ship ship)
         {
             if (ship == null)
             {
@@ -1107,7 +1106,7 @@ namespace EddiShipMonitor
                 ship.Role = Role.MultiPurpose;
             }
             _ReplaceOrAddShip(ship);
-            if (writeShip) { writeShips(); }
+            writeShips();
         }
 
         private void _ReplaceOrAddShip(Ship ship)
@@ -1134,14 +1133,14 @@ namespace EddiShipMonitor
         /// <summary>
         /// Remove a ship from the shipyard
         /// </summary>
-        private void RemoveShip(int? localid, bool writeShip = true)
+        private void RemoveShip(int? localid)
         {
             if (localid == null)
             {
                 return;
             }
             _RemoveShip(localid);
-            if (writeShip) { writeShips(); }
+            writeShips();
         }
 
         /// <summary>
@@ -1211,7 +1210,7 @@ namespace EddiShipMonitor
             return ship;
         }
 
-        public void SetCurrentShip(int? localId, string model = null, bool writeConfig = true)
+        public void SetCurrentShip(int? localId, string model = null)
         {
             lock (shipyardLock)
             {
@@ -1227,7 +1226,7 @@ namespace EddiShipMonitor
                         ship = ShipDefinitions.FromEDModel(model);
                         ship.LocalId = (int)localId;
                         ship.Role = Role.MultiPurpose;
-                        AddShip(ship, writeConfig);
+                        AddShip(ship);
                         currentShipId = ship.LocalId;
                         Logging.Debug("Created ship ID " + localId + ";  " + JsonConvert.SerializeObject(ship));
                     }
@@ -1246,7 +1245,7 @@ namespace EddiShipMonitor
                     ship.station = null;
                     EDDI.Instance.CurrentShip = ship;
                 }
-                if (writeConfig) { writeShips(); }
+                writeShips();
             }
         }
 

--- a/Tests/BodyScanTests.cs
+++ b/Tests/BodyScanTests.cs
@@ -1,26 +1,16 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiEvents;
+﻿using EddiEvents;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
-using Rollbar;
-using System;
-using Eddi;
 
 namespace UnitTests
 {
     [TestClass]
-    public class BodyScanTests
+    public class BodyScanTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/BodyScanTests.cs
+++ b/Tests/BodyScanTests.cs
@@ -1,12 +1,28 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiEvents;
 using System.Collections.Generic;
+using Rollbar;
+using System;
+using Eddi;
 
 namespace UnitTests
 {
     [TestClass]
     public class BodyScanTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestBodyScanDagutiiABC1b()
         {

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -28,6 +28,9 @@ namespace UnitTests
             
             // Set ourselves as in beta to stop sending data to remote systems
             EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.UtcNow, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using Eddi;
-using EddiCargoMonitor;
-using EddiMissionMonitor;
+﻿using EddiCargoMonitor;
 using EddiDataDefinitions;
 using EddiEvents;
 using EddiJournalMonitor;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace UnitTests
 {
     [TestClass]
-    public class CargoMonitorTests
+    public class CargoMonitorTests : TestBase
     {
         CargoMonitor cargoMonitor = new CargoMonitor();
         Cargo cargo;
@@ -23,14 +20,7 @@ namespace UnitTests
         [TestInitialize]
         private void StartTestCargoMonitor()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-            
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.UtcNow, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/CommanderDataTests.cs
+++ b/Tests/CommanderDataTests.cs
@@ -1,30 +1,19 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiCompanionAppService;
+﻿using EddiCompanionAppService;
 using EddiDataDefinitions;
-using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 using EddiShipMonitor;
-using Rollbar;
-using Eddi;
-using EddiEvents;
-using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
-    public class CommanderDataTests
+    public class CommanderDataTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         string data = @"{

--- a/Tests/CommanderDataTests.cs
+++ b/Tests/CommanderDataTests.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using EddiShipMonitor;
 using Rollbar;
+using Eddi;
+using EddiEvents;
+using System;
 
 namespace UnitTests
 {
@@ -16,6 +19,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         string data = @"{

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -1,9 +1,12 @@
-﻿using EddiDataDefinitions;
+﻿using Eddi;
+using EddiDataDefinitions;
+using EddiEvents;
 using EDDNResponder;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Rollbar;
+using System;
 
 namespace UnitTests
 {
@@ -15,6 +18,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/CommodityTests.cs
+++ b/Tests/CommodityTests.cs
@@ -1,29 +1,18 @@
-﻿using Eddi;
-using EddiDataDefinitions;
-using EddiEvents;
+﻿using EddiDataDefinitions;
 using EDDNResponder;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Rollbar;
-using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class CommodityTests
+    public class CommodityTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/CoriolisTests.cs
+++ b/Tests/CoriolisTests.cs
@@ -1,25 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Rollbar;
-using Eddi;
-using EddiEvents;
 
 namespace UnitTests
 {
     [TestClass]
-    public class CoriolisTests
+    public class CoriolisTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/CoriolisTests.cs
+++ b/Tests/CoriolisTests.cs
@@ -1,12 +1,27 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Rollbar;
 using Eddi;
+using EddiEvents;
 
 namespace UnitTests
 {
     [TestClass]
     public class CoriolisTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestUri()
         {

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -1,26 +1,15 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiDataDefinitions;
-using Rollbar;
-using Eddi;
-using EddiEvents;
-using System;
+﻿using EddiDataDefinitions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests
 {
     [TestClass]
-    public class DataDefinitionTests
+    public class DataDefinitionTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiDataDefinitions;
 using Rollbar;
+using Eddi;
+using EddiEvents;
+using System;
 
 namespace UnitTests
 {
@@ -12,6 +15,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/DataProviderTests.cs
+++ b/Tests/DataProviderTests.cs
@@ -3,6 +3,9 @@ using EddiDataDefinitions;
 using EddiDataProviderService;
 using Rollbar;
 using Newtonsoft.Json;
+using Eddi;
+using EddiEvents;
+using System;
 
 namespace UnitTests
 {
@@ -14,6 +17,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/DataProviderTests.cs
+++ b/Tests/DataProviderTests.cs
@@ -1,28 +1,17 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiDataDefinitions;
+﻿using EddiDataDefinitions;
 using EddiDataProviderService;
-using Rollbar;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using Eddi;
-using EddiEvents;
-using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class DataProviderTests
+    public class DataProviderTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/DiffTests.cs
+++ b/Tests/DiffTests.cs
@@ -1,28 +1,17 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using Utilities;
 using static Utilities.Diff;
-using System.Collections.Generic;
-using Rollbar;
-using Eddi;
-using EddiEvents;
-using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class DiffTests
+    public class DiffTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/DiffTests.cs
+++ b/Tests/DiffTests.cs
@@ -2,12 +2,29 @@
 using Utilities;
 using static Utilities.Diff;
 using System.Collections.Generic;
+using Rollbar;
+using Eddi;
+using EddiEvents;
+using System;
 
 namespace UnitTests
 {
     [TestClass]
     public class DiffTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestDiff1()
         {

--- a/Tests/EddiCoreTests.cs
+++ b/Tests/EddiCoreTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Collections.Concurrent;
+using System;
 
 namespace UnitTests
 {
@@ -18,6 +19,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/EddiCoreTests.cs
+++ b/Tests/EddiCoreTests.cs
@@ -1,30 +1,21 @@
 ﻿using Eddi;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
-using EddiJournalMonitor;
 using EddiEvents;
+using EddiJournalMonitor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Collections.Concurrent;
-using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class EddiCoreTests
+    public class EddiCoreTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -1,29 +1,20 @@
-﻿using Eddi;
-using EddiDataDefinitions;
+﻿using EddiDataDefinitions;
 using EddiDataProviderService;
 using EddiEvents;
 using EddiJournalMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
 using System;
 using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
-    public class EddnTests
+    public class EddnTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         class MockStarService : StarSystemRepository

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -1,4 +1,5 @@
-﻿using EddiDataDefinitions;
+﻿using Eddi;
+using EddiDataDefinitions;
 using EddiDataProviderService;
 using EddiEvents;
 using EddiJournalMonitor;
@@ -17,6 +18,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         class MockStarService : StarSystemRepository

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -1,9 +1,12 @@
-﻿using EddiDataDefinitions;
+﻿using Eddi;
+using EddiDataDefinitions;
+using EddiEvents;
 using EddiStarMapService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Rollbar;
+using System;
 using System.Collections.Generic;
 using Utilities;
 
@@ -19,6 +22,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -1,33 +1,21 @@
-﻿using Eddi;
-using EddiDataDefinitions;
-using EddiEvents;
+﻿using EddiDataDefinitions;
 using EddiStarMapService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Rollbar;
-using System;
 using System.Collections.Generic;
-using Utilities;
 
 namespace UnitTests
 {
     // Tests for the EDDB Service
 
     [TestClass]
-    public class EdsmDataTests
+    public class EdsmDataTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -1,30 +1,20 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiDataDefinitions;
+﻿using EddiDataDefinitions;
 using EddiEvents;
 using EddiJournalMonitor;
 using EddiMissionMonitor;
 using EddiShipMonitor;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
-using Rollbar;
-using Eddi;
-using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class JournalMonitorTests
+    public class JournalMonitorTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -6,6 +6,8 @@ using EddiMissionMonitor;
 using EddiShipMonitor;
 using System.Collections.Generic;
 using Rollbar;
+using Eddi;
+using System;
 
 namespace UnitTests
 {
@@ -17,6 +19,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/MaterialMonitorTests.cs
+++ b/Tests/MaterialMonitorTests.cs
@@ -1,29 +1,18 @@
-﻿using Eddi;
-using EddiDataDefinitions;
-using EddiEvents;
+﻿using EddiDataDefinitions;
 using EddiMaterialMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using Rollbar;
-using System;
 using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
-    public class MaterialMonitorTests
+    public class MaterialMonitorTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         string json = @"{

--- a/Tests/MaterialMonitorTests.cs
+++ b/Tests/MaterialMonitorTests.cs
@@ -1,8 +1,11 @@
-﻿using EddiDataDefinitions;
+﻿using Eddi;
+using EddiDataDefinitions;
+using EddiEvents;
 using EddiMaterialMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Rollbar;
+using System;
 using System.Collections.Generic;
 
 namespace UnitTests
@@ -15,6 +18,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         string json = @"{

--- a/Tests/MissionMonitorTests.cs
+++ b/Tests/MissionMonitorTests.cs
@@ -28,6 +28,9 @@ namespace UnitTests
 
             // Set ourselves as in beta to stop sending data to remote systems
             EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/MissionMonitorTests.cs
+++ b/Tests/MissionMonitorTests.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using Eddi;
-using EddiCargoMonitor;
-using EddiMissionMonitor;
-using EddiDataDefinitions;
+﻿using EddiDataDefinitions;
 using EddiEvents;
 using EddiJournalMonitor;
-using System.Linq;
+using EddiMissionMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace UnitTests
 {
     [TestClass]
-    public class MissionMonitorTests
+    public class MissionMonitorTests : TestBase
     {
         MissionMonitor missionMonitor = new MissionMonitor();
         Mission mission;
@@ -23,14 +19,7 @@ namespace UnitTests
         [TestInitialize]
         private void StartTestMissionMonitor()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/PromotionTests.cs
+++ b/Tests/PromotionTests.cs
@@ -3,6 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiEvents;
 using EddiJournalMonitor;
 using Rollbar;
+using Eddi;
+using System;
 
 namespace UnitTests
 {
@@ -14,6 +16,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         private void ParseSampleByName(string sampleName)

--- a/Tests/PromotionTests.cs
+++ b/Tests/PromotionTests.cs
@@ -1,27 +1,17 @@
-﻿using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiEvents;
+﻿using EddiEvents;
 using EddiJournalMonitor;
-using Rollbar;
-using Eddi;
-using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
-    public class PromotionTests
+    public class PromotionTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         private void ParseSampleByName(string sampleName)

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -1,12 +1,9 @@
 ﻿using Cottle.Documents;
 using Cottle.Functions;
 using Cottle.Stores;
-using Eddi;
-using EddiEvents;
 using EddiSpeechResponder;
 using EddiSpeechService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -14,19 +11,12 @@ using System.Text.RegularExpressions;
 namespace UnitTests
 {
     [TestClass]
-    public class ScriptResolverTest
+    public class ScriptResolverTest : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -1,9 +1,12 @@
 ﻿using Cottle.Documents;
 using Cottle.Functions;
 using Cottle.Stores;
+using Eddi;
+using EddiEvents;
 using EddiSpeechResponder;
 using EddiSpeechService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rollbar;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -13,6 +16,19 @@ namespace UnitTests
     [TestClass]
     public class ScriptResolverTest
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestTemplateSimple()
         {

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -24,8 +24,10 @@ namespace UnitTests
             RollbarLocator.RollbarInstance.Config.Enabled = false;
 
             // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.UtcNow, "JournalBeta.txt", "beta", "beta"));
-            Logging.Verbose = true;
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -1,33 +1,24 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System;
+﻿using Eddi;
 using EddiDataDefinitions;
 using EddiEvents;
 using EddiJournalMonitor;
 using EddiShipMonitor;
-using Utilities;
-using Eddi;
-using Rollbar;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using System.Linq;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace UnitTests
 {
     [TestClass]
-    public class ShipTests
+    public class ShipTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -412,7 +412,7 @@ namespace UnitTests
             string data = System.IO.File.ReadAllText("loadout.json");
             List<Event> events = JournalMonitor.ParseJournalEntry(data);
             ShipLoadoutEvent loadoutEvent = events[0] as ShipLoadoutEvent;
-            object[] loadoutArgs = new object[] { loadoutEvent, false };
+            object[] loadoutArgs = new object[] { loadoutEvent };
             privateObject.Invoke("handleShipLoadoutEvent", loadoutArgs);
 
             string data2 = System.IO.File.ReadAllText("fighterLoadout.json");

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -418,7 +418,7 @@ namespace UnitTests
             string data2 = System.IO.File.ReadAllText("fighterLoadout.json");
             events = JournalMonitor.ParseJournalEntry(data2);
             ShipLoadoutEvent fighterLoadoutEvent = events[0] as ShipLoadoutEvent;
-            object[] fighterLoadoutArgs = new object[] { fighterLoadoutEvent, false };
+            object[] fighterLoadoutArgs = new object[] { fighterLoadoutEvent };
             privateObject.Invoke("handleShipLoadoutEvent", fighterLoadoutArgs);
 
             // After a loadout event generated from a fighter, 

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -1,30 +1,28 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiVoiceAttackResponder;
-using System.Collections.Generic;
-using System.Speech.Synthesis;
-using System.IO;
-using System.Threading;
-using EddiSpeechResponder;
-using EddiSpeechService;
-using CSCore;
+﻿using CSCore;
 using CSCore.Codecs.WAV;
 using CSCore.SoundOut;
 using CSCore.Streams.Effects;
-using EddiDataDefinitions;
-using Utilities;
 using Eddi;
-using Rollbar;
+using EddiDataDefinitions;
+using EddiSpeechResponder;
+using EddiSpeechService;
+using EddiVoiceAttackResponder;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using System.Speech.Synthesis;
+using System.Threading;
+using Utilities;
 
 namespace SpeechTests
 {
     [TestClass]
-    public class SpeechTests
+    public class SpeechTests : UnitTests.TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
+            MakeSafe();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfectly correct    

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -13,12 +13,20 @@ using CSCore.Streams.Effects;
 using EddiDataDefinitions;
 using Utilities;
 using Eddi;
+using Rollbar;
 
 namespace SpeechTests
 {
     [TestClass]
     public class SpeechTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+        }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfectly correct    
         [TestMethod, TestCategory("Speech")]
         public void TestPhonemes()

--- a/Tests/StatusMonitorTests.cs
+++ b/Tests/StatusMonitorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Eddi;
 using EddiDataDefinitions;
+using EddiEvents;
 using EddiStatusMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Rollbar;
@@ -15,6 +16,12 @@ namespace UnitTests
         {
             // Prevent telemetry data from being reported based on test results
             RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
         }
 
         [TestMethod]

--- a/Tests/StatusMonitorTests.cs
+++ b/Tests/StatusMonitorTests.cs
@@ -1,27 +1,18 @@
 ﻿using Eddi;
 using EddiDataDefinitions;
-using EddiEvents;
 using EddiStatusMonitor;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
 using System;
 
 namespace UnitTests
 {
     [TestClass]
-    public class StatusMonitorTests
+    public class StatusMonitorTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/TestBase.cs
+++ b/Tests/TestBase.cs
@@ -1,0 +1,22 @@
+﻿using Eddi;
+using EddiEvents;
+using Rollbar;
+using System;
+
+namespace UnitTests
+{
+    public class TestBase
+    {
+        internal void MakeSafe()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -133,6 +133,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="TestBase.cs" />
     <Compile Include="EdsmDataTests.cs" />
     <Compile Include="CommodityTests.cs" />
     <Compile Include="DiffTests.cs" />

--- a/Tests/TranslationTests.cs
+++ b/Tests/TranslationTests.cs
@@ -1,26 +1,15 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiSpeechService;
-using Rollbar;
-using Eddi;
-using EddiEvents;
-using System;
+﻿using EddiSpeechService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace UnitTests
 {
     [TestClass]
-    public class TranslationTests
+    public class TranslationTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/TranslationTests.cs
+++ b/Tests/TranslationTests.cs
@@ -1,11 +1,28 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using EddiSpeechService;
+using Rollbar;
+using Eddi;
+using EddiEvents;
+using System;
 
 namespace UnitTests
 {
     [TestClass]
     public class TranslationTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestICAOEmpty()
         {

--- a/Tests/VersioningTests.cs
+++ b/Tests/VersioningTests.cs
@@ -1,17 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Rollbar;
 using Utilities;
 
 namespace UnitTests
 {
     [TestClass]
-    public class VersioningTests
+    public class VersioningTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/VersioningTests.cs
+++ b/Tests/VersioningTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Rollbar;
 using Utilities;
 
 namespace UnitTests
@@ -6,6 +7,13 @@ namespace UnitTests
     [TestClass]
     public class VersioningTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+        }
+
         [TestMethod]
         public void TestBetaVersionToString()
         {

--- a/Tests/VoiceAttackPluginTests.cs
+++ b/Tests/VoiceAttackPluginTests.cs
@@ -1,31 +1,21 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using EddiSpeechService;
-using System.Collections.Generic;
-using System;
-using EddiDataDefinitions;
+﻿using EddiDataDefinitions;
 using EddiDataProviderService;
+using EddiSpeechService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using Rollbar;
-using Eddi;
-using EddiEvents;
+using System;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
     [TestClass]
     [DeploymentItem(@"x86\SQLite.Interop.dll", "x86")]
-    public class VoiceAttackPluginTests
+    public class VoiceAttackPluginTests : TestBase
     {
         [TestInitialize]
         public void start()
         {
-            // Prevent telemetry data from being reported based on test results
-            RollbarLocator.RollbarInstance.Config.Enabled = false;
-
-            // Set ourselves as in beta to stop sending data to remote systems
-            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
-
-            // Don't write to permanent storage
-            Utilities.Files.unitTesting = true;
+            MakeSafe();
         }
 
         [TestMethod]

--- a/Tests/VoiceAttackPluginTests.cs
+++ b/Tests/VoiceAttackPluginTests.cs
@@ -5,6 +5,9 @@ using System;
 using EddiDataDefinitions;
 using EddiDataProviderService;
 using Newtonsoft.Json;
+using Rollbar;
+using Eddi;
+using EddiEvents;
 
 namespace UnitTests
 {
@@ -12,6 +15,19 @@ namespace UnitTests
     [DeploymentItem(@"x86\SQLite.Interop.dll", "x86")]
     public class VoiceAttackPluginTests
     {
+        [TestInitialize]
+        public void start()
+        {
+            // Prevent telemetry data from being reported based on test results
+            RollbarLocator.RollbarInstance.Config.Enabled = false;
+
+            // Set ourselves as in beta to stop sending data to remote systems
+            EDDI.Instance.enqueueEvent(new FileHeaderEvent(DateTime.Now, "JournalBeta.txt", "beta", "beta"));
+
+            // Don't write to permanent storage
+            Utilities.Files.unitTesting = true;
+        }
+
         [TestMethod]
         public void TestOutfittingCosts()
         {

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -9,7 +9,11 @@ namespace Utilities
 {
     public class Files
     {
+        /// <summary> Ignore missing config files on first launch? </summary>
         public static bool ignoreMissing { get; set; } = false;
+
+        /// <summary> If true, skips writing to permanent storage </summary>
+        public static bool unitTesting { get; set; } = false;
 
         /// <summary>
         /// Read a file, handling exceptions
@@ -77,6 +81,13 @@ namespace Utilities
         {
             if (name != null && content != null)
             {
+                // Skip writing to storage if we're unit testing
+                if (unitTesting)
+                {
+                    Logging.Debug("Skipping write to " + name + " during unit test");
+                    return;
+                }
+
                 // Attempt to write the file
                 try
                 {


### PR DESCRIPTION
Works for all methods where tests files are written via the `Files.Write` method in `Utilities.cs` and where the test initializer sets the `Files.cs` static bool to true. 