### PR TITLE
Add Power.cs method `FromName` and use for Crime Monitor ShipTargeted events

### DIFF
--- a/CrimeMonitor/CrimeMonitor.cs
+++ b/CrimeMonitor/CrimeMonitor.cs
@@ -248,7 +248,7 @@ namespace EddiCrimeMonitor
                     if (@event.faction != null)
                     {
                         Faction faction = DataProviderService.GetFactionByName(@event.faction);
-                        Power power = Power.FromEDName(@event.faction);
+                        Power power = Power.FromName(@event.faction);
                         target.Power = power ?? Power.None;
                         target.Allegiance = power?.Allegiance ?? faction?.Allegiance;
                     }

--- a/DataDefinitions/Power.cs
+++ b/DataDefinitions/Power.cs
@@ -52,5 +52,18 @@ namespace EddiDataDefinitions
             string tidiedName = edName.ToLowerInvariant().Replace(" ", "").Replace(".", "").Replace("-", "");
             return ResourceBasedLocalizedEDName<Power>.FromEDName(tidiedName);
         }
+
+        new public static Power FromName(string name)
+        {
+            if (name == null)
+            {
+                return null;
+            }
+
+            // The player journal records an abbreviated version of Arissa's name. Fix that here to match our unabbreviated version.
+            string tidiedName = name.Replace("A. Lavigny-Duval", "Arissa Lavigny-Duval");
+
+            return ResourceBasedLocalizedEDName<Power>.FromName(tidiedName);
+        }
     }
 }


### PR DESCRIPTION
Use to perform speculative power lookups (when the faction string may or may not match a power).
Resolves #1372.