### PR TITLE
Remove the StationLargestPad `FromSize` method.

### DIFF
--- a/CrimeMonitor/CrimeMonitor.cs
+++ b/CrimeMonitor/CrimeMonitor.cs
@@ -1025,11 +1025,11 @@ namespace EddiCrimeMonitor
             {
                 // Filter stations within the faction system which meet the station type prioritization,
                 // max distance from the main star, game version, and landing pad size requirements
-                string shipSize = EDDI.Instance?.CurrentShip?.size ?? "Large";
+                StationLargestPad padSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
                 List<Station> factionStations = !prioritizeOrbitalStations && EDDI.Instance.inHorizons ? factionStarSystem.stations : factionStarSystem.orbitalstations
                     .Where(s => s.stationservices.Count > 0).ToList();
                 factionStations = factionStations.Where(s => s.distancefromstar <= maxStationDistanceFromStarLs).ToList();
-                factionStations = factionStations.Where(s => s.LandingPadCheck(shipSize)).ToList();
+                factionStations = factionStations.Where(s => s.LandingPadCheck(padSize)).ToList();
 
                 // Build list to find the faction station nearest to the main star
                 SortedList<decimal, string> nearestList = new SortedList<decimal, string>();

--- a/CrimeMonitor/CrimeMonitor.cs
+++ b/CrimeMonitor/CrimeMonitor.cs
@@ -1025,7 +1025,7 @@ namespace EddiCrimeMonitor
             {
                 // Filter stations within the faction system which meet the station type prioritization,
                 // max distance from the main star, game version, and landing pad size requirements
-                StationLargestPad padSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
+                LandingPadSize padSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
                 List<Station> factionStations = !prioritizeOrbitalStations && EDDI.Instance.inHorizons ? factionStarSystem.stations : factionStarSystem.orbitalstations
                     .Where(s => s.stationservices.Count > 0).ToList();
                 factionStations = factionStations.Where(s => s.distancefromstar <= maxStationDistanceFromStarLs).ToList();

--- a/DataDefinitions/Properties/StationLargestPad.Designer.cs
+++ b/DataDefinitions/Properties/StationLargestPad.Designer.cs
@@ -39,7 +39,7 @@ namespace EddiDataDefinitions.Properties {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("EddiDataDefinitions.Properties.StationLargestPad", typeof(StationLargestPad).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("EddiDataDefinitions.Properties.LandingPadSize", typeof(StationLargestPad).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -35,7 +35,7 @@ namespace EddiDataDefinitions
 
         /// <summary>the size of this ship</summary>
         [JsonIgnore]
-        public string size { get; set; }
+        public StationLargestPad size { get; set; }
 
         /// <summary>the size of the military compartment slots</summary>
         [JsonIgnore]
@@ -334,7 +334,7 @@ namespace EddiDataDefinitions
             phoneticmanufacturer = PhoneticManufacturer;
             model = Model;
             phoneticmodel = PhoneticModel;
-            size = Size;
+            size = StationLargestPad.FromEDName(Size);
             militarysize = MilitarySize;
             health = 100M;
             hardpoints = new List<Hardpoint>();

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -35,7 +35,7 @@ namespace EddiDataDefinitions
 
         /// <summary>the size of this ship</summary>
         [JsonIgnore]
-        public StationLargestPad size { get; set; }
+        public LandingPadSize size { get; set; }
 
         /// <summary>the size of the military compartment slots</summary>
         [JsonIgnore]
@@ -334,7 +334,7 @@ namespace EddiDataDefinitions
             phoneticmanufacturer = PhoneticManufacturer;
             model = Model;
             phoneticmodel = PhoneticModel;
-            size = StationLargestPad.FromEDName(Size);
+            size = LandingPadSize.FromEDName(Size);
             militarysize = MilitarySize;
             health = 100M;
             hardpoints = new List<Hardpoint>();

--- a/DataDefinitions/Station.cs
+++ b/DataDefinitions/Station.cs
@@ -138,42 +138,42 @@ namespace EddiDataDefinitions
         public StationModel Model { get; set; } = StationModel.None;
 
         /// <summary>What is the largest ship that can land here?</summary>
-        [JsonIgnore, Obsolete("Please use StationLargestPad instead")]
+        [JsonIgnore, Obsolete("Please use LargestPad instead")]
         public string largestpad => LargestPad.localizedName;
         // This field isn't always provided, so we derive it from the station model when it's not explicitly set.
-        public StationLargestPad LargestPad
+        public LandingPadSize LargestPad
         {
             get
             {
                 if (_LargestPad != null)
                 {
-                    return _LargestPad ?? StationLargestPad.None;
+                    return _LargestPad ?? LandingPadSize.None;
                 }
                 if (Model.edname == "None")
                 {
-                    return StationLargestPad.None;
+                    return LandingPadSize.None;
                 }
                 if (Model.edname == "Outpost")
                 {
-                    return StationLargestPad.Medium;
+                    return LandingPadSize.Medium;
                 }
-                return StationLargestPad.Large;
+                return LandingPadSize.Large;
             }
             set
             {
-                _LargestPad = value ?? StationLargestPad.None;
+                _LargestPad = value ?? LandingPadSize.None;
             }
         }
-        private StationLargestPad _LargestPad;
+        private LandingPadSize _LargestPad;
 
-        public bool LandingPadCheck(StationLargestPad shipSize)
+        public bool LandingPadCheck(LandingPadSize shipSize)
         {
-            if (LargestPad == StationLargestPad.Large) { return true; }
-            else if (LargestPad == StationLargestPad.Medium)
+            if (LargestPad == LandingPadSize.Large) { return true; }
+            else if (LargestPad == LandingPadSize.Medium)
             {
-                if (shipSize == StationLargestPad.Large) { return false; } else { return true; }
+                if (shipSize == LandingPadSize.Large) { return false; } else { return true; }
             }
-            if (shipSize == StationLargestPad.Small) { return true; }
+            if (shipSize == LandingPadSize.Small) { return true; }
             return false;
         }
 

--- a/DataDefinitions/Station.cs
+++ b/DataDefinitions/Station.cs
@@ -155,9 +155,9 @@ namespace EddiDataDefinitions
                 }
                 if (Model.edname == "Outpost")
                 {
-                    return StationLargestPad.FromSize("m");
+                    return StationLargestPad.Medium;
                 }
-                return StationLargestPad.FromSize("l");
+                return StationLargestPad.Large;
             }
             set
             {
@@ -169,12 +169,12 @@ namespace EddiDataDefinitions
         public bool LandingPadCheck(string size)
         {
             StationLargestPad shipSize = StationLargestPad.FromEDName(size);
-            if (LargestPad == StationLargestPad.FromSize("l")) { return true; }
-            else if (LargestPad == StationLargestPad.FromSize("m"))
+            if (LargestPad == StationLargestPad.Large) { return true; }
+            else if (LargestPad == StationLargestPad.Medium)
             {
-                if (shipSize == StationLargestPad.FromSize("l")) { return false; } else { return true; }
+                if (shipSize == StationLargestPad.Large) { return false; } else { return true; }
             }
-            if (shipSize == StationLargestPad.FromSize("s")) { return true; }
+            if (shipSize == StationLargestPad.Small) { return true; }
             return false;
         }
 

--- a/DataDefinitions/Station.cs
+++ b/DataDefinitions/Station.cs
@@ -166,9 +166,8 @@ namespace EddiDataDefinitions
         }
         private StationLargestPad _LargestPad;
 
-        public bool LandingPadCheck(string size)
+        public bool LandingPadCheck(StationLargestPad shipSize)
         {
-            StationLargestPad shipSize = StationLargestPad.FromEDName(size);
             if (LargestPad == StationLargestPad.Large) { return true; }
             else if (LargestPad == StationLargestPad.Medium)
             {

--- a/DataDefinitions/StationLargestPad.cs
+++ b/DataDefinitions/StationLargestPad.cs
@@ -4,30 +4,30 @@ namespace EddiDataDefinitions
 {
     /// <summary> Station's largest landing pad size </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    public class StationLargestPad : ResourceBasedLocalizedEDName<StationLargestPad>
+    public class LandingPadSize : ResourceBasedLocalizedEDName<LandingPadSize>
     {
-        static StationLargestPad()
+        static LandingPadSize()
         {
             resourceManager = Properties.StationLargestPad.ResourceManager;
             resourceManager.IgnoreCase = true;
-            missingEDNameHandler = (edname) => new StationLargestPad(edname);
+            missingEDNameHandler = (edname) => new LandingPadSize(edname);
 
-            None = new StationLargestPad("None");
-            Large = new StationLargestPad("Large");
-            Medium = new StationLargestPad("Medium");
-            Small = new StationLargestPad("Small");
+            None = new LandingPadSize("None");
+            Large = new LandingPadSize("Large");
+            Medium = new LandingPadSize("Medium");
+            Small = new LandingPadSize("Small");
         }
 
-        public static readonly StationLargestPad None;
-        public static readonly StationLargestPad Large;
-        public static readonly StationLargestPad Medium;
-        public static readonly StationLargestPad Small;
+        public static readonly LandingPadSize None;
+        public static readonly LandingPadSize Large;
+        public static readonly LandingPadSize Medium;
+        public static readonly LandingPadSize Small;
 
         // dummy used to ensure that the static constructor has run
-        public StationLargestPad() : this("")
+        public LandingPadSize() : this("")
         { }
 
-        private StationLargestPad(string edname) : base(edname, edname)
+        private LandingPadSize(string edname) : base(edname, edname)
         { }
     }
 }

--- a/DataDefinitions/StationLargestPad.cs
+++ b/DataDefinitions/StationLargestPad.cs
@@ -13,12 +13,15 @@ namespace EddiDataDefinitions
             missingEDNameHandler = (edname) => new StationLargestPad(edname);
 
             None = new StationLargestPad("None");
-            var Large = new StationLargestPad("Large");
-            var Medium = new StationLargestPad("Medium");
-            var Small = new StationLargestPad("Small");
+            Large = new StationLargestPad("Large");
+            Medium = new StationLargestPad("Medium");
+            Small = new StationLargestPad("Small");
         }
 
         public static readonly StationLargestPad None;
+        public static readonly StationLargestPad Large;
+        public static readonly StationLargestPad Medium;
+        public static readonly StationLargestPad Small;
 
         // dummy used to ensure that the static constructor has run
         public StationLargestPad() : this("")
@@ -26,18 +29,5 @@ namespace EddiDataDefinitions
 
         private StationLargestPad(string edname) : base(edname, edname)
         { }
-
-        public static StationLargestPad FromSize(string value)
-        {
-            // Map old values from when we had an enum and map abbreviated sizes
-            string size = string.Empty;
-            if (value == "0" || value == null) { size = "None"; }
-            value = value?.ToLowerInvariant();
-            if (value == "1" || value == "s") { size = "Small"; }
-            if (value == "2" || value == "m") { size = "Medium"; }
-            if (value == "3" || value == "l") { size = "Large"; }
-
-            return FromName(size);
-        }
     }
 }

--- a/NavigationService/Navigation.cs
+++ b/NavigationService/Navigation.cs
@@ -315,7 +315,7 @@ namespace EddiNavigationService
             StarSystem currentSystem = EDDI.Instance?.CurrentStarSystem;
             if (currentSystem != null)
             {
-                StationLargestPad shipSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
+                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
 
                 StarSystem ServiceStarSystem = GetServiceSystem(serviceType, maxStationDistance, prioritizeOrbitalStations);
@@ -361,7 +361,7 @@ namespace EddiNavigationService
             if (currentSystem != null)
             {
                 // Get the filter parameters
-                StationLargestPad shipSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
+                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
                 int cubeLy = filter.cubeLy;
 

--- a/NavigationService/Navigation.cs
+++ b/NavigationService/Navigation.cs
@@ -315,7 +315,7 @@ namespace EddiNavigationService
             StarSystem currentSystem = EDDI.Instance?.CurrentStarSystem;
             if (currentSystem != null)
             {
-                string shipSize = EDDI.Instance?.CurrentShip?.size ?? "Large";
+                StationLargestPad shipSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
 
                 StarSystem ServiceStarSystem = GetServiceSystem(serviceType, maxStationDistance, prioritizeOrbitalStations);
@@ -361,7 +361,7 @@ namespace EddiNavigationService
             if (currentSystem != null)
             {
                 // Get the filter parameters
-                string shipSize = EDDI.Instance?.CurrentShip?.size ?? "Large";
+                StationLargestPad shipSize = EDDI.Instance?.CurrentShip?.size ?? StationLargestPad.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
                 int cubeLy = filter.cubeLy;
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -353,7 +353,7 @@ namespace EddiShipMonitor
                 updatedAt = @event.timestamp;
 
                 // Save swapped ship size for minor faction station update
-                string swappedShipSize = GetCurrentShip()?.size;
+                StationLargestPad swappedShipSize = GetCurrentShip()?.size;
 
                 // Update our current ship
                 SetCurrentShip(@event.shipid, @event.ship);
@@ -377,7 +377,7 @@ namespace EddiShipMonitor
                 if (!@event.fromLoad) { writeShips(); }
 
                 // Update stations in minor faction records
-                if (swappedShipSize != "Large" && swappedShipSize != GetCurrentShip()?.size)
+                if (swappedShipSize != StationLargestPad.Large && swappedShipSize != GetCurrentShip()?.size)
                 {
                     ((CrimeMonitor)EDDI.Instance.ObtainMonitor("Crime monitor"))?.UpdateStations();
                 }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -353,7 +353,7 @@ namespace EddiShipMonitor
                 updatedAt = @event.timestamp;
 
                 // Save swapped ship size for minor faction station update
-                StationLargestPad swappedShipSize = GetCurrentShip()?.size;
+                LandingPadSize swappedShipSize = GetCurrentShip()?.size;
 
                 // Update our current ship
                 SetCurrentShip(@event.shipid, @event.ship);
@@ -377,7 +377,7 @@ namespace EddiShipMonitor
                 if (!@event.fromLoad) { writeShips(); }
 
                 // Update stations in minor faction records
-                if (swappedShipSize != StationLargestPad.Large && swappedShipSize != GetCurrentShip()?.size)
+                if (swappedShipSize != LandingPadSize.Large && swappedShipSize != GetCurrentShip()?.size)
                 {
                     ((CrimeMonitor)EDDI.Instance.ObtainMonitor("Crime monitor"))?.UpdateStations();
                 }

--- a/SpeechService/SpeechFX.cs
+++ b/SpeechService/SpeechFX.cs
@@ -84,15 +84,15 @@ namespace EddiSpeechService
             int echoDelay = 50; // Default
             if (ship != null)
             {
-                if (ship.size == StationLargestPad.Small)
+                if (ship.size == LandingPadSize.Small)
                 {
                     echoDelay = 50;
                 }
-                else if (ship.size == StationLargestPad.Medium)
+                else if (ship.size == LandingPadSize.Medium)
                 {
                     echoDelay = 100;
                 }
-                else if (ship.size == StationLargestPad.Large)
+                else if (ship.size == LandingPadSize.Large)
                 {
                     echoDelay = 200;
                 }

--- a/SpeechService/SpeechFX.cs
+++ b/SpeechService/SpeechFX.cs
@@ -84,21 +84,17 @@ namespace EddiSpeechService
             int echoDelay = 50; // Default
             if (ship != null)
             {
-                if (ship.size == "Small")
+                if (ship.size == StationLargestPad.Small)
                 {
                     echoDelay = 50;
                 }
-                else if (ship.size == "Medium")
+                else if (ship.size == StationLargestPad.Medium)
                 {
                     echoDelay = 100;
                 }
-                else if (ship.size == "Large")
+                else if (ship.size == StationLargestPad.Large)
                 {
                     echoDelay = 200;
-                }
-                else if (ship.size == "Huge")
-                {
-                    echoDelay = 400;
                 }
             }
             return echoDelay;

--- a/Tests/TestBase.cs
+++ b/Tests/TestBase.cs
@@ -21,6 +21,7 @@ namespace UnitTests
             Utilities.Files.unitTesting = true;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
         public static T DeserializeJsonResource<T>(byte[] data) where T : class
         {
             using (var stream = new MemoryStream(data))

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -569,7 +569,7 @@ namespace EddiVoiceAttackResponder
                     vaProxy.SetText(prefix + " ident", ship?.ident);
                     vaProxy.SetText(prefix + " ident (spoken)", Translations.ICAO(ship?.ident, false));
                     vaProxy.SetText(prefix + " role", ship?.Role?.localizedName);
-                    vaProxy.SetText(prefix + " size", ship?.size?.ToString());
+                    vaProxy.SetText(prefix + " size", ship?.size?.localizedName);
                     vaProxy.SetDecimal(prefix + " value", ship?.value);
                     vaProxy.SetText(prefix + " value (spoken)", Translations.Humanize(ship?.value));
                     vaProxy.SetDecimal(prefix + " health", ship?.health);


### PR DESCRIPTION
Note: Please review #1424 prior to reviewing this PR.

The method isn't really serving any useful purpose, streamline to simply use ednames instead.
Removes an area with inconsistently reported code coverage (possibly because abbreviated values if if conditions were being hit while enum values were not).