### PR TITLE
Prevent deletion of responder scripts

### DIFF
--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -53,7 +53,7 @@ namespace EddiSpeechResponder
         }
 
         [JsonIgnore]
-        public bool IsDeleteable => !isDefault;
+        public bool IsDeleteable => !isDefault && !responder;
 
         [JsonIgnore]
         public string Value


### PR DESCRIPTION
At present it is possible to temporarily delete responder scripts (scripts tied to events) by following the sequence:
- Modify the `AFMU repairs` script
- Note that the delete button becomes available.
- Press the delete button and delete the script from my custom personality.

If I then restart EDDI, the script is regenerated / restored from the default template. Giving users the ability to temporarily delete scripts that will be restored to their default state on EDDI's next load is confusing to the end user. This PR makes responder scripts undeletable.