### PR TITLE
Update `Docking granted` script to include basic landing pad info for surface ports.

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -4,6 +4,8 @@ Full details of the variables available for each noted event, and VoiceAttack in
 
 ### Development
   * Fixed a crash that could occur when looking up information about specific factions. 
+  * Speech responder
+    * Updated the `Docking granted` script to include basic landing pad info for surface ports.
 
 ### 3.4.1
   * Amended a configuration error in the Frontier API module.

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -591,7 +591,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n|else:\r\n    {Pause(8000)}\r\n    Landing pad {event.landingpad}\r\n    {OneOf('ready', 'assigned', 'allocated')}\r\n    {Occasionally(4, cat(', ', F('Honorific') ))}.\r\n}",
       "default": true,
       "name": "Docking granted",
       "description": "Triggered when your ship is granted docking permission at a station or outpost"

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -591,7 +591,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n|else:\r\n    {Pause(8000)}\r\n    Landing pad {event.landingpad}\r\n    {OneOf('ready', 'assigned', 'allocated')}\r\n    {Occasionally(4, cat(', ', F('Honorific') ))}.\r\n}",
       "default": true,
       "name": "Docking granted",
       "description": "Triggered when your ship is granted docking permission at a station or outpost"

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -591,7 +591,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n|else:\r\n    {Pause(8000)}\r\n    Landing pad {event.landingpad}\r\n    {OneOf('ready', 'assigned', 'allocated')}\r\n    {Occasionally(4, cat(', ', F('Honorific') ))}.\r\n}",
       "default": true,
       "name": "Docking granted",
       "description": "Triggered when your ship is granted docking permission at a station or outpost"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -591,7 +591,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n|else:\r\n    {Pause(8000)}\r\n    Landing pad {event.landingpad}\r\n    {OneOf('ready', 'assigned', 'allocated')}\r\n    {Occasionally(4, cat(', ', F('Honorific') ))}.\r\n}",
       "default": true,
       "name": "Docking granted",
       "description": "Triggered when your ship is granted docking permission at a station or outpost"

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -591,7 +591,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n}\r\n",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'landing pad')}\r\n{SetState('eddi_context_landing_pad_system', system.name)}\r\n{SetState('eddi_context_landing_pad_station', event.station)}\r\n{SetState('eddi_context_landing_pad_station_model', event.stationtype)}\r\n{SetState('eddi_context_landing_pad_pad', event.landingpad)}\r\n\r\n{if event.stationDefinition.basename = \"Coriolis\" || \r\n    event.stationDefinition.basename = \"Orbis\" || \r\n    event.stationDefinition.basename = \"Bernal\" || \r\n    event.stationDefinition.basename = \"AsteroidBase\":\r\n    {Pause(8000)}\r\n    {F(\"Landing pad report\")}\r\n|else:\r\n    {Pause(8000)}\r\n    Landing pad {event.landingpad}\r\n    {OneOf('ready', 'assigned', 'allocated')}\r\n    {Occasionally(4, cat(', ', F('Honorific') ))}.\r\n}",
       "default": true,
       "name": "Docking granted",
       "description": "Triggered when your ship is granted docking permission at a station or outpost"


### PR DESCRIPTION
Resolves #321.