### PR TITLE
Null protect and fix trying to read null faction data from the…

### DIFF
--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -304,14 +304,20 @@ namespace EddiDataProviderService
 
                                 // Carry over Faction properties that we want to preserve (e.g. reputation data)
                                 oldStarSystem.TryGetValue("factions", out object factionsVal);
-                                List<Faction> oldFactions = JsonConvert.DeserializeObject<List<Faction>>(JsonConvert.SerializeObject(factionsVal));
-                                foreach (var updatedFaction in updatedSystem.factions)
+                                if (factionsVal != null)
                                 {
-                                    foreach (var oldFaction in oldFactions)
+                                    List<Faction> oldFactions = JsonConvert.DeserializeObject<List<Faction>>(JsonConvert.SerializeObject(factionsVal));
+                                    if (oldFactions?.Count > 0)
                                     {
-                                        if (updatedFaction.name == oldFaction.name)
+                                        foreach (var updatedFaction in updatedSystem.factions)
                                         {
-                                            updatedFaction.myreputation = oldFaction.myreputation;
+                                            foreach (var oldFaction in oldFactions)
+                                            {
+                                                if (updatedFaction.name == oldFaction.name)
+                                                {
+                                                    updatedFaction.myreputation = oldFaction.myreputation;
+                                                }
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Resolves exceptions like
```
2019-09-20T04:33:18 [Error] EDDI:eventHandler EDDI core failed to handle event Next jump {"event":"{\"system\":\"Ladon\",\"systemaddress\":3309012240739,\"remainingjumpsinroute\":5,\"raw\":\"{ \\\"timestamp\\\":\\\"2019-09-20T04:33:15Z\\\", \\\"event\\\":\\\"FSDTarget\\\", \\\"Name\\\":\\\"Ladon\\\", \\\"SystemAddress\\\":3309012240739, \\\"RemainingJumpsInRoute\\\":5 }\",\"timestamp\":\"2019-09-20T04:33:15Z\",\"type\":\"Next jump\",\"fromLoad\":false}","exception":"Object reference not set to an instance of an object.","stacktrace":"   at EddiDataProviderService.StarSystemSqLiteRepository.GetStarSystems(String[] names, Boolean refreshIfOutdated) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\DataProviderService\\StarSystemSqLiteRepository.cs:line 310\r\n   at EddiDataProviderService.StarSystemSqLiteRepository.GetOrFetchStarSystems(String[] names, Boolean fetchIfMissing, Boolean refreshIfOutdated) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\DataProviderService\\StarSystemSqLiteRepository.cs:line 167\r\n   at EddiDataProviderService.StarSystemSqLiteRepository.GetOrFetchStarSystem(String name, Boolean fetchIfMissing, Boolean refreshIfOutdated) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\DataProviderService\\StarSystemSqLiteRepository.cs:line 160\r\n   at Eddi.EDDI.eventFSDTarget(FSDTargetEvent event) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\EDDI\\EDDI.cs:line 1645\r\n   at Eddi.EDDI.eventHandler(Event event) in C:\\Users\\%USERNAME%\\source\\repos\\EDDI\\EDDI\\EDDI.cs:line 724"}
```