### PR TITLE
Clear old / incompatible .dll files before installing

### DIFF
--- a/Installer.iss
+++ b/Installer.iss
@@ -68,7 +68,6 @@ Source: "System.Data.SQLite.dll.config"; DestDir: "{app}"; Flags: ignoreversion
 Type: files; Name: "{app}\Eddi.exe"
 Type: files; Name: "{app}\EDDI.ico"
 Type: files; Name: "{app}\Eddi*.dll"
-Type: files; Name: "{app}\EddiNetLogMonitor.dll"
 Type: files; Name: "{app}\Newtonsoft.Json.xml"
 Type: files; Name: "{app}\CommonMark.xml"
 Type: files; Name: "{app}\Exceptionless.Wpf.xml"

--- a/Installer.iss
+++ b/Installer.iss
@@ -67,6 +67,7 @@ Source: "System.Data.SQLite.dll.config"; DestDir: "{app}"; Flags: ignoreversion
 [InstallDelete]
 Type: files; Name: "{app}\Eddi.exe"
 Type: files; Name: "{app}\EDDI.ico"
+Type: files; Name: "{app}\Eddi*.dll"
 Type: files; Name: "{app}\EddiNetLogMonitor.dll"
 Type: files; Name: "{app}\Newtonsoft.Json.xml"
 Type: files; Name: "{app}\CommonMark.xml"


### PR DESCRIPTION
Fix #1322 by removing incompatible .dll files (like .dll files from future versions) during the installation process.
Only files prefixed "Eddi" and ending in ".dll" are affected (e.g. EddiCrimeMonitor.dll).