### PR TITLE
Fix EDDN commodies message exception due to EDDNEconomy definition.

### DIFF
--- a/EDDNResponder/EDDNEconomy.cs
+++ b/EDDNResponder/EDDNEconomy.cs
@@ -4,15 +4,15 @@ namespace EDDNResponder
 {
     class EDDNEconomy
     {
-        public string Name;
-        public string Name_Localized;
-        public decimal Proportion = 0M;
+        // Schema ref.: https://github.com/EDSM-NET/EDDN/blob/b21bdf76e549ea9e69fedf3ad6434b2fcdc5a5e7/schemas/commodity-v3.0.json#L105
+
+        public string name;
+        public decimal proportion = 0M;
 
         public EDDNEconomy(EconomyShare economyShareEconomy)
         {
-            Name = economyShareEconomy.economy.edname;
-            Name_Localized = economyShareEconomy.economy.fallbackLocalizedName;
-            Proportion = economyShareEconomy.proportion;
+            name = economyShareEconomy.economy.edname;
+            proportion = economyShareEconomy.proportion;
         }
     }
 }


### PR DESCRIPTION
Error message from EDDN:
```
"Response": "FAIL: [<ValidationError: " Additional properties are not allowed(u 'Proportion', u 'Name', u 'Name_Localized' were unexpected)">]",
"Exception": {
 "ClassName": "System.ArgumentException",
 "Message": "Value does not fall within the expected range.",
 "Data": null,
 "InnerException": null,
 "HelpURL": null,
 "StackTraceString": "   at EDDNResponder.EDDNResponder.<>c__DisplayClass59_0.<sendMessage>b__0() in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\EDDNResponder\\EDDNResponder.cs:line 558",
 "RemoteStackTraceString": null,
 "RemoteStackIndex": 0,
 "ExceptionMethod": "8\n<sendMessage>b__0\nEddiEddnResponder, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\nEDDNResponder.EDDNResponder+<>c__DisplayClass59_0\nVoid <sendMessage>b__0()",
 "HResult": -2147024809,
 "Source": "EddiEddnResponder",
 "WatsonBuckets": null,
 "ParamName": null
}
```

Updated EDDNEconomy definition match schema. Ref. https://github.com/EDSM-NET/EDDN/blob/b21bdf76e549ea9e69fedf3ad6434b2fcdc5a5e7/schemas/commodity-v3.0.json#L105
- propery names are lower cased
- localized economy name is removed