### PR TITLE
Fix concurrency issue in system materialEdNames list

### DIFF
--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -151,7 +151,7 @@ namespace EddiDataDefinitions
                 }
             }
         }
-        private readonly object bodyLock;
+        private readonly object bodyLock = new object();
 
         // Not intended to be user facing - discoverable bodies as reported by a discovery scan "honk"
         public int discoverableBodies = 0;

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -225,7 +225,7 @@ namespace EddiDataDefinitions
         {
             try
             {
-                return new List<Body>(bodies).SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
+                return bodies.SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
             }
             catch (InvalidOperationException ex)
             {

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -140,7 +140,7 @@ namespace EddiDataDefinitions
                     List<Body> bodiesList = null;
                     lock (bodyLock)
                     {
-                        bodiesList = bodies;
+                        bodiesList = new List<Body>(bodies);
                     }
                     return bodiesList.SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
                 }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -137,12 +137,7 @@ namespace EddiDataDefinitions
             {
                 try
                 {
-                    List<Body> bodiesList = null;
-                    lock (bodyLock)
-                    {
-                        bodiesList = new List<Body>(bodies);
-                    }
-                    return bodiesList.SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
+                    return new List<Body>(bodies).SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
                 }
                 catch (InvalidOperationException ex)
                 {
@@ -151,7 +146,6 @@ namespace EddiDataDefinitions
                 }
             }
         }
-        private readonly object bodyLock = new object();
 
         // Not intended to be user facing - discoverable bodies as reported by a discovery scan "honk"
         public int discoverableBodies = 0;

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -131,21 +131,7 @@ namespace EddiDataDefinitions
 
         // Not intended to be user facing - materials available within the system
         [JsonIgnore]
-        public List<string> materialEdNames
-        {
-            get
-            {
-                try
-                {
-                    return new List<Body>(bodies).SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Logging.Error("Error aggregating system materials list.", ex);
-                    return new List<string>();
-                }
-            }
-        }
+        public List<string> materialEdNames => getSystemMaterials(bodies);
 
         // Not intended to be user facing - discoverable bodies as reported by a discovery scan "honk"
         public int discoverableBodies = 0;
@@ -233,6 +219,19 @@ namespace EddiDataDefinitions
             }
 
             return value;
+        }
+
+        private List<string> getSystemMaterials(List<Body> bodies)
+        {
+            try
+            {
+                return new List<Body>(bodies).SelectMany(b => b.materials, (b, m) => m.definition.edname).Distinct().ToList();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Logging.Error("Error aggregating system materials list.", ex);
+                return new List<string>();
+            }
         }
     }
 }


### PR DESCRIPTION
Fix #1310.
1. Enclose everything in a try-catch block (if it fails the same way again, handle it gracefully)
2. Lock our bodies list while we make a copy, then iterate over the copy so that nothing can change underneath us