### PR TITLE
Fix exception generated when Galnet feed item content is null.

### DIFF
--- a/GalnetMonitor/GalnetMonitor.cs
+++ b/GalnetMonitor/GalnetMonitor.cs
@@ -158,27 +158,28 @@ namespace GalnetMonitor
                     locales.TryGetValue(configuration.language, out locale);
                     string url = GetGalnetResource("sourceURL");
                     altURL = false;
-                    try
-                    {
-                        WebRequest request = WebRequest.Create(url);
-                        HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                    }
-                    catch (WebException wex)
-                    {
-                        Logging.Warn("Exception contacting primary galnet feed, trying alternate: ", wex.Message);
-                        url = GetGalnetResource("alternateURL");
-                        altURL = true;
-                    }
+
                     Logging.Debug("Fetching Galnet articles from " + url);
+                    FeedReader feedReader = new FeedReader(new GalnetFeedItemNormalizer(), true);
                     IEnumerable<FeedItem> items = null;
                     try
                     {
-                        FeedReader feedReader = new FeedReader(new GalnetFeedItemNormalizer(), true);
                         items = feedReader.RetrieveFeed(url);
                     }
                     catch (WebException wex)
                     {
-                        Logging.Warn("Exception attempting to obtain galnet feed: ", wex);
+                        Logging.Warn("Exception contacting primary Galnet feed: ", wex);
+                        url = GetGalnetResource("alternateURL");
+                        altURL = true;
+                        Logging.Warn("Trying alternate Galnet feed " + url);
+                        try
+                        {
+                            items = feedReader.RetrieveFeed(url);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logging.Error("Galnet feed exception (alternate url unsuccessful): ", ex);
+                        }
                     }
                     catch (System.Xml.XmlException xex)
                     {

--- a/GalnetMonitor/GalnetMonitor.cs
+++ b/GalnetMonitor/GalnetMonitor.cs
@@ -203,6 +203,12 @@ namespace GalnetMonitor
                                     break;
                                 }
 
+                                if (item.Title is null || item.GetContent() is null)
+                                {
+                                    // Skip items which do not contain useful content.
+                                    continue;
+                                }
+
                                 News newsItem = new News(item.Id, assignCategory(item.Title, item.GetContent()), item.Title, item.GetContent(), item.PublishDate.DateTime, false);
                                 newsItems.Add(newsItem);
                                 GalnetSqLiteRepository.Instance.SaveNews(newsItem);
@@ -269,24 +275,37 @@ namespace GalnetMonitor
         /// <returns></returns>
         private string assignCategory(string title, string content)
         {
-            if (title.StartsWith(GetGalnetResource("titleFilterPowerplay")))
+            try
             {
-                return GetGalnetResource("categoryPowerplay");
-            }
+                if (title.StartsWith(GetGalnetResource("titleFilterPowerplay")))
+                {
+                    return GetGalnetResource("categoryPowerplay");
+                }
 
-            if (title.StartsWith(GetGalnetResource("titleFilterStarportStatus")))
-            {
-                return GetGalnetResource("categoryStarportStatus");
-            }
+                if (title.StartsWith(GetGalnetResource("titleFilterStarportStatus")))
+                {
+                    return GetGalnetResource("categoryStarportStatus");
+                }
 
-            if (title.StartsWith(GetGalnetResource("titleFilterWeekInReview")))
-            {
-                return GetGalnetResource("categoryWeekInReview");
+                if (title.StartsWith(GetGalnetResource("titleFilterWeekInReview")))
+                {
+                    return GetGalnetResource("categoryWeekInReview");
+                }
+                if (title.StartsWith(GetGalnetResource("titleFilterCg")) ||
+                    Regex.IsMatch(content, GetGalnetResource("contentFilterCgRegex")))
+                {
+                    return GetGalnetResource("categoryCG");
+                }
             }
-            if (title.StartsWith(GetGalnetResource("titleFilterCg")) ||
-                Regex.IsMatch(content, GetGalnetResource("contentFilterCgRegex")))
+            catch (Exception ex)
             {
-                return GetGalnetResource("categoryCG");
+                Dictionary<string, object> data = new Dictionary<string, object>()
+                {
+                    { "title", title },
+                    { "content", content },
+                    { "exception", ex }
+                };
+                Logging.Error("Exception categorizing Galnet article.", data);
             }
 
             return GetGalnetResource("categoryArticle");


### PR DESCRIPTION
```
2019-05-01T02:10:59 [Error] GalnetMonitor:monitor Exception attempting to handle galnet feed:  {"ClassName":"System.ArgumentNullException","Message":"Value cannot be null.","Data":null,"InnerException":null,"HelpURL":null,"StackTraceString":"   at System.Text.RegularExpressions.Regex.IsMatch(String input)\r\n   at System.Text.RegularExpressions.Regex.IsMatch(String input, String pattern)\r\n   at GalnetMonitor.GalnetMonitor.assignCategory(String title, String content) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\GalnetMonitor\\GalnetMonitor.cs:line 286\r\n   at GalnetMonitor.GalnetMonitor.<monitor>g__monitorGalnet|20_0() in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\GalnetMonitor\\GalnetMonitor.cs:line 206","RemoteStackTraceString":null,"RemoteStackIndex":0,"ExceptionMethod":"8\nIsMatch\nSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\nSystem.Text.RegularExpressions.Regex\nBoolean IsMatch(System.String)","HResult":-2147467261,"Source":"System","WatsonBuckets":null,"ParamName":"input"}
```