### PR TITLE
EDDN sanity checks

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -633,6 +633,8 @@ namespace EddiCompanionAppService
                     debt = (long)json["commander"]["debt"]
                 };
                 Profile.Cmdr = Commander;
+                Profile.docked = (bool)json["commander"]["docked"];
+                Profile.alive = (bool)json["commander"]["alive"];
 
                 string systemName = json["lastSystem"] == null ? null : (string)json["lastSystem"]["name"];
                 if (systemName != null)

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -434,15 +434,16 @@ namespace EddiCompanionAppService
                 market = "{\"lastStarport\":" + market + "}";
                 JObject marketJson = JObject.Parse(market);
                 string lastStarport = (string)marketJson["lastStarport"]["name"];
+                long? marketId = (long?)marketJson["lastStarport"]["id"];
 
                 cachedProfile.CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(systemName);
                 cachedProfile.LastStation = cachedProfile.CurrentStarSystem?.stations?.Find(s => s.name == lastStarport);
                 if (cachedProfile.LastStation == null)
                 {
                     // Don't have a station so make one up
-                    cachedProfile.LastStation = new Station { name = lastStarport };
+                    cachedProfile.LastStation = new Station { name = lastStarport, marketId = marketId };
                 }
-                cachedProfile.LastStation.systemname = systemName;
+                cachedProfile.CurrentStarSystem.systemname = systemName;
 
                 if (cachedProfile.LastStation.hasmarket ?? false)
                 {
@@ -647,14 +648,15 @@ namespace EddiCompanionAppService
                         // Don't have a station so make one up
                         Profile.LastStation = new Station
                         {
-                            name = (string)json["lastStarport"]["name"]
+                            name = (string)json["lastStarport"]["name"],
+                            marketId = (long?)json["lastStarport"]["id"]
                         };
                     }
-
-                    Profile.LastStation.systemname = Profile.CurrentStarSystem.systemname;
-                    Profile.LastStation.systemAddress = Profile.CurrentStarSystem.systemAddress;
-                    Profile.LastStation.marketId = (long?)json["lastStarport"]["id"];
-
+                    if ((bool)json["commander"]["docked"])
+                    {
+                        Profile.LastStation.systemname = Profile.CurrentStarSystem.systemname;
+                        Profile.LastStation.systemAddress = Profile.CurrentStarSystem.systemAddress;
+                    }
                 }
             }
 

--- a/CompanionAppService/Profile.cs
+++ b/CompanionAppService/Profile.cs
@@ -19,5 +19,11 @@ namespace EddiCompanionAppService
 
         /// <summary>The last station the commander docked at</summary>
         public Station LastStation { get; set; }
