### PR TITLE
Fix repeating powerplay event

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -922,6 +922,12 @@ namespace Eddi
             Cmdr.Power = Power.None;
             Cmdr.powermerits = null;
             Cmdr.powerrating = 0;
+
+            // Store power merits
+            EDDIConfiguration configuration = EDDIConfiguration.FromFile();
+            configuration.powerMerits = Cmdr.powermerits;
+            configuration.ToFile();
+
             return true;
         }
 
@@ -930,6 +936,12 @@ namespace Eddi
             Cmdr.Power = @event.Power;
             Cmdr.powermerits = 0;
             Cmdr.powerrating = 1;
+
+            // Store power merits
+            EDDIConfiguration configuration = EDDIConfiguration.FromFile();
+            configuration.powerMerits = Cmdr.powermerits;
+            configuration.ToFile();
+
             return true;
         }
 
@@ -958,6 +970,12 @@ namespace Eddi
             {
                 Cmdr.powerrating = 0;
             }
+
+            // Store power merits
+            EDDIConfiguration configuration = EDDIConfiguration.FromFile();
+            configuration.powerMerits = Cmdr.powermerits;
+            configuration.ToFile();
+
             return true;
         }
 
@@ -970,6 +988,12 @@ namespace Eddi
                 Cmdr.Power = @event.Power;
                 Cmdr.powerrating = @event.rank;
                 Cmdr.powermerits = @event.merits;
+
+                // Store power merits
+                EDDIConfiguration configuration = EDDIConfiguration.FromFile();
+                configuration.powerMerits = @event.merits;
+                configuration.ToFile();
+
                 return true;
             }
             else
@@ -2159,6 +2183,7 @@ namespace Eddi
                         if (configuration != null)
                         {
                             Cmdr.gender = configuration.Gender;
+                            Cmdr.powermerits = configuration.powerMerits;
                             Cmdr.squadronname = configuration.SquadronName;
                             Cmdr.squadronid = configuration.SquadronID;
                             Cmdr.squadronrank = configuration.SquadronRank;

--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -155,6 +155,9 @@ namespace Eddi
         [JsonProperty("Gender")]
         public string Gender { get; set; } = "Male";
 
+        [JsonProperty("powerMerits")]
+        public int? powerMerits { get; set; }
+
         /// <summary>the current export target for the shipyard</summary>
         [JsonProperty("exporttarget")]
         public string exporttarget { get; set; } = "Coriolis";


### PR DESCRIPTION
The `Powerplay` event was intended to trigger once but powermerits were being reset whenever the Frontier API updated the Cmdr object. This PR corrects the repetition by saving power merits to EddiConfiguration.