### PR TITLE
Fix missing fileheader events

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### Development
+  * Journal monitor
+    * Fixed a bug that would prevent new file header events from registering when Elite Dangerous was restarted with EDDI running.
+
 ### 3.3.7-b1
   * Core
     * Fixed a bug whereby names of materials (Carbon, Iron, Conductive Components, etc) were not always localized.

--- a/JournalMonitor/LogMonitor.cs
+++ b/JournalMonitor/LogMonitor.cs
@@ -60,6 +60,7 @@ namespace EddiJournalMonitor
                 else if (fileInfo?.Name != null && fileInfo?.Name != journalFileName)
                 {
                     // We have found a player journal file that is fresher than the one we are using
+                    bool isFirstLoad = journalFileName == null;
                     journalFileName = fileInfo.Name;
                     lastSize = fileInfo.Length;
 
@@ -68,12 +69,12 @@ namespace EddiJournalMonitor
                         // Read everything in the file into the journal monitor
                         long seekPos = 0;
                         int readLen = (int)fileInfo.Length;
-                        Read(seekPos, readLen, fileInfo, true);
+                        Read(seekPos, readLen, fileInfo, isFirstLoad);
                     }
                     else
                     {
                         // Read the header and latest loaded game into the journal monitor
-                        ReadLastCommanderLoad(fileInfo, true);
+                        ReadLastCommanderLoad(fileInfo, isFirstLoad);
                     }
                 }
                 else


### PR DESCRIPTION
Fixes missing events when we load a new session of Elite Dangerous with EDDI already running.
Resolves #1233.