### PR TITLE
Fix EDDN exception - shipyard information

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -196,6 +196,11 @@ namespace EddiDataDefinitions
                 // get the canonical role object for the given EDName
                 Role = Role.FromEDName(Role.edname);
             }
+            if (EDName is null && !(model is null)) // legacy shipmonitor JSON may not include EDName or EDID
+            {
+                Ship template = ShipDefinitions.FromModel(model);
+                EDName = EDName ?? template?.EDName;
+            }
             additionalJsonData = null;
         }
 
@@ -311,7 +316,6 @@ namespace EddiDataDefinitions
         [JsonIgnore]
         public long EDID { get; set; }
         // The name in Elite: Dangerous' database
-        [JsonIgnore]
         public string EDName { get; set; }
 
         public Ship()

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -485,8 +485,12 @@ namespace EDDNResponder
                 List<string> eddnShips = new List<string>();
                 foreach (Ship ship in EDDI.Instance.CurrentStation.shipyard)
                 {
-                    eddnShips.Add(ship.EDName);
+                    if (ship?.EDName != null)
+                    {
+                        eddnShips.Add(ship.EDName);
+                    }
                 }
+                eddnShips = eddnShips?.Distinct()?.ToList();
 
                 // Only send the message if we have ships
                 if (eddnShips.Count > 0)

--- a/ShipMonitor/ShipLoadoutEvent.cs
+++ b/ShipMonitor/ShipLoadoutEvent.cs
@@ -14,7 +14,7 @@ namespace EddiShipMonitor
 
         static ShipLoadoutEvent()
         {
-            VARIABLES.Add("ship", "The ship");
+            VARIABLES.Add("ship", "The ship model");
             VARIABLES.Add("shipid", "The ID of the ship");
             VARIABLES.Add("shipname", "The name of the ship");
             VARIABLES.Add("shipident", "The identification string of the ship");
@@ -33,7 +33,7 @@ namespace EddiShipMonitor
         }
 
         public int? shipid { get; private set; }
-        public string ship { get; private set; }
+        public string ship => shipDefinition?.model;
         public string shipname { get; private set; }
         public string shipident { get; private set; }
         public long? value => hullvalue + modulesvalue;
@@ -49,9 +49,12 @@ namespace EddiShipMonitor
         public List<Hardpoint> hardpoints { get; private set;  }
         public List<Compartment> compartments { get; private set; }
 
+        // Not intended to be user facing
+        public Ship shipDefinition;
+
         public ShipLoadoutEvent(DateTime timestamp, string ship, int? shipId, string shipName, string shipIdent, long? hullValue, long? modulesValue, decimal hullHealth, decimal unladenmass, decimal maxjumprange, decimal optimalmass, long rebuy, bool hot, List<Compartment> compartments, List<Hardpoint> hardpoints, string paintjob) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
             this.shipid = shipId;
             this.shipname = shipName;
             this.shipident = shipIdent;

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -447,7 +447,7 @@ namespace EddiShipMonitor
             {
                 // The ship is unknown - create it
                 Logging.Debug("Unknown ship ID " + @event.shipid);
-                ship = ShipDefinitions.FromEDModel(@event.ship);
+                ship = @event.shipDefinition;
                 ship.LocalId = (int)@event.shipid;
                 ship.Role = Role.MultiPurpose;
             }


### PR DESCRIPTION
Ship deserialization wasn't deserializing ednames.
```
2019-06-06T21:35:20 [Error] EDDNResponder:sendMessage Failed to send data to EDDN {"eddnMessage":"{\"timestamp\":\"2019-06-06T21:35:20Z\",\"systemName\":\"Aryak\",\"stationName\":\"Garneau Port\",\"marketId\":3230837248,\"ships\":[null,null,null,null,null,null,null,null,null,null],\"horizons\":true}","Response":"FAIL: [<ValidationError: '[None, None, None, None, None, None, None, None, None, None] has non-unique elements'>]","Exception":{"ClassName":"System.ArgumentException","Message":"Value does not fall within the expected range.","Data":null,"InnerException":null,"HelpURL":null,"StackTraceString":"   at EDDNResponder.EDDNResponder.<>c__DisplayClass59_0.<sendMessage>b__0()","RemoteStackTraceString":null,"RemoteStackIndex":0,"ExceptionMethod":"8\n<sendMessage>b__0\nEddiEddnResponder, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\nEDDNResponder.EDDNResponder+<>c__DisplayClass59_0\nVoid <sendMessage>b__0()","HResult":-2147024809,"Source":"EddiEddnResponder","WatsonBuckets":null,"ParamName":null}}
```
Continues from #1308, which was our initial attempt to resolve this exception.