### PR TITLE
Fix exception when sorting modules after module purchase

### DIFF
--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1364,9 +1364,9 @@ namespace EddiShipMonitor
                         {
                             hardpoint = new Hardpoint() { name = slot };
                             hardpoint.size = getHardpointSize(slot);
+                            ship.hardpoints.Add(hardpoint);
                         }
                         hardpoint.module = module;
-                        ship.hardpoints.Add(hardpoint);
                         sortHardpoints(ship);
                     }
                     else if (slot.Contains("Slot") || slot.Contains("Military"))
@@ -1377,9 +1377,9 @@ namespace EddiShipMonitor
                         {
                             compartment = new Compartment() { name = slot };
                             compartment.size = getCompartmentSize(slot, ship.militarysize);
+                            ship.compartments.Add(compartment);
                         }
                         compartment.module = module;
-                        ship.compartments.Add(compartment);
                         sortCompartments(ship);
                     }
                 }
@@ -1438,7 +1438,7 @@ namespace EddiShipMonitor
                 Dictionary<string, object> data = new Dictionary<string, object>()
                 {
                     { "Exception", ex },
-                    { "Ship", ship }
+                    { "Ship compartments", ship.compartments}
                 };
                 Logging.Error("Failed to sort ship compartments", data);
             }


### PR DESCRIPTION
2019-06-16T23:14:20 [Error] ShipMonitor:sortCompartments Failed to sort ship compartments {"Exception":{"ClassName":"System.ArgumentException","Message":"An item with the same key has already been added.","Data":null,"InnerException":null,"HelpURL":null,"StackTraceString":"   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)\r\n   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)\r\n   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)\r\n   at EddiShipMonitor.ShipMonitor.sortCompartments(Ship ship) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\ShipMonitor\\ShipMonitor.cs:line 1412","RemoteStackTraceString":null,"RemoteStackIndex":0,"ExceptionMethod":"8\nThrowArgumentException\nmscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\nSystem.ThrowHelper\nVoid ThrowArgumentException(System.ExceptionResource)","HResult":-2147024809,"Source":"mscorlib","WatsonBuckets":null,"ParamName":null}