### PR TITLE
Refactor `syncEdsmLogBatch` to loop through star systems before looping through flight logs, optimize database access

### DIFF
--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -192,6 +192,17 @@ namespace EddiDataProviderService
                             {
                                 if (flightLog.system == starSystem.systemname)
                                 {
+                                    if (starSystem.EDSMID == null)
+                                    {
+                                        starSystem.EDSMID = flightLog.systemId;
+                                    }
+                                    else
+                                    {
+                                        if (starSystem.EDSMID != flightLog.systemId)
+                                        {
+                                            continue;
+                                        }
+                                    }
                                     starSystem.visitLog.Add(flightLog.date);
                                 }
                             }
@@ -226,6 +237,17 @@ namespace EddiDataProviderService
                 {
                     foreach (StarMapResponseLogEntry flightLog in flightLogBatch.Where(log => log.system == starSystem.systemname))
                     {
+                        if (starSystem.EDSMID == null)
+                        {
+                            starSystem.EDSMID = flightLog.systemId;
+                        }
+                        else
+                        {
+                            if (starSystem.EDSMID != flightLog.systemId)
+                            {
+                                continue;
+                            }
+                        }
                         starSystem.visitLog.Add(flightLog.date);
                         if (comments.ContainsKey(flightLog.system))
                         {

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -390,17 +390,17 @@ namespace EddiDataProviderService
                                         string starSystemJson = null;
                                         for (int i = 0; i < rdr.FieldCount; i++)
                                         {
-                                            if (rdr.GetName(i) == "name")
-                                            {
-                                                systemName = rdr.GetString(i);
-                                            }
                                             if (SCHEMA_VERSION >= 2 && rdr.GetName(i) == "systemaddress")
                                             {
-                                                systemAddress = rdr.GetInt32(i);
+                                                systemAddress = rdr.IsDBNull(i) ? null : (long?)rdr.GetInt64(i);
                                             }
                                             if (SCHEMA_VERSION >= 2 && rdr.GetName(i) == "edsmid")
                                             {
-                                                edsmId = rdr.GetInt32(i);
+                                                edsmId = rdr.IsDBNull(i) ? null : (long?)rdr.GetInt64(i);
+                                            }
+                                            if (rdr.GetName(i) == "name")
+                                            {
+                                                systemName = rdr.GetString(i);
                                             }
                                             if (rdr.GetName(i) == "starsystem")
                                             {

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -23,7 +23,7 @@ namespace EddiDataProviderService
         private const string CREATE_TABLE_SQL = @" 
                     CREATE TABLE IF NOT EXISTS starsystems
                     (
-                        name TEXT NOT NULL,
+                        name TEXT NOT NULL COLLATE NOCASE,
                         totalvisits INT NOT NULL,
                         lastvisit DATETIME,
                         starsystem TEXT NOT NULL,
@@ -35,7 +35,7 @@ namespace EddiDataProviderService
                      );";
         private const string CREATE_INDEX_SQL = @" 
                     CREATE INDEX IF NOT EXISTS 
-                        starsystems_idx_1 ON starsystems(name);
+                        starsystems_idx_1 ON starsystems(name COLLATE NOCASE);
                     CREATE UNIQUE INDEX IF NOT EXISTS 
                         starsystems_idx_2 ON starsystems(systemaddress) WHERE systemaddress IS NOT NULL;
                     CREATE UNIQUE INDEX IF NOT EXISTS 
@@ -103,7 +103,7 @@ namespace EddiDataProviderService
                     )";
         private const string WHERE_SYSTEMADDRESS = @"WHERE systemaddress = @systemaddress; PRAGMA optimize;";
         private const string WHERE_EDSMID = @"WHERE edsmid = @edsmid; PRAGMA optimize;";
-        private const string WHERE_NAME = @"WHERE LOWER(name) = LOWER(@name); PRAGMA optimize;";
+        private const string WHERE_NAME = @"WHERE name = @name; PRAGMA optimize;";
 
         private static StarSystemSqLiteRepository instance;
 
@@ -271,7 +271,7 @@ namespace EddiDataProviderService
                 List<string> systemsToRevert = new List<string>();
                 foreach (StarSystem starSystem in updatedSystems)
                 {
-                    if (starSystem.systemAddress == null || starSystem.x == null || starSystem.y == null || starSystem.z == null)
+                    if (starSystem.systemAddress == null)
                     {
                         systemsToRevert.Add(starSystem.systemname);
                     }

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,7 +4,7 @@ Full details of the variables available for each noted event, and VoiceAttack in
 
 ### Development
   * EDSM responder
-    * Fixed a bug that caused EDSM synchronization to slow to a crawl and could spawn multiple copies of star systems within EDDI's database. Deleting `EDDI.sqlite` from `%APPDATA/EDDI` is resynchronizing is recommended for all pilots who tested version 3.4.1-rc1.
+    * Fixed a bug that caused EDSM synchronization to slow to a crawl and optimized database access. Resynchronizing with EDSM will speed database access and is recommended for all pilots.
 
 ### 3.4.1-rc1
   * EDSM responder

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### Development
+  * EDSM responder
+    * Fixed a bug that caused EDSM synchronization to slow to a crawl and could spawn multiple copies of star systems within EDDI's database. Deleting `EDDI.sqlite` from `%APPDATA/EDDI` is resynchronizing is recommended for all pilots who tested version 3.4.1-rc1.
+
 ### 3.4.1-rc1
   * EDSM responder
     * Improved EDSM synchronization for system visits and comments

--- a/EDSMResponder/ConfigurationWindow.xaml.cs
+++ b/EDSMResponder/ConfigurationWindow.xaml.cs
@@ -116,9 +116,7 @@ namespace EddiEdsmResponder
                     {
                         int batchSize = Math.Min(total, StarMapService.syncBatchSize);
                         List<StarMapResponseLogEntry> flightLogBatch = flightLogs.Skip(i).Take(batchSize).ToList();
-                        string[] batchNames = flightLogBatch.Select(x => x.system).ToArray();
-                        List<StarSystem> batchsystems = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystems(batchNames, true, false);
-                        DataProviderService.syncEdsmLogBatch(batchsystems, flightLogs.Skip(i).Take(batchSize).ToList(), comments);
+                        DataProviderService.syncEdsmLogBatch(flightLogs.Skip(i).Take(batchSize).ToList(), comments);
                         i += batchSize;
                         progress.Report($"{Properties.EDSMResources.log_button_fetching_progress} {i}/{total}");
                     }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1215,7 +1215,7 @@ namespace EddiJournalMonitor
                                             string arrivalStation = EDDI.Instance.CurrentStation?.name ?? string.Empty;
                                             string arrivalSystem = EDDI.Instance.CurrentStarSystem?.systemname ?? string.Empty;
                                             await Task.Delay((int)time * 1000);
-                                            EDDI.Instance.enqueueEvent(new ShipArrivedEvent(DateTime.UtcNow, ship, shipId, arrivalSystem, distance, price, time, arrivalStation, fromMarketId, toMarketId));
+                                            EDDI.Instance.enqueueEvent(new ShipArrivedEvent(DateTime.UtcNow, ship, shipId, arrivalSystem, distance, price, time, arrivalStation, fromMarketId, toMarketId) { fromLoad = fromLogLoad });
                                         }
                                     }
                                 }
@@ -1252,7 +1252,7 @@ namespace EddiJournalMonitor
                                             string arrivalStation = EDDI.Instance.CurrentStation?.name ?? string.Empty;
                                             string arrivalSystem = EDDI.Instance.CurrentStarSystem?.systemname ?? string.Empty;
                                             await Task.Delay((int)transferTime * 1000);
-                                            EDDI.Instance.enqueueEvent(new ModuleArrivedEvent(DateTime.UtcNow, ship, shipId, storageSlot, serverId, module, transferCost, transferTime, arrivalSystem, arrivalStation));
+                                            EDDI.Instance.enqueueEvent(new ModuleArrivedEvent(DateTime.UtcNow, ship, shipId, storageSlot, serverId, module, transferCost, transferTime, arrivalSystem, arrivalStation) { fromLoad = fromLogLoad });
                                         }
                                     }
                                 }

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -234,6 +234,7 @@ namespace EddiStarMapService
             var request = new RestRequest("api-logs-v1/get-logs", Method.POST);
             request.AddParameter("apiKey", apiKey);
             request.AddParameter("commanderName", commanderName);
+            request.AddParameter("showId", 1); // Obtain EDSM IDs
             if (systemNames?.Count() == 1)
             {
                 /// When a single system name is provided, the api responds with 

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -307,7 +307,9 @@ namespace EddiStarMapService
 
     public class StarMapResponseLogEntry
     {
-        public string system { get; set; }
+        public string system { get; set; } // System name
+
+        public long systemId { get; set; } // EDSM ID
         public DateTime date { get; set; }
     }
 


### PR DESCRIPTION
- Without looping on the star system, the same star system could be added to our list of star systems multiple times (causing it to be added to the database multiple times).
- Create empty star systems to log visits for stars not in the database rather than trying to pull full data on each star system. (StarSystems will be fleshed out via visits or SystemDetails() and similar).
- Optimizes comments sync to only fetch comments once.
- Adds `systemaddress` and `edsmid` unique columns and prefer searching for these values using new indices.
- Optimizes database access to take full advantage of indexing with binary search.
- Sets up basic versioning for future table updates.
Fixes #1343 and significantly boosts synchronization speeds.

Bonus: Fix ship and module arrived events triggering from log loads.