### PR TITLE
System Selection Tweak

### DIFF
--- a/EDDI/StarSystemComboBox.cs
+++ b/EDDI/StarSystemComboBox.cs
@@ -41,20 +41,13 @@ namespace Eddi
                     cmbTextBox.CaretIndex = Text.Length;
                 }
             }
-            else if (systemName.Length == 1)
-            {
-                systemList = SystemsBeginningWith(systemName);
-                IsDropDownOpen = false;
-                ItemsSource = null;
-                SelectedIndex = -1;
-                return;
-            }
             else
             {
                 if (ItemsSource != null)
                 {
                     IsDropDownOpen = false;
                     ItemsSource = null;
+                    SelectedIndex = -1;
                 }
             }
 


### PR DESCRIPTION
Do not query EDSM with 'partial' < 2 chars