### PR TITLE
Fix exception that can occur when `happiness` or `updated_at` properties are not provided for faction BGS data

### DIFF
--- a/BgsService/BgsFactionData.cs
+++ b/BgsService/BgsFactionData.cs
@@ -87,9 +87,12 @@ namespace EddiBgsService
                     systemName = (string)presenceJson["system_name"],
                     influence = (decimal?)(double?)presenceJson["influence"] * 100, // Convert from a 0-1 range to a percentage
                     FactionState = FactionState.FromEDName((string)presenceJson["state"]) ?? FactionState.None,
-                    Happiness = Happiness.FromEDName((string)presenceJson["happiness"]) ?? Happiness.None,
-                    updatedAt = (DateTime)presenceJson["updated_at"],
                 };
+
+                // These properties may not be present in the json, so we pass them after initializing our FactionPresence object.
+                factionPresence.Happiness = Happiness.FromEDName(JsonParsing.getString(presenceJson, "happiness")) ?? Happiness.None;
+                presenceJson.TryGetValue("updated_at", out object updatedVal);
+                factionPresence.updatedAt = (DateTime?)updatedVal ?? DateTime.MinValue;
 
                 // Active states
                 presenceJson.TryGetValue("active_states", out object activeStatesVal);


### PR DESCRIPTION
Example from log:
```json
{
    "system_name": "Eol Prou LW-L c8-48",
    "system_name_lower": "eol prou lw-l c8-48",
    "state": "none",
    "influence": 0.046,
    "recovering_states": [],
    "pending_states": [{
      "state": "boom",
      "trend": 1
     }
    ],
    "active_states": []
   }
```