### PR TITLE
Feature/redact env vars

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -251,7 +251,7 @@ namespace EddiSpeechService
             }
             catch (ThreadAbortException tax)
             {
-                Logging.Error(tax);
+                Logging.Error("", tax);
                 Thread.ResetAbort();
             }
         }

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -228,9 +228,11 @@ namespace EddiSpeechService
                         }
                     }
                 }
-                catch (ThreadAbortException)
+                catch (ThreadAbortException tax)
                 {
-                    Logging.Debug("Thread aborted");
+                    Logging.Error("", tax);
+                    Thread.ResetAbort();
+
                 }
                 catch (Exception ex)
                 {

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -298,7 +298,7 @@ namespace EddiStatusMonitor
             catch (Exception ex)
             {
                 Logging.Warn("Failed to parse Status.json line: " + ex.ToString());
-                Logging.Error(ex);
+                Logging.Error("", ex);
             }
             return status = null;
         }

--- a/Tests/RedactionTests.cs
+++ b/Tests/RedactionTests.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace UnitTests
 {
@@ -16,5 +12,13 @@ namespace UnitTests
             MakeSafe();
         }
 
+        [TestMethod]
+        public void TestAppdataRedaction()
+        {
+            string source = @"%APPDATA%\EDDI\eddi.json";
+            string rawPath = Environment.ExpandEnvironmentVariables(source);
+            string redacted = Utilities.Redaction.RedactEnvironmentVariables(rawPath);
+            Assert.AreEqual(source, redacted);
+        }
     }
 }

--- a/Tests/RedactionTests.cs
+++ b/Tests/RedactionTests.cs
@@ -6,19 +6,47 @@ namespace UnitTests
     [TestClass]
     public class RedactionTests : TestBase
     {
-        [TestInitialize]
-        public void start()
+        private void TestRoundTrip(string source)
         {
-            MakeSafe();
+            string rawPath = source != null ? Environment.ExpandEnvironmentVariables(source) : null;
+            string redacted = Utilities.Redaction.RedactEnvironmentVariables(rawPath);
+            string expected = source?.Replace("%TMP%", "%TEMP%"); // these are exact synonyms and we normalise on %TEMP%
+            Assert.AreEqual(expected, redacted);
+        }
+
+        [TestMethod]
+        public void TestNullRedaction()
+        {
+            string source = null;
+            TestRoundTrip(source);
+        }
+
+        [TestMethod]
+        public void TestEmptyRedaction()
+        {
+            string source = "";
+            TestRoundTrip(source);
         }
 
         [TestMethod]
         public void TestAppdataRedaction()
         {
             string source = @"%APPDATA%\EDDI\eddi.json";
-            string rawPath = Environment.ExpandEnvironmentVariables(source);
-            string redacted = Utilities.Redaction.RedactEnvironmentVariables(rawPath);
-            Assert.AreEqual(source, redacted);
+            TestRoundTrip(source);
+        }
+
+        [TestMethod]
+        public void TestLocalappdataRedaction()
+        {
+            string source = @"%LOCALAPPDATA%\EDDI\eddi.json";
+            TestRoundTrip(source);
+        }
+
+        [TestMethod]
+        public void TestMedleyRedaction()
+        {
+            string source = @"ice cream %USERNAME% foo %TMP% bar %TEMP% baz %APPDATA% quux %USERNAME% womble";
+            TestRoundTrip(source);
         }
     }
 }

