### PR TITLE
Correct pronunciation of "Luyten 205-128" to speak the dash

### DIFF
--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -360,7 +360,8 @@ namespace EddiSpeechService
                 || starSystem.StartsWith("ADS ")
                 || starSystem.StartsWith("HR ")
                 || starSystem.StartsWith("HD ")
-                )
+                || starSystem.StartsWith("Luyten ")
+            )
             {
                 starSystem = starSystem.Replace("-", " " + Properties.Phrases.dash + " ");
             }


### PR DESCRIPTION
Rather than "Luyten two hundred and five to one hundred and twenty eight".
Ref. https://forums.frontier.co.uk/threads/eddi-3-3-bring-your-cockpit-to-life.387955/post-8002482