+
+        /// <summary>Whether this profile describes a docked commander</summary>
+        public bool docked { get; set; }
+
+        /// <summary>Whether this profile describes a currently living commander</summary>
+        public bool alive { get; set; }
     }
 }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1265,10 +1265,12 @@ namespace Eddi
 
         private bool eventMarket(MarketEvent theEvent)
         {
-            if (allowMarketUpdate && CurrentStation != null && CurrentStation.marketId == theEvent.marketId)
+            if (allowMarketUpdate)
             {
                 MarketInfoReader info = MarketInfoReader.FromFile();
-                if (info != null)
+                if (info != null && info.MarketID == theEvent.marketId 
+                    && info.StarSystem == theEvent.system 
+                    && info.StationName == theEvent.station)
                 {
                     List<CommodityMarketQuote> quotes = new List<CommodityMarketQuote>();
                     foreach (MarketInfo item in info.Items)
@@ -1282,18 +1284,21 @@ namespace Eddi
 
                     if (quotes != null && info.Items.Count == quotes.Count)
                     {
-                        // Update the current station commodities
-                        allowMarketUpdate = false;
-                        CurrentStation.commodities = quotes;
-                        CurrentStation.commoditiesupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                        if (CurrentStation?.marketId == theEvent.marketId)
+                        {
+                            // Update the current station commodities
+                            allowMarketUpdate = false;
+                            CurrentStation.commodities = quotes;
+                            CurrentStation.commoditiesupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
 
-                        // Update the current station information in our backend DB
-                        Logging.Debug("Star system information updated from remote server; updating local copy");
-                        StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                            // Update the current station information in our backend DB
+                            Logging.Debug("Star system information updated from remote server; updating local copy");
+                            StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                        }
 
                         // Post an update event for new market data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, "market");
+                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1304,10 +1309,13 @@ namespace Eddi
 
         private bool eventOutfitting(OutfittingEvent theEvent)
         {
-            if (allowOutfittingUpdate && CurrentStation != null && CurrentStation.marketId == theEvent.marketId)
+            if (allowOutfittingUpdate)
             {
                 OutfittingInfoReader info = OutfittingInfoReader.FromFile();
-                if (info.Items != null)
+                if (info.Items != null && info.MarketID == theEvent.marketId 
+                    && info.StarSystem == theEvent.system 
+                    && info.StationName == theEvent.station 
+                    && info.Horizons == Instance.inHorizons)
                 {
                     List<EddiDataDefinitions.Module> modules = new List<EddiDataDefinitions.Module>();
                     foreach (OutfittingInfo item in info.Items)
@@ -1321,18 +1329,21 @@ namespace Eddi
 
                     if (modules != null && info.Items.Count == modules.Count)
                     {
-                        // Update the current station outfitting
-                        allowOutfittingUpdate = false;
-                        CurrentStation.outfitting = modules;
-                        CurrentStation.outfittingupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                        if (CurrentStation?.marketId == theEvent.marketId)
+                        {
+                            // Update the current station outfitting
+                            allowOutfittingUpdate = false;
+                            CurrentStation.outfitting = modules;
+                            CurrentStation.outfittingupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
 
-                        // Update the current station information in our backend DB
-                        Logging.Debug("Star system information updated from remote server; updating local copy");
-                        StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                            // Update the current station information in our backend DB
+                            Logging.Debug("Star system information updated from remote server; updating local copy");
+                            StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                        }
 
                         // Post an update event for new outfitting data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, "outfitting");
+                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1343,10 +1354,13 @@ namespace Eddi
 
         private bool eventShipyard(ShipyardEvent theEvent)
         {
-            if (allowShipyardUpdate && CurrentStation != null && CurrentStation.marketId == theEvent.marketId)
+            if (allowShipyardUpdate)
             {
                 ShipyardInfoReader info = ShipyardInfoReader.FromFile();
-                if (info.PriceList != null)
+                if (info.PriceList != null && info.MarketID == theEvent.marketId 
+                    && info.StarSystem == theEvent.system 
+                    && info.StationName == theEvent.station 
+                    && info.Horizons == Instance.inHorizons)
                 {
                     List<Ship> ships = new List<Ship>();
                     foreach (ShipyardInfo item in info.PriceList)
@@ -1360,18 +1374,21 @@ namespace Eddi
 
                     if (ships != null && info.PriceList.Count == ships.Count)
                     {
-                        // Update the current station shipyard
-                        allowShipyardUpdate = false;
-                        CurrentStation.shipyard = ships;
-                        CurrentStation.shipyardupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                        if (CurrentStation?.marketId == theEvent.marketId)
+                        {
+                            // Update the current station shipyard
+                            allowShipyardUpdate = false;
+                            CurrentStation.shipyard = ships;
+                            CurrentStation.shipyardupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
 
-                        // Update the current station information in our backend DB
-                        Logging.Debug("Star system information updated from remote server; updating local copy");
-                        StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                            // Update the current station information in our backend DB
+                            Logging.Debug("Star system information updated from remote server; updating local copy");
+                            StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                        }
 
                         // Post an update event for new shipyard data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, "shipyard");
+                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -2043,7 +2060,7 @@ namespace Eddi
 
                             // We don't know if we are docked or not at this point.  Fill in the data if we can, and
                             // let later systems worry about removing it if it's decided that we aren't docked
-                            if (profile.LastStation != null && profile.LastStation.systemname == CurrentStarSystem.systemname && CurrentStarSystem.stations != null)
+                            if (profile.LastStation?.systemname == CurrentStarSystem.systemname && CurrentStarSystem.stations != null)
                             {
                                 CurrentStation = CurrentStarSystem.stations.FirstOrDefault(s => s.name == profile.LastStation.name);
                                 if (CurrentStation != null)
@@ -2330,7 +2347,7 @@ namespace Eddi
                     if (profileUpdateNeeded)
                     {
                         // See if we still need this particular update
-                        if (profileStationRequired != null && (CurrentStation == null || CurrentStation.name != profileStationRequired))
+                        if ((profileStationRequired != null && (CurrentStation?.name != profileStationRequired)) || Environment != Constants.ENVIRONMENT_DOCKED)
                         {
                             Logging.Debug("No longer at requested station; giving up on update");
                             profileUpdateNeeded = false;
@@ -2345,40 +2362,48 @@ namespace Eddi
                         }
 
                         // We do need to fetch an updated profile; do so
-                        ApiTimeStamp = DateTime.UtcNow;
-                        long profileTime = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-                        Logging.Debug("Fetching station profile");
-                        Profile profile = CompanionAppService.Instance.Station(CurrentStarSystem.systemname);
-
-                        // See if it is up-to-date regarding our requirements
-                        Logging.Debug("profileStationRequired is " + profileStationRequired + ", profile station is " + profile.LastStation.name);
-
-                        if (profileStationRequired != null && profileStationRequired == profile.LastStation.name)
+                        Profile profile = CompanionAppService.Instance?.Profile();
+                        if (profile != null)
                         {
-                            // We have the required station information
-                            Logging.Debug("Current station matches profile information; updating info");
-                            CurrentStation.commodities = profile.LastStation.commodities;
-                            CurrentStation.economyShares = profile.LastStation.economyShares;
-                            CurrentStation.prohibited = profile.LastStation.prohibited;
-                            CurrentStation.commoditiesupdatedat = profileTime;
-                            CurrentStation.outfitting = profile.LastStation.outfitting;
-                            CurrentStation.shipyard = profile.LastStation.shipyard;
-                            CurrentStation.updatedat = profileTime;
+                            if ((bool)profile.json["commander"]["docked"])
+                            {
+                                ApiTimeStamp = DateTime.UtcNow;
+                                long profileTime = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
 
-                            // Update the current station information in our backend DB
-                            Logging.Debug("Star system information updated from remote server; updating local copy");
-                            StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                                Logging.Debug("Fetching station profile");
+                                Profile stationProfile = CompanionAppService.Instance.Station(CurrentStarSystem.systemname);
 
-                            // Post an update event
-                            Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, "profile");
-                            enqueueEvent(@event);
+                                // See if it is up-to-date regarding our requirements
+                                Logging.Debug("profileStationRequired is " + profileStationRequired + ", profile station is " + stationProfile.LastStation.name);
 
-                            profileUpdateNeeded = false;
-                            allowMarketUpdate = false;
-                            allowOutfittingUpdate = false;
-                            allowShipyardUpdate = false;
+                                if (profileStationRequired != null && profileStationRequired == stationProfile.LastStation.name)
+                                {
+                                    // We have the required station information
+                                    Logging.Debug("Current station matches profile information; updating info");
+                                    CurrentStation.commodities = stationProfile.LastStation.commodities;
+                                    CurrentStation.economyShares = stationProfile.LastStation.economyShares;
+                                    CurrentStation.prohibited = stationProfile.LastStation.prohibited;
+                                    CurrentStation.commoditiesupdatedat = profileTime;
+                                    CurrentStation.outfitting = stationProfile.LastStation.outfitting;
+                                    CurrentStation.shipyard = stationProfile.LastStation.shipyard;
+                                    CurrentStation.updatedat = profileTime;
 
-                            break;
+                                    // Update the current station information in our backend DB
+                                    Logging.Debug("Star system information updated from remote server; updating local copy");
+                                    StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+
+                                    // Post an update event
+                                    Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, stationProfile.CurrentStarSystem.systemname, stationProfile.LastStation.name, stationProfile.LastStation.marketId, stationProfile.LastStation.commodities, stationProfile.LastStation.prohibited, stationProfile.LastStation.outfitting, stationProfile.LastStation.shipyard);
+                                    enqueueEvent(@event);
+
+                                    profileUpdateNeeded = false;
+                                    allowMarketUpdate = false;
+                                    allowOutfittingUpdate = false;
+                                    allowShipyardUpdate = false;
+
+                                    break;
+                                }
+                            }
                         }
 
                         // No luck; sleep and try again

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1298,7 +1298,7 @@ namespace Eddi
 
                         // Post an update event for new market data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1343,7 +1343,7 @@ namespace Eddi
 
                         // Post an update event for new outfitting data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1388,7 +1388,7 @@ namespace Eddi
 
                         // Post an update event for new shipyard data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(DateTime.UtcNow, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
+                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -2058,13 +2058,12 @@ namespace Eddi
                             CurrentStarSystem = profile?.CurrentStarSystem;
                             setSystemDistanceFromHome(CurrentStarSystem);
 
-                            // We don't know if we are docked or not at this point.  Fill in the data if we can, and
-                            // let later systems worry about removing it if it's decided that we aren't docked
-                            if (profile.LastStation?.systemname == CurrentStarSystem.systemname && CurrentStarSystem.stations != null)
+                            if (profile.docked && profile.CurrentStarSystem?.systemname == CurrentStarSystem.systemname && CurrentStarSystem.stations != null)
                             {
                                 CurrentStation = CurrentStarSystem.stations.FirstOrDefault(s => s.name == profile.LastStation.name);
                                 if (CurrentStation != null)
                                 {
+                                    // Only set the current station if it is not present, otherwise we leave it to events
                                     Logging.Debug("Set current station to " + CurrentStation.name);
                                     CurrentStation.updatedat = profileTime;
                                     updatedCurrentStarSystem = true;
@@ -2366,7 +2365,7 @@ namespace Eddi
                         if (profile != null)
                         {
                             // If we're docked, the lastStation information is located within the lastSystem identified by the profile
-                            if ((bool)profile.json["commander"]["docked"] &&  Environment == Constants.ENVIRONMENT_DOCKED)
+                            if (profile.docked && Environment == Constants.ENVIRONMENT_DOCKED)
                             {
                                 ApiTimeStamp = DateTime.UtcNow;
                                 long profileTime = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;

--- a/EDDI/MarketInfoReader.cs
+++ b/EDDI/MarketInfoReader.cs
@@ -1,5 +1,6 @@
 ﻿using EddiDataDefinitions;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using Utilities;
 
@@ -7,6 +8,8 @@ namespace Eddi
 {
     public class MarketInfoReader
     {
+        public string timestamp { get; set; }
+        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/MarketInfoReader.cs
+++ b/EDDI/MarketInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class MarketInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
+        public DateTime timeStamp => DateTime.Parse(timestamp);
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/OutfittingInfoReader.cs
+++ b/EDDI/OutfittingInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class OutfittingInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
+        public DateTime timeStamp => DateTime.Parse(timestamp);
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/OutfittingInfoReader.cs
+++ b/EDDI/OutfittingInfoReader.cs
@@ -1,5 +1,6 @@
 ﻿using EddiDataDefinitions;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using Utilities;
 

--- a/EDDI/OutfittingInfoReader.cs
+++ b/EDDI/OutfittingInfoReader.cs
@@ -7,6 +7,8 @@ namespace Eddi
 {
     public class OutfittingInfoReader
     {
+        public string timestamp { get; set; }
+        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/ShipyardInfoReader.cs
+++ b/EDDI/ShipyardInfoReader.cs
@@ -1,5 +1,6 @@
 ﻿using EddiDataDefinitions;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using Utilities;
 

--- a/EDDI/ShipyardInfoReader.cs
+++ b/EDDI/ShipyardInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class ShipyardInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
+        public DateTime timeStamp => DateTime.Parse(timestamp);
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/ShipyardInfoReader.cs
+++ b/EDDI/ShipyardInfoReader.cs
@@ -7,6 +7,8 @@ namespace Eddi
 {
     public class ShipyardInfoReader
     {
+        public string timestamp { get; set; }
+        public DateTime timeStamp => DateTime.Parse("yyyy-MM-ddTHH:mm:ssZ");
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/Events/MarketInformationUpdatedEvent.cs
+++ b/Events/MarketInformationUpdatedEvent.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EddiDataDefinitions;
+using System;
 using System.Collections.Generic;
 
 namespace EddiEvents
@@ -15,12 +16,32 @@ namespace EddiEvents
         {
         }
 
-        // Update type - `market`, `outfitting`, `profile`, or `shipyard`
-        public string update { get; private set; }
+        public bool inHorizons { get; private set; }
 
-        public MarketInformationUpdatedEvent(DateTime timestamp, string update) : base(timestamp, NAME)
+        public string starSystem { get; private set; }
+
+        public string stationName { get; private set; }
+
+        public long? marketId { get; private set; }
+
+        public List<CommodityMarketQuote> commodities { get; private set; }
+
+        public List<string> prohibitedCommodities { get; private set; }
+
+        public List<Module> outfitting { get; private set; }
+
+        public List<Ship> shipyard { get; private set; }
+
+        public MarketInformationUpdatedEvent(DateTime timestamp, bool inHorizons, string starSystem, string stationName, long? marketId, List<CommodityMarketQuote> commodities, List<string> prohibitedCommodities, List<Module> outfitting, List<Ship> shipyard) : base(timestamp, NAME)
         {
-            this.update = update;
+            this.inHorizons = inHorizons;
+            this.starSystem = starSystem;
+            this.stationName = stationName;
+            this.marketId = marketId;
+            this.commodities = commodities;
+            this.prohibitedCommodities = prohibitedCommodities;
+            this.outfitting = outfitting;
+            this.shipyard = shipyard;
         }
     }
 }


### PR DESCRIPTION
Add sanity checks for updates from `market.json`, `outfitting.json`, and `shipyard.json`.
Add `docked` and `alive` properties from the Frontier API profile.
Convert the `MarketInformationUpdated` event to be more self contained.