--- a/Tests/RedactionTests.cs
+++ b/Tests/RedactionTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class RedactionTests : TestBase
+    {
+        [TestInitialize]
+        public void start()
+        {
+            MakeSafe();
+        }
+
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -133,6 +133,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="RedactionTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="EdsmDataTests.cs" />
     <Compile Include="CommodityTests.cs" />

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -11,16 +11,9 @@ namespace Utilities
     public partial class Logging // convenience methods
     {
         public static void Error(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Error(message, ex.ToString(), memberName, filePath);
-        public static void Error(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Error(ex.Message, ex.ToString(), memberName, filePath);
-
         public static void Warn(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Warn(message, ex.ToString(), memberName, filePath);
-        public static void Warn(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Warn(ex.Message, ex.ToString(), memberName, filePath);
-
         public static void Info(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Info(message, ex.ToString(), memberName, filePath);
-        public static void Info(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Info(ex.Message, ex.ToString(), memberName, filePath);
-
         public static void Debug(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Debug(message, ex.ToString(), memberName, filePath);
-        public static void Debug(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Debug(ex.ToString(), memberName, filePath);
     }
 
     public partial class Logging: _Rollbar

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -48,6 +48,9 @@ namespace Utilities
         private static readonly object logLock = new object();
         private static void log(ErrorLevel errorlevel, string data, string method, string path)
         {
+            data = Redaction.RedactEnvironmentVariables(data);
+            method = Redaction.RedactEnvironmentVariables(method);
+            path = Redaction.RedactEnvironmentVariables(path);
             lock (logLock)
             {
                 try
@@ -107,74 +110,22 @@ namespace Utilities
             }
         }
 
-        internal static void Report(ErrorLevel errorLevel, string message, object data = null, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
+        private static void Report(ErrorLevel errorLevel, string message, string data, string memberName, string filePath)
         {
-            Dictionary<string, object> thisData = PrepRollbarData(message, ref data);
-            if (thisData != null)
-            {
-                var rollbarReport = System.Threading.Tasks.Task.Run(() => SendToRollbar(errorLevel, message, data, thisData, memberName, filePath));
-            }
+            message = Redaction.RedactEnvironmentVariables(message);
+            data = Redaction.RedactEnvironmentVariables(data);
+            filePath = Redaction.RedactEnvironmentVariables(filePath);
+            var rollbarReport = System.Threading.Tasks.Task.Run(() => SendToRollbar(errorLevel, message, data, memberName, filePath));
         }
 
-        private static Dictionary<string, object> PrepRollbarData(string message, ref object data)
-        {
-            try
-            {
-                // It's not possible to scrub filepaths from exception messages, so since we don't want  
-                // to collect this personal data these exceptions need to be handled locally only.
-                if (data is Exception ex)
-                {
-                    if (ex.Message.Contains(Constants.DATA_DIR))
-                    {
-                        return null;
-                    }
-                }
-                else if (!(data is Dictionary<string, object>))
-                {
-                    var wrappedData = new Dictionary<string, object>()
-                    {
-                        {"data", data}
-                    };
-                    data = wrappedData;
-                }
-
-                // The Frontier API uses lowercase keys while the journal uses Titlecased keys. Establish case insensitivity before we proceed.
-                Dictionary<string, object> thisData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-                thisData = (Dictionary<string, object>)data;
-
-                // Repeated data should be matched even if timestamps differ, so remove journal event timestamps here.
-                thisData.Remove("timestamp");
-
-                // Strip module data that is not useful to report for more consistent matching
-                thisData.Remove("on");
-                thisData.Remove("priority");
-                thisData.Remove("health");
-
-                // Strip commodity data that is not useful to report for more consistent matching
-                thisData.Remove("buyprice");
-                thisData.Remove("stock");
-                thisData.Remove("stockbracket");
-                thisData.Remove("sellprice");
-                thisData.Remove("demand");
-                thisData.Remove("demandbracket");
-                thisData.Remove("StatusFlags");
-                return thisData;
-            }
-            catch (Exception)
-            {
-                // Return null and don't send data to Rollbar
-                return null;
-            }
-
-        }
-
-        private static void SendToRollbar(ErrorLevel errorLevel, string message, object data, Dictionary<string, object> thisData, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
+        private static void SendToRollbar(ErrorLevel errorLevel, string message, string data, string memberName, string filePath)
         {
             if (RollbarLocator.RollbarInstance.Config.Enabled != false)
             {
                 string personID = RollbarLocator.RollbarInstance.Config.Person?.Id;
                 if (personID.Length > 0)
                 {
+                    var thisData = new Dictionary<string, object>(){ ["data"] = "data" };
                     switch (errorLevel)
                     {
                         case ErrorLevel.Error:

--- a/Utilities/Logging.cs
+++ b/Utilities/Logging.cs
@@ -8,20 +8,25 @@ using System.Runtime.CompilerServices;
 
 namespace Utilities
 {
-    public class Logging: _Rollbar
+    public partial class Logging // convenience methods
+    {
+        public static void Error(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Error(message, ex.ToString(), memberName, filePath);
+        public static void Error(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Error(ex.Message, ex.ToString(), memberName, filePath);
+
+        public static void Warn(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Warn(message, ex.ToString(), memberName, filePath);
+        public static void Warn(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Warn(ex.Message, ex.ToString(), memberName, filePath);
+
+        public static void Info(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Info(message, ex.ToString(), memberName, filePath);
+        public static void Info(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Info(ex.Message, ex.ToString(), memberName, filePath);
+
+        public static void Debug(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Debug(message, ex.ToString(), memberName, filePath);
+        public static void Debug(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "") => Debug(ex.ToString(), memberName, filePath);
+    }
+
+    public partial class Logging: _Rollbar
     {
         public static readonly string LogFile = Constants.DATA_DIR + @"\eddi.log";
         public static bool Verbose { get; set; } = false;
-
-        public static void Error(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Error(message, ex.ToString(), memberName, filePath);
-        }
-
-        public static void Error(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Error(ex.Message, ex.ToString(), memberName, filePath);
-        }
 
         public static void Error(string message, string data = "", [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
@@ -29,50 +34,14 @@ namespace Utilities
             Report(ErrorLevel.Error, message, data, memberName, filePath);
         }
 
-        public static void Warn(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Warn(message, ex.ToString(), memberName, filePath);
-        }
-
-        public static void Warn(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Warn(ex.Message, ex.ToString(), memberName, filePath);
-        }
-
         public static void Warn(string message, string data = "", [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
             log(ErrorLevel.Warning, message + " " + data, memberName, filePath);
         }
 
-        public static void Info(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Info(message, ex.ToString(), memberName, filePath);
-        }
-
-        public static void Info(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            Info(ex.Message, ex.ToString(), memberName, filePath);
-        }
-
         public static void Info(string message, string data = "", [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
         {
             log(ErrorLevel.Info, message + " " + data, memberName, filePath);
-        }
-
-        public static void Debug(string message, Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            if (Verbose)
-            {
-                Debug(message, ex.ToString(), memberName, filePath);
-            }
-        }
-
-        public static void Debug(Exception ex, [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")
-        {
-            if (Verbose)
-            {
-                Debug(ex.ToString(), memberName, filePath);
-            }
         }
 
         public static void Debug(string message, string data = "", [CallerMemberName] string memberName = "", [CallerFilePath] string filePath = "")

--- a/Utilities/Redaction.cs
+++ b/Utilities/Redaction.cs
@@ -1,16 +1,35 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Utilities
 {
     public class Redaction
     {
+        /// <summary>Removes potentially personally identifying data by replacing expanded environment variables with their percent-quoted names.</summary>
         public static string RedactEnvironmentVariables(string rawString)
         {
-            return RedactEnvironmentVariable(rawString, "APPDATA");
+            // The order here is important: we should redact the longest strings first
+            List<string> envVarsToRedact = new List<string>()
+            {
+                "APPDATA",
+                "LOCALAPPDATA",
+                "TEMP",
+                "TMP",
+                "USERPROFILE",
+                "HOMEPATH",
+                "USERNAME",
+            };
+            string result = envVarsToRedact.Aggregate(rawString, RedactEnvironmentVariable);
+            return result;
         }
 
         internal static string RedactEnvironmentVariable(string rawString, string envVar)
         {
+            if (String.IsNullOrEmpty(rawString))
+            {
+                return rawString;
+            }
             string envVarExpansion = Environment.GetEnvironmentVariable(envVar);
             string redacted = rawString.Replace(envVarExpansion, $"%{envVar}%");
             return redacted;

--- a/Utilities/Redaction.cs
+++ b/Utilities/Redaction.cs
@@ -1,12 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Utilities
 {
     public class Redaction
     {
+        public static string RedactEnvironmentVariables(string rawString)
+        {
+            return RedactEnvironmentVariable(rawString, "APPDATA");
+        }
+
+        internal static string RedactEnvironmentVariable(string rawString, string envVar)
+        {
+            string envVarExpansion = Environment.GetEnvironmentVariable(envVar);
+            string redacted = rawString.Replace(envVarExpansion, $"%{envVar}%");
+            return redacted;
+        }
     }
 }

--- a/Utilities/Redaction.cs
+++ b/Utilities/Redaction.cs
@@ -9,9 +9,11 @@ namespace Utilities
         /// <summary>Removes potentially personally identifying data by replacing expanded environment variables with their percent-quoted names.</summary>
         public static string RedactEnvironmentVariables(string rawString)
         {
-            // The order here is important: we should redact the longest strings first
+            // The order here is important: we should redact the most specific strings first
             List<string> envVarsToRedact = new List<string>()
             {
+                "TEMP",
+                "TMP",
                 "APPDATA",
                 "LOCALAPPDATA",
                 "TEMP",

--- a/Utilities/Redaction.cs
+++ b/Utilities/Redaction.cs
@@ -16,8 +16,6 @@ namespace Utilities
                 "TMP",
                 "APPDATA",
                 "LOCALAPPDATA",
-                "TEMP",
-                "TMP",
                 "USERPROFILE",
                 "HOMEPATH",
                 "USERNAME",

--- a/Utilities/Redaction.cs
+++ b/Utilities/Redaction.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Utilities
+{
+    public class Redaction
+    {
+    }
+}

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -98,6 +98,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Utilities.resx</DependentUpon>
     </Compile>
+    <Compile Include="Redaction.cs" />
     <Compile Include="Translation.cs" />
     <Compile Include="ServerInfo.cs" />
     <Compile Include="Versioning.cs" />


### PR DESCRIPTION
Removes all potentially personally identifying info from logs and Rollbar reports by substituting percent-quoted environment variable names.

* Test class calls only pure functions so doesn't need the overhead of calling `MakeSafe()`.
* Redacts the following, including repeated calls:
    * APPDATA
    * LOCALAPPDATA
    * TEMP
    * TMP
    * USERPROFILE
    * HOMEPATH
    * USERNAME
* Cleans up the `Logging` API and separates out the convenience calls, making the core code easier to grasp.
