### PR TITLE
Slightly boost speech volume when chorus level is low.

### DIFF
--- a/SpeechService/SpeechFX.cs
+++ b/SpeechService/SpeechFX.cs
@@ -58,6 +58,10 @@ namespace EddiSpeechService
                 int radioGain = radio ? 7 : 0;
                 source = source.AppendSource(x => new DmoCompressorEffect(x) { Gain = effectsLevel / 15 + radioGain });
             }
+            else
+            {
+                source = source.AppendSource(x => new DmoCompressorEffect(x) { Gain = 5 });
+            }
 
             return source;
         }


### PR DESCRIPTION
A small adjustment to better equalize volume gain across chorus levels (chorus level zero was quieter than other levels where a chorus effect was applied).