### PR TITLE
Fix inadvertantly disabled hyperlink in the Speech Responder tab

### DIFF
--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -335,14 +335,8 @@ namespace EddiSpeechResponder
 
         private void SpeechResponderHelp_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is CheckBox checkBox)
-            {
-                if (checkBox.IsLoaded)
-                {
-                    MarkdownWindow speechResponderHelpWindow = new MarkdownWindow("speechResponderHelp.md");
-                    speechResponderHelpWindow.Show();
-                }
-            }
+            MarkdownWindow speechResponderHelpWindow = new MarkdownWindow("speechResponderHelp.md");
+            speechResponderHelpWindow.Show();
         }
     }
 }


### PR DESCRIPTION
The "Read about the speech responder's functions here" hyperlink was broken by recent changes. Since the click is triggered by a hyperlink, the sender is never a checkbox and does not trigger on loading the UI.