### PR TITLE
Fixed EDSM sphere & cube queries

### DIFF
--- a/DataProviderService/StarSystemRepository.cs
+++ b/DataProviderService/StarSystemRepository.cs
@@ -6,14 +6,14 @@ namespace EddiDataProviderService
     public interface StarSystemRepository
     {
         StarSystem GetStarSystem(string name, bool refreshIfOutdated = true);
-        StarSystem GetOrCreateStarSystem(string name, bool refreshIfOutdated = true);
-        StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true);
+        StarSystem GetOrCreateStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true);
+        StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true);
         void SaveStarSystem(StarSystem starSystem);
         void LeaveStarSystem(StarSystem starSystem);
 
         List<StarSystem> GetStarSystems(string[] names, bool refreshIfOutdated = true);
-        List<StarSystem> GetOrCreateStarSystems(string[] names, bool refreshIfOutdated = true);
-        List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true);
+        List<StarSystem> GetOrCreateStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true);
+        List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true);
         void SaveStarSystems(List<StarSystem> starSystems);
     }
 }

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -80,18 +80,18 @@ namespace EddiDataProviderService
             }
         }
 
-        public StarSystem GetOrCreateStarSystem(string name, bool fetchIfMissing = true)
+        public StarSystem GetOrCreateStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetOrCreateStarSystems(new string[] { name }).FirstOrDefault();
+            return GetOrCreateStarSystems(new string[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
         }
 
-        public List<StarSystem> GetOrCreateStarSystems(string[] names, bool fetchIfMissing = true)
+        public List<StarSystem> GetOrCreateStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (names.Count() == 0) { return null; }
 
             // Get (and update if required) systems already in our database
-            List<StarSystem> systems = Instance.GetStarSystems(names, fetchIfMissing);
+            List<StarSystem> systems = Instance.GetStarSystems(names, refreshIfOutdated);
 
             // If a system isn't found after we've read our local database, we need to fetch it.
             List<string> fetchSystems = new List<string>();
@@ -121,17 +121,17 @@ namespace EddiDataProviderService
             return systems;
         }
 
-        public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true)
+        public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetOrFetchStarSystems(new string[] { name }).FirstOrDefault();
+            return GetOrFetchStarSystems(new string[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
         }
 
-        public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true)
+        public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (names.Count() == 0) { return null; }
 
-            List<StarSystem> systems = Instance.GetStarSystems(names, fetchIfMissing);
+            List<StarSystem> systems = Instance.GetStarSystems(names, refreshIfOutdated);
             List<string> fetchSystems = new List<string>();
 
             // If a system isn't found after we've read our local database, we need to fetch it.
@@ -156,7 +156,7 @@ namespace EddiDataProviderService
         public StarSystem GetStarSystem(string name, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetStarSystems(new string[] { name }).FirstOrDefault();
+            return GetStarSystems(new string[] { name }, refreshIfOutdated).FirstOrDefault();
         }
 
         public List<StarSystem> GetStarSystems(string[] names, bool refreshIfOutdated = true)

--- a/StarMapService/EdsmSystemData.cs
+++ b/StarMapService/EdsmSystemData.cs
@@ -82,18 +82,18 @@ namespace EddiStarMapService
             request.AddParameter("showCoordinates", showCoordinates ? 1 : 0);
             request.AddParameter("showInformation", showInformation ? 1 : 0);
             request.AddParameter("showPermit", showPermit ? 1 : 0);
-            var clientResponse = client.Execute<JObject>(request);
+            var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = JObject.Parse(clientResponse.Content).ToObject<JArray>();
+                JArray responses = JArray.Parse(clientResponse.Content);
                 List<Dictionary<string, object>> distantSystems = new List<Dictionary<string, object>>();
                 foreach (JObject response in responses)
                 {
                     Dictionary<string, object> distantSystem = new Dictionary<string, object>()
-                {
-                    { "distance", (decimal)response["distance"] },
-                    { "system", ParseStarMapSystem(response, (string)response["name"]) }
-                };
+                    {
+                        { "distance", (decimal)response["distance"] },
+                        { "system", ParseStarMapSystem(response, (string)response["name"]) }
+                    };
                     distantSystems.Add(distantSystem);
                 }
                 return distantSystems;
@@ -117,10 +117,10 @@ namespace EddiStarMapService
             request.AddParameter("showCoordinates", showCoordinates ? 1 : 0);
             request.AddParameter("showInformation", showInformation ? 1 : 0);
             request.AddParameter("showPermit", showPermit ? 1 : 0);
-            var clientResponse = client.Execute<JArray>(request);
+            var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = clientResponse.Data;
+                JArray responses = JArray.Parse(clientResponse.Content);
                 List<StarSystem> starSystems = new List<StarSystem>();
                 foreach (JObject response in responses)
                 {

--- a/Tests/EddnTests.cs
+++ b/Tests/EddnTests.cs
@@ -19,22 +19,22 @@ namespace UnitTests
 
         class MockStarService : StarSystemRepository
         {
-            public StarSystem GetOrCreateStarSystem(string name, bool refreshIfOutdated = true)
+            public StarSystem GetOrCreateStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
             {
                 return GetStarSystem(name, refreshIfOutdated);
             }
 
-            public List<StarSystem> GetOrCreateStarSystems(string[] names, bool refreshIfOutdated = true)
+            public List<StarSystem> GetOrCreateStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
             {
                 throw new NotImplementedException();
             }
 
-            public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true)
+            public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
             {
                 return GetStarSystem(name, fetchIfMissing);
             }
 
-            public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true)
+            public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
             {
                 throw new NotImplementedException();
             }

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -358,6 +358,22 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestSystemsSphere()
+        {
+            string systemName = "Sol";
+            List<Dictionary<string, object>> sphereSystems = StarMapService.GetStarMapSystemsSphere(systemName, 0, 10, false, false, false, false);
+            Assert.AreEqual(12, sphereSystems.Count);
+        }
+
+        [TestMethod]
+        public void TestSystemsCube()
+        {
+            string systemName = "Sol";
+            List<StarSystem> starSystems = StarMapService.GetStarMapSystemsCube(systemName, 15, false, false, false, false);
+            Assert.AreEqual(9, starSystems.Count);
+        }
+
+        [TestMethod]
         public void TestUnknown()
         {
             // Unknown systems shall return null from here. We create a synthetic system in DataProviderService.cs if this returns null;


### PR DESCRIPTION
- Fixed EDSM Sphere and Cube systems queries. Added unit tests.
- Added `refreshIfOutdated` option (defaulted to `True`) to `GetOrCreateStarSystems` and `GetOrFetchStarSystems` to minimize EDSM system(s) queries when only static data is required.