### PR TITLE
Fix to screen unknown 'Power' ednames

### DIFF
--- a/DataDefinitions/Power.cs
+++ b/DataDefinitions/Power.cs
@@ -50,7 +50,7 @@ namespace EddiDataDefinitions
             }
 
             string tidiedName = edName.ToLowerInvariant().Replace(" ", "").Replace(".", "").Replace("-", "");
-            return ResourceBasedLocalizedEDName<Power>.FromEDName(tidiedName);
+            return AllOfThem.FirstOrDefault(v => v.edname == tidiedName);
         }
     }
 }


### PR DESCRIPTION
Background: `Ship targeted` event `faction` property can be either a minor faction or power. The Crime Monitor event handler uses both `DataProviderService.GetFactionByName()` and `Power.FromEDName()` to determine which.

Fix serves to screen the ResourceBasedLocalizedEDName [Info] reports when the `@event.faction` property is a minor faction.