### PR TITLE
Highlight non-default scripts in the Speech Responder UI

### DIFF
--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -87,7 +87,18 @@
         </Grid>
         <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding Personality.Scripts}" EnableRowVirtualization="False">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending" />
+                <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending">
+                    <DataGridTextColumn.CellStyle>
+                        <Style TargetType="{x:Type DataGridCell}">
+                            <Setter Property="FontWeight" Value="Normal"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=Value.Default}" Value="False">
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </DataGridTextColumn.CellStyle>
+                </DataGridTextColumn>
                 <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_enabled}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -196,7 +196,7 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its &apos;Test&apos; and &apos;View&apos; buttons are disabled. Event-based scripts can be disabled or re-prioritized but not deleted..
+        ///   Looks up a localized string similar to Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its &apos;Test&apos; and &apos;View&apos; buttons are disabled. If a script response differs from the default, it&apos;s name shall be written in bold text. Event-based scripts can be disabled or re-prioritized but not deleted..
         /// </summary>
         public static string desc {
             get {

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -164,7 +164,7 @@
     <value>Are you sure you want to delete the "{0}" script ?</value>
   </data>
   <data name="desc" xml:space="preserve">
-    <value>Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its 'Test' and 'View' buttons are disabled. Event-based scripts can be disabled or re-prioritized but not deleted.</value>
+    <value>Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its 'Test' and 'View' buttons are disabled. If a script response differs from the default, it's name shall be written in bold text. Event-based scripts can be disabled or re-prioritized but not deleted.</value>
   </data>
   <data name="edit_script" xml:space="preserve">
     <value>Edit</value>


### PR DESCRIPTION
If a script response differs from the default, it's name shall be written in bold text.
Resolves #1464.