### PR TITLE
Revise the `Delete` button in the Speech Responder UI to either `Delete` or `Reset`, as appropriate.

### DIFF
--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -144,12 +144,12 @@
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button IsEnabled="{Binding Path=Value.IsResetableOrDeletable}" Click="resetOrDeleteScript">
+                            <Button IsEnabled="{Binding Path=Value.IsResettableOrDeletable}" Click="resetOrDeleteScript">
                                 <Button.Style>
                                     <Style TargetType="{x:Type Button}">
                                         <Setter Property="Content" Value="{x:Static resx:SpeechResponder.delete_script}" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Path=Value.IsResetable}" Value="True">
+                                            <DataTrigger Binding="{Binding Path=Value.IsResettable}" Value="True">
                                                 <Setter Property="Content" Value="{x:Static resx:SpeechResponder.reset_script}" />
                                             </DataTrigger>
                                         </Style.Triggers>

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -144,7 +144,18 @@
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button IsEnabled="{Binding Path=Value.IsDeleteable}" Click="deleteScript" Content="{x:Static resx:SpeechResponder.delete_script}" />
+                            <Button IsEnabled="{Binding Path=Value.IsResetableOrDeletable}" Click="resetOrDeleteScript">
+                                <Button.Style>
+                                    <Style TargetType="{x:Type Button}">
+                                        <Setter Property="Content" Value="{x:Static resx:SpeechResponder.delete_script}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Path=Value.IsResetable}" Value="True">
+                                                <Setter Property="Content" Value="{x:Static resx:SpeechResponder.reset_script}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -168,7 +168,7 @@ namespace EddiSpeechResponder
             Script script = ((KeyValuePair<string, Script>)((Button)e.Source).DataContext).Value;
             if (script != null)
             {
-                if (script.IsResetable)
+                if (script.IsResettable)
                 {
                     resetScript(sender, e);
                 }

--- a/SpeechResponder/EditScriptWindow.xaml
+++ b/SpeechResponder/EditScriptWindow.xaml
@@ -30,7 +30,7 @@
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Rows="1" Columns="3" Width="770" Margin="0,0,0,10" HorizontalAlignment="Center">
                 <Button x:Name="testButton" FontSize="18" Content="{x:Static resx:SpeechResponder.test_script_button}" VerticalAlignment="Top" Click="testButtonClick" Margin="0,0,5,0"/>
                 <Button x:Name="resetToDefaultButton" FontSize="18" Content="{x:Static resx:SpeechResponder.reset_script_button}" VerticalAlignment="Top" Click="resetButtonClick" Margin="5,0,5,0"/>
-                <Button x:Name="showDefaultButton" FontSize="18" Content="{x:Static resx:SpeechResponder.compare_script_button}" VerticalAlignment="Top" Click="showDefaultButtonClick" Margin="5,0,0,0"/>
+                <Button x:Name="showDiffButton" FontSize="18" Content="{x:Static resx:SpeechResponder.compare_script_button}" VerticalAlignment="Top" Click="showDiffButtonClick" Margin="5,0,0,0"/>
             </UniformGrid>
             <UniformGrid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Rows="1" Columns="4" Width="770" Margin="0,0,0,10" HorizontalAlignment="Center">
                 <Button x:Name="acceptButton" FontSize="18" Content="{x:Static resx:SpeechResponder.button_ok}" VerticalAlignment="Top" Click="acceptButtonClick" Margin="0,0,5,0"/>

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -48,6 +48,8 @@ namespace EddiSpeechResponder
             set { responder = value; OnPropertyChanged("Responder"); }
         }
 
+        public string ScriptDefaultValue;
+
         public event PropertyChangedEventHandler PropertyChanged;
         protected void OnPropertyChanged(string name)
         {
@@ -77,16 +79,15 @@ namespace EddiSpeechResponder
                 ScriptName = script.Name;
                 ScriptDescription = script.Description;
                 ScriptValue = script.Value;
+                ScriptDefaultValue = script.defaultValue;
                 Responder = script.Responder;
             }
 
