### PR TITLE
Code coverage fixes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  token: c0cc9048-1cdc-464b-b2fa-dac79464e1c4
   notify: no
 #    require_ci_to_pass: no
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,9 +12,7 @@ coverage:
     project: yes
       default:
 	    threshold: 10%
-	patch: yes
-      default:
-	    threshold: 10%
+	patch: off
     changes: off
 
 parsers:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,6 +27,7 @@ comment:
   layout: "header, diff, changes, tree"
   behavior: default
   require_changes: no 
+  branch: !l10n_develop # never post comments if the PR head is on the l10n_develop branch
 
 # Available parameters:
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,7 +15,7 @@ coverage:
 	patch: yes
       default:
 	    threshold: 10%
-    changes: no
+    changes: off
 
 parsers:
   gcov:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,9 +8,13 @@ coverage:
   round: down
   range: "25...80"
 
-  status:
+  status: 
     project: yes
-    patch: yes
+      default:
+	    threshold: 10%
+	patch: yes
+      default:
+	    threshold: 10%
     changes: no
 
 parsers:
@@ -113,7 +117,7 @@ comment:
 #       default:
 #         against: parent
 #         target: auto
-#         threshold: 1%
+#         threshold: 1% # the amount that coverage can drop while still posting a success
 #         branches:
 #           - master
 #         if_no_uploads: error

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
-  notify:
-    require_ci_to_pass: no
+  notify: no
+#    require_ci_to_pass: no
 
 coverage:
   precision: 2
@@ -10,19 +10,19 @@ coverage:
   status:
     project: yes
     patch: yes
-    changes: yes
+    changes: no
 
 parsers:
   gcov:
     branch_detection:
       conditional: yes
       loop: yes
-      method: yes
-      macro: yes
+      method: no
+      macro: no
 
 comment:
-  layout: "header, diff, trends, uncovered"
-  behavior: new
+  layout: "header, diff, changes, tree"
+  behavior: default
   require_changes: no 
 
 # Available parameters:

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -9,7 +9,7 @@
   <package id="NetMQ" version="4.0.0.1" targetFramework="net471" />
   <package id="NETStandard.Library" version="2.0.1" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
-  <package id="OpenCover" version="4.7.922" targetFramework="net471" />
+  <package id="OpenCover" version="4.6.519" targetFramework="net471" />
   <package id="Rollbar" version="1.2.1" targetFramework="net471" />
   <package id="System.Collections" version="4.3.0" targetFramework="net471" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net471" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ nuget:
 before_build:
 - cmd: nuget restore
 build:
+  project: EDDI.sln      # path to Visual Studio solution or project
   parallel: true
   verbosity: minimal
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,25 @@ build:
   parallel: true
   verbosity: minimal
 test_script:
- # File path must be updated if OpenCover package version is updated
- - cd bin\Release
- - .\..\..\packages\OpenCover.4.7.922\tools\OpenCover.Console.exe -register:user -target:vstest.console.exe -targetargs:"Tests.dll /logger:Appveyor /tests:UnitTests /Parallel /InIsolation" -mergebyhash -skipautoprops -output:coverage.xml -excludeByFile:*.Designer.cs;*.xaml -filter:"+[Eddi*]* +[Utilities*]* -[Tests*]*"
+ # This powershell script may be run locally from your EDDI repo installation folder.
+ # The OpenCover file path must be updated if the OpenCover package version is updated
+ # The VSTest target file path must be updated if the CI is building using something other than Visual Studios 2017 Community Edition
+ - ps: |
+      $openCoverConsole = '.\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe'
+      $openCoverReg = '-register:user'
+      $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs -filter:"+[Eddi*]* +[Utilities*]* -[Tests*]*"'
+      $target = '-target:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
+      $targetArgs = '-targetargs:"bin\Release\Tests.dll' + $(If ($APPVEYOR) {' /logger:Appveyor'}) + ' /tests:UnitTests /Parallel /InIsolation /Blame"'
+      New-Item -ItemType directory -Path '.\TestResults' -Force
+      $resultsPath = '.\TestResults\coverage.xml'
+      $output = '-output:' + $resultsPath
+      $runCoverageCmd = "$openCoverConsole $openCoverArgs $openCoverReg $target $targetArgs $output"
+      ECHO $runCoverageCmd
+      IEX $runCoverageCmd
 after_test:
  # Our CodeCov token is "c0cc9048-1cdc-464b-b2fa-dac79464e1c4" 
  - ps: |
+      cd TestResults
       $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-      bash codecov.sh -f "coverage.xml" -t c0cc9048-1cdc-464b-b2fa-dac79464e1c4
+      bash codecov.sh -f coverage.xml -t c0cc9048-1cdc-464b-b2fa-dac79464e1c4


### PR DESCRIPTION
Resolves #1406.
Converts the script used to generate code coverage to a powershell script that can be run locally from the EDDI repos folder to generate code coverage reports locally.
At least in theory, code coverage must now drop by more than 10% for CodeCov to fail the build.