### PR TITLE
Update attachable logs for Github issues

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -99,6 +99,8 @@ namespace Eddi
         private ConcurrentBag<EDDIResponder> activeResponders = new ConcurrentBag<EDDIResponder>();
         private static readonly object responderLock = new object();
 
+        public string vaVersion { get; set; }
+
         // Information obtained from the companion app service
         public DateTime ApiTimeStamp { get; private set; }
 

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -163,6 +163,10 @@ namespace EddiVoiceAttackResponder
                     EDDI.Instance.enqueueEvent(@event);
                 }
 
+                // Set a variable indicating the version of VoiceAttack in use
+                System.Version v = vaProxy.VAVersion;
+                EDDI.Instance.vaVersion = v.ToString();
+
                 // Set a variable indicating whether EDDI is speaking
                 try
                 {


### PR DESCRIPTION
- Attach logs from both the current session and last session (since people sometimes report issues that occurred on the prior run but not the current run)
- Include the VoiceAttack version, when appropriate.