### PR TITLE
Suggested revisions to Immutable Body Lists

### DIFF
--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -51,7 +51,7 @@ namespace EddiDataProviderService
                         body.systemAddress = starSystem.systemAddress;
                         body.systemEDDBID = starSystem.EDDBID;
                     }
-                    starSystem.AddBodies(bodies);
+                    starSystem.AddOrUpdateBodies(bodies);
                 }
 
                 if (starSystem?.population > 0)

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1538,6 +1538,7 @@ namespace Eddi
                 CurrentStellarBody = new Body()
                 {
                     bodyname = theEvent.star,
+                    bodyId = 0,
                     bodyType = BodyType.FromEDName("Star"),
                     stellarclass = LastFSDEngagedEvent?.stellarclass,
                 };

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1541,7 +1541,7 @@ namespace Eddi
                     bodyType = BodyType.FromEDName("Star"),
                     stellarclass = LastFSDEngagedEvent?.stellarclass,
                 };
-                CurrentStarSystem.bodies.Add(CurrentStellarBody);
+                CurrentStarSystem.AddOrUpdateBody(CurrentStellarBody);
             }
 
             // Update to most recent information
@@ -1933,15 +1933,11 @@ namespace Eddi
                 if (star == null)
                 {
                     Logging.Debug("Scanned star " + theEvent.bodyname + " is new - creating");
-                    CurrentStarSystem.AddBody(theEvent.star);
+                    CurrentStarSystem.AddOrUpdateBody(theEvent.star);
                 }
                 else
                 {
-                    int index = CurrentStarSystem.bodies.IndexOf(star);
-                    if (index != -1)
-                    {
-                        CurrentStarSystem.UpdateBodyAt(index, theEvent.star);
-                    }
+                    CurrentStarSystem.AddOrUpdateBody(theEvent.star);
                 }
 
                 Logging.Debug("Saving data for scanned star " + theEvent.star.bodyname);
@@ -1959,18 +1955,13 @@ namespace Eddi
                 if (body == null)
                 {
                     Logging.Debug("Scanned body " + theEvent.bodyname + " is new - creating");
-                    CurrentStarSystem.AddBody(theEvent.body);
+                    CurrentStarSystem.AddOrUpdateBody(theEvent.body);
                 }
                 else
                 {
                     if (body.scanned == null)
                     {
-                        int index = CurrentStarSystem.bodies.IndexOf(body);
-                        if (index != -1)
-                        {
-                            // Update our body with the scan data.
-                            CurrentStarSystem.UpdateBodyAt(index, theEvent.body);
-                        }
+                        CurrentStarSystem.AddOrUpdateBody(theEvent.body);
                     }
                     else
                     {

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -134,7 +134,7 @@ namespace UnitTests
             StarSystem starSystem = new StarSystem() { systemname = "testSystem" };
             starSystem.AddOrUpdateBody(jumponiumBody);
             Assert.IsTrue(starSystem.isgreen, "green system should be green");
-            Assert.IsFalse(starSystem.isgold, "green system should be gold");
+            Assert.IsFalse(starSystem.isgold, "green system should not be gold");
         }
 
         [TestMethod]

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -132,9 +132,9 @@ namespace UnitTests
 
             // Add a body with green materials and re-test
             StarSystem starSystem = new StarSystem() { systemname = "testSystem" };
-            starSystem.AddBody(jumponiumBody);
+            starSystem.AddOrUpdateBody(jumponiumBody);
             Assert.IsTrue(starSystem.isgreen, "green system should be green");
-            Assert.IsFalse(starSystem.isgold, "green system should not be gold");
+            Assert.IsFalse(starSystem.isgold, "green system should be gold");
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace UnitTests
 
             // Add a body with gold materials and re-test
             StarSystem starSystem = new StarSystem() { systemname = "testSystem" };
-            starSystem.AddBody(goldBody);
+            starSystem.AddOrUpdateBody(goldBody);
             Assert.IsTrue(starSystem.isgreen, "gold system should be green");
             Assert.IsTrue(starSystem.isgold, "gold system should be gold");
         }


### PR DESCRIPTION
1. Use a private setter for `bodies`, to prevent misuse of the ImmutableList.Add() methods
2. Body data is derived from various sources and `bodyId` can potentially be null. Thus, `bodyname` is still the best key to use for adding and removing bodies from our list.
3. Combine the `AddBody` and `AddBodies` methods with `UpdateBodyAt` to create methods `AddOrUpdateBody` and `AddOrUpdateBodies`. This allows us to easily update incomplete body information when more complete data becomes available.
4. Remove unused method `SortBodiesById`