### PR TITLE
Preserve exploration results through server updates

### DIFF
--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -227,6 +227,7 @@ namespace EddiDataDefinitions
         public string comment;
 
         /// <summary>distance from home</summary>
+        [JsonIgnore]
         public decimal? distancefromhome;
 
         /// <summary>Whether a system scan has already been completed for this system in the current play session</summary>

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -91,7 +91,7 @@ namespace EddiDataDefinitions
             }
         }
 
-        public void PreserveBodyData(ImmutableList<Body> oldBodies, ImmutableList<Body> newBodies)
+        public void PreserveBodyData(List<Body> oldBodies, ImmutableList<Body> newBodies)
         {
             // Update `bodies` with new server data, except preserve properties not available via the server
             var newBodyBuilder = newBodies.ToBuilder();
@@ -304,6 +304,7 @@ namespace EddiDataDefinitions
         public StarSystem()
         {
             bodies = ImmutableList.Create<Body>();
+            factions = new List<Faction>();
             stations = new List<Station>();
         }
 

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -295,7 +295,6 @@ namespace EddiDataProviderService
                                 oldStarSystem.TryGetValue("visitLog", out object visitLogVal);
                                 updatedSystem.visitLog = JsonConvert.DeserializeObject<SortedSet<DateTime>>(JsonConvert.SerializeObject(visitLogVal));
                                 updatedSystem.comment = JsonParsing.getString(oldStarSystem, "comment");
-                                updatedSystem.distancefromhome = JsonParsing.getOptionalDecimal(oldStarSystem, "distancefromhome");
                                 updatedSystem.discoverableBodies = JsonParsing.getInt(oldStarSystem, "discoverableBodies");
 
                                 // Carry over Body properties that we want to preserve (e.g. exploration data)

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -280,6 +280,9 @@ namespace EddiDataProviderService
                     results.Add(GetStarSystem(systemName, false));
                 }
 
