### PR TITLE
Code coverage tweaks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
  - ps: |
       $openCoverConsole = '.\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe'
       $openCoverReg = '-register:user'
-      $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs -filter:"+[Eddi*]* +[Utilities*]* -[Tests*]*"'
+      $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs,*.xaml.cs -filter:"+[Eddi*]* +[Utilities*]* -[Tests*]*"'
       $target = '-target:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
       $targetArgs = '-targetargs:"bin\Release\Tests.dll' + $(If ($APPVEYOR) {' /logger:Appveyor'}) + ' /tests:UnitTests /Parallel /InIsolation /Blame"'
       New-Item -ItemType directory -Path '.\TestResults' -Force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
  - ps: |
       $openCoverConsole = '.\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe'
       $openCoverReg = '-register:user'
-      $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs,*.xaml.cs -filter:"+[Eddi*]* +[Utilities*]* -[Tests*]*"'
+      $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs,*.xaml -filter:"+[Eddi*]* +[Utilities*]* +[Tests*]UnitTests*"'
       $target = '-target:"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
       $targetArgs = '-targetargs:"bin\Release\Tests.dll' + $(If ($APPVEYOR) {' /logger:Appveyor'}) + ' /tests:UnitTests /Parallel /InIsolation /Blame"'
       New-Item -ItemType directory -Path '.\TestResults' -Force


### PR DESCRIPTION
- Include tests from the UnitTests namespace in the coverage evaluation.
- Exclude *.xaml (but not *.xaml.*) from code coverage.