-            // See if there is a default for this script
-            Personality defaultPersonality = Personality.Default();
-            defaultPersonality.Scripts.TryGetValue(scriptName, out Script defaultScript);
-            if (defaultScript == null || defaultScript.Value == null)
+            // See if there is the default value for this script is empty
+            if (string.IsNullOrWhiteSpace(ScriptDefaultValue))
             {
                 // No default; disable reset and show
-                showDefaultButton.IsEnabled = false;
+                showDiffButton.IsEnabled = false;
                 resetToDefaultButton.IsEnabled = false;
             }
         }
@@ -101,8 +102,8 @@ namespace EddiSpeechResponder
             }
             else
             {
-                // Fetch the default script and mark this as default if it matches
-                script = new Script(scriptName, scriptDescription, script == null ? false : script.Responder, scriptValue, script.Priority, false);
+                // Update the script
+                script = new Script(scriptName, scriptDescription, script == null ? false : script.Responder, scriptValue, script.Priority, script.defaultValue);
                 Script defaultScript = null;
                 if (Personality.Default().Scripts?.TryGetValue(script.Name, out defaultScript) ?? false)
                 {
@@ -140,9 +141,7 @@ namespace EddiSpeechResponder
         private void resetButtonClick(object sender, RoutedEventArgs e)
         {
             // Resetting the script resets it to its value in the default personality
-            Personality defaultPersonality = Personality.Default();
-            defaultPersonality.Scripts.TryGetValue(scriptName, out Script defaultScript);
-            ScriptValue = defaultScript.Value;
+            ScriptValue = ScriptDefaultValue;
         }
 
         private void testButtonClick(object sender, RoutedEventArgs e)
@@ -190,13 +189,11 @@ namespace EddiSpeechResponder
             }
         }
 
-        private void showDefaultButtonClick(object sender, RoutedEventArgs e)
+        private void showDiffButtonClick(object sender, RoutedEventArgs e)
         {
-            Personality defaultPersonality = Personality.Default();
-            if (defaultPersonality.Scripts.TryGetValue(scriptName, out Script defaultScript))
+            if (!string.IsNullOrWhiteSpace(ScriptDefaultValue))
             {
-                new ShowDiffWindow(defaultScript.Value, ScriptValue).Show();
-                //new ShowScriptWindow(defaultScript.Value).Show();
+                new ShowDiffWindow(ScriptDefaultValue, ScriptValue).Show();
             }
         }
     }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -301,6 +301,7 @@ namespace EddiSpeechResponder
             fixedScripts = fixedScripts.OrderBy(s => s.Key).ToDictionary(s => s.Key, s => s.Value);
 
             personality.Scripts = fixedScripts;