+                // Synchronize EDSM visits and comments
+                updatedSystems = DataProviderService.syncFromStarMapService(updatedSystems);
+                
                 // Update properties that aren't synced from the server and that we want to preserve
                 foreach (StarSystem updatedSystem in updatedSystems)
                 {
@@ -291,10 +294,7 @@ namespace EddiDataProviderService
 
                             if (oldStarSystem != null)
                             {
-                                // Carry over StarSystem properties that we want to preserve (e.g. visits and comments)
-                                oldStarSystem.TryGetValue("visitLog", out object visitLogVal);
-                                updatedSystem.visitLog = JsonConvert.DeserializeObject<SortedSet<DateTime>>(JsonConvert.SerializeObject(visitLogVal));
-                                updatedSystem.comment = JsonParsing.getString(oldStarSystem, "comment");
+                                // Carry over StarSystem properties that we want to preserve
                                 updatedSystem.discoverableBodies = JsonParsing.getInt(oldStarSystem, "discoverableBodies");
 
                                 // Carry over Body properties that we want to preserve (e.g. exploration data)

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -15,7 +15,7 @@ namespace EddiDataProviderService
         private const string TABLE_GET_SCHEMA_VERSION_SQL = @"PRAGMA user_version;";
         private const string TABLE_SET_SCHEMA_VERSION_SQL = @"PRAGMA user_version = ";
 
-        public long SCHEMA_VERSION { get; private set; } = 0;
+        public long SCHEMA_VERSION { get; private set; }
 
         // Append new table columns to the end of the list to maximize compatibility with schema version 0.
         // systemaddress and edsmid must each be unique. 
@@ -134,11 +134,12 @@ namespace EddiDataProviderService
         public StarSystem GetOrCreateStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetOrCreateStarSystems(new string[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
+            return GetOrCreateStarSystems(new[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
         }
 
         public List<StarSystem> GetOrCreateStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
+            if (!names.Any()) { return null; }
             List<StarSystem> systems = GetOrFetchStarSystems(names, fetchIfMissing, refreshIfOutdated);
 
             // Create a new system object for each name that isn't in the database and couldn't be fetched from a server
@@ -146,7 +147,7 @@ namespace EddiDataProviderService
             {
                 if (systems?.Find(s => s?.systemname == name) == null)
                 {
-                    systems.Add(new StarSystem() { systemname = name });
+                    systems?.Add(new StarSystem() { systemname = name });
                 }
             }
 
@@ -156,12 +157,12 @@ namespace EddiDataProviderService
         public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetOrFetchStarSystems(new string[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
+            return GetOrFetchStarSystems(new[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
         }
 
         public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
-            if (names.Count() == 0) { return null; }
+            if (!names.Any()) { return null; }
 
             List<StarSystem> systems = Instance.GetStarSystems(names, refreshIfOutdated);
 
@@ -188,7 +189,7 @@ namespace EddiDataProviderService
         public StarSystem GetStarSystem(string name, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetStarSystems(new string[] { name }, refreshIfOutdated).FirstOrDefault();
+            return GetStarSystems(new[] { name }, refreshIfOutdated).FirstOrDefault();
         }
 
         public List<StarSystem> GetStarSystems(string[] names, bool refreshIfOutdated = true)
@@ -197,18 +198,16 @@ namespace EddiDataProviderService
             {
                 return null;
             }
-            if (names.Count() == 0) { return null; }
+            if (!names.Any()) { return null; }
 
             List<StarSystem> results = new List<StarSystem>();
-            List<string> systemsToUpdate = new List<string>();
+            List<KeyValuePair<string, string>> systemsToUpdate = new List<KeyValuePair<string, string>>();
             List<KeyValuePair<string, string>> dataSets = Instance.ReadStarSystems(names);
 
+            bool needToUpdate = false;
             foreach (KeyValuePair<string, string> kv in dataSets)
             {
-                bool needToUpdate = false;
-                StarSystem result = null;
-
-                if (kv.Value != null && kv.Value != "")
+                if (!string.IsNullOrEmpty(kv.Value))
                 {
                     string name = kv.Key;
 
@@ -217,12 +216,10 @@ namespace EddiDataProviderService
 
                     // Determine whether our data is stale (We won't deserialize the the entire system if it's stale) 
                     IDictionary<string, object> system = Deserializtion.DeserializeData(data);
-                    system.TryGetValue("comment", out object commentVal);
                     system.TryGetValue("lastupdated", out object lastUpdatedVal);
                     system.TryGetValue("systemAddress", out object systemAddressVal);
                     system.TryGetValue("EDSMID", out object edsmIdVal);
 
-                    string comment = (string)commentVal ?? "";
                     DateTime? lastupdated = (DateTime?)lastUpdatedVal;
                     long? systemAddress = (long?)systemAddressVal;
                     long? edsmId = (long?)edsmIdVal;
@@ -248,13 +245,13 @@ namespace EddiDataProviderService
 
                     if (needToUpdate)
                     {
-                        // We want to update this star system
-                        systemsToUpdate.Add(name);
+                        // We want to update this star system (don't deserialize the old result at this time)
+                        systemsToUpdate.Add(new KeyValuePair<string, string>(name, kv.Value));
                     }
                     else
                     {
                         // Deserialize the old result
-                        result = DeserializeStarSystem(name, data, ref needToUpdate);
+                        StarSystem result = DeserializeStarSystem(name, data, ref needToUpdate);
                         if (result != null)
                         {
                             results.Add(result);
@@ -265,9 +262,10 @@ namespace EddiDataProviderService
 
             if (systemsToUpdate.Count > 0)
             {
-                List<StarSystem> updatedSystems = DataProviderService.GetSystemsData(systemsToUpdate.ToArray());
+                List<StarSystem> updatedSystems = DataProviderService.GetSystemsData(systemsToUpdate.Select(s => s.Key).ToArray());
 
                 // If the newly fetched star system is an empty object except (for the object name), reject it
+                // Return old results when new results have been rejected
                 List<string> systemsToRevert = new List<string>();
                 foreach (StarSystem starSystem in updatedSystems)
                 {
@@ -277,15 +275,53 @@ namespace EddiDataProviderService
                     }
                 }
                 updatedSystems.RemoveAll(s => systemsToRevert.Contains(s.systemname));
-
-                // Return old results when new results have been rejected
                 foreach (string systemName in systemsToRevert)
                 {
                     results.Add(GetStarSystem(systemName, false));
                 }
 
-                // Synchronize EDSM visits and comments
-                updatedSystems = DataProviderService.syncFromStarMapService(updatedSystems);
+                // Update properties that aren't synced from the server and that we want to preserve
+                foreach (StarSystem updatedSystem in updatedSystems)
+                {
+                    foreach (KeyValuePair<string, string> systemToUpdate in systemsToUpdate)
+                    {
+                        if (updatedSystem.systemname == systemToUpdate.Key)
+                        {
+                            StarSystem oldStarSystem = DeserializeStarSystem(systemToUpdate.Key, systemToUpdate.Value, ref needToUpdate);
+                            if (oldStarSystem != null)
+                            {
+                                // Carry over StarSystem properties that we want to preserve (e.g. visits and comments)
+                                updatedSystem.visitLog = oldStarSystem.visitLog;
+                                updatedSystem.comment = oldStarSystem.comment;
+                                updatedSystem.distancefromhome = oldStarSystem.distancefromhome;
+                                updatedSystem.discoverableBodies = oldStarSystem.discoverableBodies;
+
+                                // Carry over Body properties that we want to preserve (e.g. exploration data)
+                                updatedSystem.PreserveBodyData(oldStarSystem.bodies, updatedSystem.bodies);
+
+                                // Carry over Faction properties that we want to preserve (e.g. reputation data)
+                                foreach (var updatedFaction in updatedSystem.factions)
+                                {
+                                    foreach (var oldFaction in oldStarSystem.factions)
+                                    {
+                                        if (updatedFaction.name == oldFaction.name)
+                                        {
+                                            updatedFaction.myreputation = oldFaction.myreputation;
+                                        }
+                                    }
+                                }
+
+                                // No station data needs to be carried over at this time.
+                            }
+                        }
+                    }
+                }
+                
+                // Update the `lastupdated` timestamps for the systems we have updated
+                foreach (StarSystem starSystem in updatedSystems)
+                {
+                    starSystem.lastupdated = DateTime.UtcNow;
+                }
 
                 // Add our updated systems to our results
                 results.AddRange(updatedSystems);
@@ -293,17 +329,12 @@ namespace EddiDataProviderService
                 // Save changes to our star systems
                 Instance.updateStarSystems(updatedSystems);
             }
-
-            foreach (StarSystem starSystem in results)
-            {
-                starSystem.lastupdated = DateTime.UtcNow;
-            }
             return results;
         }
 
         private List<KeyValuePair<string, string>> ReadStarSystems(string[] names)
         {
-            if (names.Count() == 0) { return null; }
+            if (!names.Any()) { return null; }
 
             List<KeyValuePair<string, string>> results = new List<KeyValuePair<string, string>>();
             using (var con = SimpleDbConnection())
@@ -311,7 +342,7 @@ namespace EddiDataProviderService
                 con.Open();
                 using (var cmd = new SQLiteCommand(con))
                 {
-                    using (var transaction = con.BeginTransaction())
+                    using (con.BeginTransaction())
                     {
                         foreach (string name in names)
                         {
@@ -350,7 +381,7 @@ namespace EddiDataProviderService
 
         private List<StarSystemDatabaseResult> ReadStarSystems(List<StarSystem> starSystems)
         {
-            if (starSystems.Count() == 0) { return null; }
+            if (!starSystems.Any()) { return null; }
 
             List<StarSystemDatabaseResult> results = new List<StarSystemDatabaseResult>();
             using (var con = SimpleDbConnection())
@@ -358,7 +389,7 @@ namespace EddiDataProviderService
                 con.Open();
                 using (var cmd = new SQLiteCommand(con))
                 {
-                    using (var transaction = con.BeginTransaction())
+                    using (con.BeginTransaction())
                     {
                         foreach (StarSystem starSystem in starSystems)
                         {
@@ -432,13 +463,14 @@ namespace EddiDataProviderService
         {
             if (systemName == string.Empty || data == string.Empty) { return null; }
 
-            StarSystem result = null;
+            StarSystem result;
             try
             {
                 result = JsonConvert.DeserializeObject<StarSystem>(data);
                 if (result == null)
                 {
                     Logging.Info("Failed to obtain system for " + systemName + " from the SQLiteRepository");
+                    needToUpdate = true;
                 }
             }
             catch (Exception)
@@ -447,6 +479,8 @@ namespace EddiDataProviderService
                 try
                 {
                     result = DataProviderService.GetSystemData(systemName);
+                    result = DataProviderService.syncFromStarMapService(new List<StarSystem> { result })?.FirstOrDefault(); // Synchronize EDSM visits and comments
+                    needToUpdate = true;
                 }
                 catch (Exception ex)
                 {
@@ -460,12 +494,12 @@ namespace EddiDataProviderService
         public void SaveStarSystem(StarSystem starSystem)
         {
             if (starSystem == null) { return; }
-            SaveStarSystems(new List<StarSystem>() { starSystem });
+            SaveStarSystems(new List<StarSystem> { starSystem });
         }
 
         public void SaveStarSystems(List<StarSystem> starSystems)
         {
-            if (starSystems.Count() == 0) { return; }
+            if (!starSystems.Any()) { return; }
 
             var delete = new List<StarSystem>();
             var update = new List<StarSystem>();
@@ -475,12 +509,12 @@ namespace EddiDataProviderService
             foreach (StarSystem system in starSystems)
             {
                 StarSystemDatabaseResult dbSystem = dbSystems.FirstOrDefault(s =>
-                    s.systemAddress != null && s.systemAddress == system.systemAddress ? true :
-                    s.edsmId != null && s.edsmId == system.EDSMID ? true :
-                    s.systemName == system.systemname ? true : false);
+                    s.systemAddress != null && s.systemAddress == system.systemAddress || 
+                    s.edsmId != null && s.edsmId == system.EDSMID || 
+                    s.systemName == system.systemname);
 
                 if (dbSystem?.starSystemJson is null ||
-                    (dbSystem.systemAddress is null && dbSystem.edsmId is null))
+                    dbSystem?.systemAddress is null && dbSystem?.edsmId is null)
                 {
                     // If we're updating to schema version 2, systemAddress and edsmId will both be null. 
                     // Use our delete method to purge all obsolete copies of the star system from the database,
@@ -726,10 +760,8 @@ namespace EddiDataProviderService
         }
 
         /// <summary> Valid columnNames are "systemaddress", "edsmid", and "comment" </summary>
-        private static bool AddColumnIfMissing(SQLiteConnection con, string columnName)
+        private static void AddColumnIfMissing(SQLiteConnection con, string columnName)
         {
-            bool result = false;
-
             // Parameters like `DISTINCT` cannot be set on columns by this method
             string command = string.Empty;
             switch (columnName)
@@ -770,7 +802,6 @@ namespace EddiDataProviderService
                         {
                             cmd.ExecuteNonQuery();
                         }
-                        result = true;
                     }
                     catch (SQLiteException ex)
                     {
@@ -778,7 +809,6 @@ namespace EddiDataProviderService
                     }
                 }
             }
-            return result;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
@@ -798,7 +828,7 @@ namespace EddiDataProviderService
                 }
             }
             CreateOrUpdateDatabase();
-            var updateLogs = Task.Run(() => DataProviderService.syncFromStarMapService());
+            Task.Run(() => DataProviderService.syncFromStarMapService());
         }
 
         private static void handleSqlLiteException(SQLiteConnection con, SQLiteException ex)
@@ -825,10 +855,10 @@ namespace EddiDataProviderService
         protected internal class StarSystemDatabaseResult
         {
             // Data as read from columns in our database
-            public string systemName { get; private set; } = null;
-            public long? systemAddress { get; private set; } = null;
-            public long? edsmId { get; private set; } = null;
-            public string starSystemJson { get; private set; } = null;
+            public string systemName { get; private set; }
+            public long? systemAddress { get; private set; }
+            public long? edsmId { get; private set; }
+            public string starSystemJson { get; private set; }
 
             public StarSystemDatabaseResult(string systemName, long? systemAddress, long? edsmId, string starSystemJson)
             {

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -2119,13 +2119,10 @@ namespace Eddi
         {
             if (CurrentStarSystem != null)
             {
-                Body body = CurrentStarSystem.bodies.Find(b => b.bodyname == theEvent.bodyName);
-                if (body?.mapped is null && !(theEvent.body is null))
-                {
-                    CurrentStarSystem.AddOrUpdateBody(theEvent.body);
-                    StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
-                    updateCurrentStellarBody(theEvent.bodyName, CurrentStarSystem?.systemname, CurrentStarSystem?.systemAddress);
-                }
+                // We've already updated the body (via the journal monitor) if the CurrentStarSystem isn't null
+                // Here, we just need to save the data and update our current stellar body
+                StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
+                updateCurrentStellarBody(theEvent.bodyName, CurrentStarSystem?.systemname, CurrentStarSystem?.systemAddress);
             }
             return true;
         }


### PR DESCRIPTION
Resolves #1480.
Uses data that we were already deserializing to carry over data not available from the server when we refresh stale star system data from the server.