### PR TITLE
Preserve language settings across both standalone and VoiceAttack instances of EDDI.

### DIFF
--- a/EDDI/App.xaml.cs
+++ b/EDDI/App.xaml.cs
@@ -84,16 +84,27 @@ namespace Eddi
 
         public static void ApplyAnyOverrideCulture()
         {
+            string overrideCultureName = null;
             try
             {
-                string overrideCultureName = Eddi.Properties.Settings.Default.OverrideCulture;
+                // Use Eddi.Properties.Settings if an override culture isn't set in our configuration
+                EDDIConfiguration configuration = EDDIConfiguration.FromFile();
+                if (configuration.OverrideCulture is null && !string.IsNullOrEmpty(Eddi.Properties.Settings.Default.OverrideCulture))
+                {
+                    configuration.OverrideCulture = Eddi.Properties.Settings.Default.OverrideCulture;
+                    configuration.ToFile();
+                }
+
+                overrideCultureName = configuration.OverrideCulture;
+
                 // we are using the InvariantCulture name "" to mean user's culture
-                CultureInfo overrideCulture = String.IsNullOrEmpty(overrideCultureName) ? null : new CultureInfo(overrideCultureName);
+                CultureInfo overrideCulture = string.IsNullOrEmpty(overrideCultureName) ? null : new CultureInfo(overrideCultureName);
                 ApplyCulture(overrideCulture);
             }
             catch
             {
                 ApplyCulture(null);
+                Debug.WriteLine("Culture [{0}] not available", overrideCultureName);
             }
         }
 

--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -159,6 +159,9 @@ namespace Eddi
         [JsonProperty("exporttarget")]
         public string exporttarget { get; set; } = "Coriolis";
 
+        [JsonProperty("OverrideCulture")]
+        public string OverrideCulture { get; set; }
+
         [JsonIgnore]
         private string dataPath;
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -178,10 +178,12 @@ namespace Eddi
                 // Allow the EDDI VA plugin to change window state
                 VaWindowStateChange = new vaWindowStateChangeDelegate(OnVaWindowStateChange);
                 heroText.Text = Properties.EddiResources.change_affect_va;
+                chooseLanguageText.Text = Properties.MainWindow.choose_lang_label_va;
             }
             else
             {
                 heroText.Text = Properties.EddiResources.if_using_va;
+                chooseLanguageText.Text = Properties.MainWindow.choose_lang_label;
             }
 
             EDDIConfiguration eddiConfiguration = EDDIConfiguration.FromFile();
@@ -222,11 +224,12 @@ namespace Eddi
             List<LanguageDef> langs = GetAvailableLangs(); // already correctly sorted
             chooseLanguageDropDown.ItemsSource = langs;
             chooseLanguageDropDown.DisplayMemberPath = "displayName";
-            chooseLanguageDropDown.SelectedItem = langs.Find(l => l.ci.Name == Eddi.Properties.Settings.Default.OverrideCulture);
+            chooseLanguageDropDown.SelectedItem = langs.Find(l => l.ci.Name == eddiConfiguration.OverrideCulture);
             chooseLanguageDropDown.SelectionChanged += (sender, e) =>
             {
                 LanguageDef cultureDef = (LanguageDef)chooseLanguageDropDown.SelectedItem;
-                Eddi.Properties.Settings.Default.OverrideCulture = cultureDef.ci.Name;
+                eddiConfiguration.OverrideCulture = cultureDef.ci.Name;
+                eddiConfiguration.ToFile();
             };
 
             // Configure the Frontier API tab

--- a/EDDI/Properties/MainWindow.Designer.cs
+++ b/EDDI/Properties/MainWindow.Designer.cs
@@ -19,7 +19,7 @@ namespace Eddi.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class MainWindow {
@@ -75,6 +75,15 @@ namespace Eddi.Properties {
         public static string choose_lang_label {
             get {
                 return ResourceManager.GetString("choose_lang_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select EDDI&apos;s language (requires relaunching VoiceAttack):.
+        /// </summary>
+        public static string choose_lang_label_va {
+            get {
+                return ResourceManager.GetString("choose_lang_label_va", resourceCulture);
             }
         }
         

--- a/EDDI/Properties/MainWindow.resx
+++ b/EDDI/Properties/MainWindow.resx
@@ -275,4 +275,7 @@
     <value>The Frontier API is not enabled in this build of EDDI.</value>
     <comment>Displayed when the Frontier API is not enabled because the current build has no OAuth ClientID configured.</comment>
   </data>
+  <data name="choose_lang_label_va" xml:space="preserve">
+    <value>Select EDDI's language (requires relaunching VoiceAttack):</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #1367. Moves language settings to a config file accessible by both standalone and VoiceAttack instances of EDDI.