+            personality.ToFile();
         }
 
         public static Script UpgradeScript(Script personalityScript, Script defaultScript)

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -315,8 +315,9 @@ namespace EddiSpeechResponder
 
                     if (defaultScript.Responder)
                     {
-                        // This is a responder script so update the description
+                        // This is a responder script so update applicable parameters
                         script.Description = defaultScript.Description;
+                        script.Responder = defaultScript.Responder;
                     }
                 }
             }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -310,22 +310,13 @@ namespace EddiSpeechResponder
             {
                 if (defaultScript != null)
                 {
+                    // Set the default value of our script
+                    script.defaultValue = defaultScript.Value;
+
                     if (defaultScript.Responder)
                     {
                         // This is a responder script so update the description
                         script.Description = defaultScript.Description;
-                    }
-
-                    if (script.Default)
-                    {
-                        // This is a default script so take the latest value
-                        script.Value = defaultScript.Value;
-                    }
-
-                    if (script.Value == defaultScript.Value)
-                    {
-                        // Ensure this is flaged as a default script (pre 2-3 didn't have this flag)
-                        script.Default = true;
                     }
                 }
             }

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -160,7 +160,7 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the &quot;{0}&quot; personality ?.
+        ///   Looks up a localized string similar to Are you sure you want to delete the &quot;{0}&quot; personality?.
         /// </summary>
         public static string delete_personality_message {
             get {
@@ -187,7 +187,7 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to delete the &quot;{0}&quot; script ?.
+        ///   Looks up a localized string similar to Are you sure you want to delete the &quot;{0}&quot; script?.
         /// </summary>
         public static string delete_script_message {
             get {
@@ -304,7 +304,7 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to reset the &quot;{0}&quot; script ?.
+        ///   Looks up a localized string similar to Are you sure you want to reset the &quot;{0}&quot; script?.
         /// </summary>
         public static string reset_script_message {
             get {

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -286,11 +286,29 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string reset_script {
+            get {
+                return ResourceManager.GetString("reset_script", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Reset to default.
         /// </summary>
         public static string reset_script_button {
             get {
                 return ResourceManager.GetString("reset_script_button", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to reset the &quot;{0}&quot; script ?.
+        /// </summary>
+        public static string reset_script_message {
+            get {
+                return ResourceManager.GetString("reset_script_message", resourceCulture);
             }
         }
         

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -152,7 +152,7 @@
     <value>Delete Personality</value>
   </data>
   <data name="delete_personality_message" xml:space="preserve">
-    <value>Are you sure you want to delete the "{0}" personality ?</value>
+    <value>Are you sure you want to delete the "{0}" personality?</value>
   </data>
   <data name="delete_script" xml:space="preserve">
     <value>Delete</value>
@@ -161,7 +161,7 @@
     <value>Delete script</value>
   </data>
   <data name="delete_script_message" xml:space="preserve">
-    <value>Are you sure you want to delete the "{0}" script ?</value>
+    <value>Are you sure you want to delete the "{0}" script?</value>
   </data>
   <data name="desc" xml:space="preserve">
     <value>Respond to events with scripted speech based on the information in the event. Not all events have scripted responses. If a script response is empty, its 'Test' and 'View' buttons are disabled. Event-based scripts can be disabled or re-prioritized but not deleted.</value>
@@ -228,6 +228,6 @@
     <value>Reset</value>
   </data>
   <data name="reset_script_message" xml:space="preserve">
-    <value>Are you sure you want to reset the "{0}" script ?</value>
+    <value>Are you sure you want to reset the "{0}" script?</value>
   </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -224,4 +224,10 @@
   <data name="localizedAnd" xml:space="preserve">
     <value>and</value>
   </data>
+  <data name="reset_script" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="reset_script_message" xml:space="preserve">
+    <value>Are you sure you want to reset the "{0}" script ?</value>
+  </data>
 </root>

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -47,16 +47,16 @@ namespace EddiSpeechResponder
         public bool Default => Value == defaultValue;
 
         [JsonIgnore]
-        public bool IsResetableOrDeletable
+        public bool IsResettableOrDeletable
         {
-            get { resetableOrDeletable = !Default || (!Responder && string.IsNullOrWhiteSpace(defaultValue)); return resetableOrDeletable; }
-            set { resetableOrDeletable = value; OnPropertyChanged("IsResetableOrDeletable"); }
+            get { resettableOrDeletable = !Default || (!Responder && string.IsNullOrWhiteSpace(defaultValue)); return resettableOrDeletable; }
+            set { resettableOrDeletable = value; OnPropertyChanged("IsResettableOrDeletable"); }
         }
         [JsonIgnore]
-        private bool resetableOrDeletable;
+        private bool resettableOrDeletable;
 
         [JsonIgnore]
-        public bool IsResetable => Responder || (!Responder && !string.IsNullOrWhiteSpace(defaultValue));
+        public bool IsResettable => Responder || (!Responder && !string.IsNullOrWhiteSpace(defaultValue));
 
         [JsonIgnore]
         public string Value

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -40,7 +40,7 @@ namespace EddiSpeechResponder
         public bool Responder
         {
             get { return responder; }
-            private set { responder = value; OnPropertyChanged("Responder"); }
+            set { responder = value; OnPropertyChanged("Responder"); }
         }
 
         [JsonIgnore]

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -19,8 +19,6 @@ namespace EddiSpeechResponder
         private bool responder;
         [JsonProperty("script")]
         private string script;
-        [JsonProperty("default")]
-        private bool isDefault;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -46,14 +44,19 @@ namespace EddiSpeechResponder
         }
 
         [JsonIgnore]
-        public bool Default
-        {
-            get { return isDefault; }
-            set { isDefault = value; OnPropertyChanged("Default"); }
-        }
+        public bool Default => Value == defaultValue;
 
         [JsonIgnore]
-        public bool IsDeleteable => !isDefault;
+        public bool IsResetableOrDeletable
+        {
+            get { resetableOrDeletable = !Default || (!Responder && string.IsNullOrWhiteSpace(defaultValue)); return resetableOrDeletable; }
+            set { resetableOrDeletable = value; OnPropertyChanged("IsResetableOrDeletable"); }
+        }
+        [JsonIgnore]
+        private bool resetableOrDeletable;
+
+        [JsonIgnore]
+        public bool IsResetable => Responder || (!Responder && !string.IsNullOrWhiteSpace(defaultValue));
 
         [JsonIgnore]
         public string Value
@@ -61,6 +64,9 @@ namespace EddiSpeechResponder
             get { return script; }
             set { script = value; OnPropertyChanged("Value"); }
         }
+
+        [JsonIgnore]
+        public string defaultValue;
 
         [JsonIgnore]
         public bool HasValue
@@ -78,7 +84,7 @@ namespace EddiSpeechResponder
         [JsonIgnore]
         private IList<int> priorities;
 
-        public Script(string name, string description, bool responder, string script, int priority = 3, bool Default = false)
+        public Script(string name, string description, bool responder, string script, int priority = 3, string defaultScript = null)
         {
             Name = name;
             Description = description;
@@ -86,7 +92,7 @@ namespace EddiSpeechResponder
             Value = script;
             Priority = priority;
             Enabled = true;
-            this.Default = Default;
+            defaultValue = defaultScript;
 
             Priorities = new List<int>();
             for (int i = 1; i <= SpeechService.Instance.speechQueue.priorityQueues.Count - 1; i++)

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -950,7 +950,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -977,7 +977,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": "{_ Context }\r\n\r\n{if state.cargo_scoop= \"fermée\":\r\n {SetState(\"cargo_scoop\", \"ouverte\")}\r\n|else : {SetState(\"cargo_scoop\", \"fermée\")}\r\n}\r\n\r\nécoutille de soute {state.cargo_scoop}.",
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": "{_ Context }\r\n\r\n{if state.landing_gear= \"sortis\":\r\n {SetState(\"landing_gear\", \"rentré\")}\r\n|else : {SetState(\"landing_gear\", \"sortis\")}\r\n}\r\n\r\nTrain d'atérissage {state.landing_gear}.",
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 2,
-      "responder": false,
+      "responder": true,
       "script": "{_ Context }\r\n\r\n{if state.phares= \"allumés\":\r\n {SetState(\"phares\", \"éteints\")}\r\n|else : {SetState(\"phares\", \"allumés\")}\r\n}\r\n\r\n{OneOf(\"Phares \",\"Projecteurs \")} {state.phares}.",
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.pt-BR.json
+++ b/SpeechResponder/eddi.pt-BR.json
@@ -203,7 +203,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -1076,7 +1076,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -1103,7 +1103,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -185,7 +185,7 @@
     "Cargo scoop": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Cargo scoop",
@@ -959,7 +959,7 @@
     "Landing gear": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Landing gear",
@@ -986,7 +986,7 @@
     "Lights": {
       "enabled": true,
       "priority": 3,
-      "responder": false,
+      "responder": true,
       "script": null,
       "default": true,
       "name": "Lights",


### PR DESCRIPTION
Resolves #1464.
Replaces #1469 and #1475.
If either `Delete` or `Reset` is enabled then the script is non-default.
Stores the default script when we're loading scripts and automatically determines whether a script matches the default.
Adds a confirmation dialog prior to resetting a script from the main window tab. 