### PR TITLE
Fix deep-space crash caused by empty EDSM array

### DIFF
--- a/StarMapService/EdsmBodyData.cs
+++ b/StarMapService/EdsmBodyData.cs
@@ -21,8 +21,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<Dictionary<string, object>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapBodies(response);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapBodies(response);
+                }
             }
             else
             {

--- a/StarMapService/EdsmFactionData.cs
+++ b/StarMapService/EdsmFactionData.cs
@@ -22,8 +22,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<JObject>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapFactions(response, systemName);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapFactions(response, systemName);
+                }
             }
             else
             {

--- a/StarMapService/EdsmStationData.cs
+++ b/StarMapService/EdsmStationData.cs
@@ -23,8 +23,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<JObject>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapStations(response);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapStations(response);
+                }
             }
             else
             {

--- a/StarMapService/EdsmSystemData.cs
+++ b/StarMapService/EdsmSystemData.cs
@@ -24,8 +24,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<JObject>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapSystem(response, system);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapSystem(response, system);
+                }
             }
             else
             {
@@ -51,16 +54,19 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = JArray.Parse(clientResponse.Content);
-                List<StarSystem> starSystems = new List<StarSystem>();
-                foreach (JObject response in responses)
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JArray responses)
                 {
-                    if (response != null)
+                    List<StarSystem> starSystems = new List<StarSystem>();
+                    foreach (JObject response in responses)
                     {
-                        starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        if (response != null)
+                        {
+                            starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        }
                     }
+                    return starSystems;
                 }
-                return starSystems;
             }
             else
             {
@@ -85,16 +91,19 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = JArray.Parse(clientResponse.Content);
-                List<StarSystem> starSystems = new List<StarSystem>();
-                foreach (JObject response in responses)
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JArray responses)
                 {
-                    if (response != null)
+                    List<StarSystem> starSystems = new List<StarSystem>();
+                    foreach (JObject response in responses)
                     {
-                        starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        if (response != null)
+                        {
+                            starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        }
                     }
+                    return starSystems;
                 }
-                return starSystems;
             }
             else
             {
@@ -119,18 +128,21 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = JArray.Parse(clientResponse.Content);
-                List<Dictionary<string, object>> distantSystems = new List<Dictionary<string, object>>();
-                foreach (JObject response in responses)
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JArray responses)
                 {
-                    Dictionary<string, object> distantSystem = new Dictionary<string, object>()
+                    List<Dictionary<string, object>> distantSystems = new List<Dictionary<string, object>>();
+                    foreach (JObject response in responses)
                     {
-                        { "distance", (decimal)response["distance"] },
-                        { "system", ParseStarMapSystem(response, (string)response["name"]) }
-                    };
-                    distantSystems.Add(distantSystem);
+                        Dictionary<string, object> distantSystem = new Dictionary<string, object>()
+                        {
+                            { "distance", (decimal)response["distance"] },
+                            { "system", ParseStarMapSystem(response, (string)response["name"]) }
+                        };
+                        distantSystems.Add(distantSystem);
+                    }
+                    return distantSystems;
                 }
-                return distantSystems;
             }
             else
             {
@@ -154,16 +166,19 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JArray responses = JArray.Parse(clientResponse.Content);
-                List<StarSystem> starSystems = new List<StarSystem>();
-                foreach (JObject response in responses)
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JArray responses)
                 {
-                    if (response != null)
+                    List<StarSystem> starSystems = new List<StarSystem>();
+                    foreach (JObject response in responses)
                     {
-                        starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        if (response != null)
+                        {
+                            starSystems.Add(ParseStarMapSystem(response, (string)response["name"]));
+                        }
                     }
+                    return starSystems;
                 }
-                return starSystems;
             }
             return null;
         }

--- a/StarMapService/EdsmTrafficData.cs
+++ b/StarMapService/EdsmTrafficData.cs
@@ -35,8 +35,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<Dictionary<string, object>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapTraffic(response);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapTraffic(response);
+                }
             }
             return null;
         }
@@ -58,8 +61,11 @@ namespace EddiStarMapService
             var clientResponse = client.Execute<Dictionary<string, object>>(request);
             if (clientResponse.IsSuccessful)
             {
-                JObject response = JObject.Parse(clientResponse.Content);
-                return ParseStarMapDeaths(response);
+                var token = JToken.Parse(clientResponse.Content);
+                if (token is JObject response)
+                {
+                    return ParseStarMapDeaths(response);
+                }
             }
             return null;
         }

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -422,6 +422,21 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestSystemsCubeUnknown()
+        {
+            string systemName = "No such system";
+            try
+            {
+                List<StarSystem> starSystems = StarMapService.GetStarMapSystemsCube(systemName, 15, false, false, false, false);
+                Assert.IsNull(starSystems);
+            }
+            catch (System.Exception)
+            {
+                Assert.Fail();
+            }
+        }
+
+        [TestMethod]
         public void TestUnknown()
         {
             // Unknown systems shall return null from here. We create a synthetic system in DataProviderService.cs if this returns null;


### PR DESCRIPTION
Fix deep-space crash when searching cube systems and EDSM results are an empty json / not the expected json type. 
Fixes #1316