### PR TITLE
Fix BGS Faction invalid cast exception

### DIFF
--- a/BgsService/BgsFactionData.cs
+++ b/BgsService/BgsFactionData.cs
@@ -83,10 +83,15 @@ namespace EddiBgsService
             {
                 IDictionary<string, object> presenceJson = (IDictionary<string, object>)presence;
                 FactionPresence factionPresence = new FactionPresence()
+                /*
+                factionPresence.systemName = (string)presenceJson["system_name"];
+                factionPresence.influence = (decimal?)(double?)presenceJson["influence"] * 100;
+                factionPresence.FactionState = FactionState.FromEDName((string)presenceJson["state"]) ?? FactionState.None;
+                */
                 {
-                    systemName = (string)presenceJson["system_name"],
-                    influence = (decimal?)(double?)presenceJson["influence"] * 100, // Convert from a 0-1 range to a percentage
-                    FactionState = FactionState.FromEDName((string)presenceJson["state"]) ?? FactionState.None,
+                    systemName = JsonParsing.getString(presenceJson, "system_name"),
+                    influence = (JsonParsing.getOptionalDecimal(presenceJson, "influence") ?? 0) * 100, // Convert from a 0-1 range to a percentage
+                    FactionState = FactionState.FromEDName(JsonParsing.getString(presenceJson, "state")) ?? FactionState.None,
                 };
 
                 // These properties may not be present in the json, so we pass them after initializing our FactionPresence object.

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,9 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### Development
+  * Fixed a crash that could occur when looking up information about specific factions. 
+
 ### 3.4.1
   * Amended a configuration error in the Frontier API module.
 


### PR DESCRIPTION
Fir errors like
```
at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)\r\n
at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)\r\n
at System.Threading.Tasks.Task`1.get_Result()\r\n
at EddiBgsService.BgsService.ParseFactionsAsync(List`1 responses)\r\n
at EddiBgsService.BgsService.GetFactions(String endpoint, List`1 queryList)\r\n
at EddiDataProviderService.DataProviderService.GetFactionByName(String factionName, String systemName)\r\n
at EddiCrimeMonitor.CrimeMonitor.handleShipTargetedEvent(ShipTargetedEvent event)\r\n
at EddiCrimeMonitor.CrimeMonitor.PreHandle(Event event)\r\n
at Eddi.EDDI.passToMonitorPreHandlers(Event event)
```
which can occur when a faction's influence is 100% as in the example below:
```json
{
            "_id": "59e7a567d22c775be0fe03be",
            "name": "Merope Expeditionary Fleet",
            "__v": 0,
            "name_lower": "merope expeditionary fleet",
            "updated_at": "2019-07-14T03:15:37.000Z",
            "government": "patronage",
            "allegiance": "empire",
            "eddb_id": 75105,
            "faction_presence": [
                {
                    "system_name": "Pleiades Sector OI-T c3-7",
                    "system_name_lower": "pleiades sector oi-t c3-7",
                    "state": "boom",
                    "influence": 1,
                    "happiness": "$faction_happinessband2;",
                    "active_states": [
                        {
                            "state": "boom"
                        }
                    ],
                    "pending_states": [],
                    "recovering_states": [],
                    "conflicts": [],
                    "updated_at": "2019-07-13T19:04:46.000Z"
                }
            ]
        }
```
