### PR TITLE
Re-reinstate glide

### DIFF
--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -740,6 +740,7 @@ Any values might be missing, depending on EDDI's configuration.
     - `longitude` a decimal value indicating the ship's current longitude (if near a surface)
     - `altitude` a decimal value indicating the ship's current altitude (if in flight near a surface)
     - `heading` a decimal value indicating the ship's current heading (if near a surface)
+    - `slope` a decimal value indicating the ship's current slope relative to the horizon (if near a surface)
     - `analysis_mode` a boolean value indicating whether the ship's HUD is currently in Analysis Mode
     - `night_vision` a boolean value indicating whether night vision is currently active
     - `fuel` a decimal value indicating the ship's current fuel (including fuel in the active fuel reservoir)

--- a/StatusMonitor/Status.cs
+++ b/StatusMonitor/Status.cs
@@ -108,6 +108,7 @@ namespace EddiDataDefinitions
         public decimal? planetradius;
 
         // Variables calculated from event data
+        public decimal? slope { get; set; }
         public decimal? fuel => fuelInTanks + fuelInReservoir;
         public decimal? fuel_percent { get; set; }
         public int? fuel_seconds { get; set; }

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -324,18 +324,22 @@ namespace EddiStatusMonitor
                     if (thisStatus.hyperspace)
                     {
                         EDDI.Instance.Environment = Constants.ENVIRONMENT_WITCH_SPACE;
+                        gliding = false;
                     }
                     else if (thisStatus.supercruise)
                     {
                         EDDI.Instance.Environment = Constants.ENVIRONMENT_SUPERCRUISE;
+                        gliding = false;
                     }
                     else if (thisStatus.docked)
                     {
                         EDDI.Instance.Environment = Constants.ENVIRONMENT_DOCKED;
+                        gliding = false;
                     }
                     else if (thisStatus.landed)
                     {
                         EDDI.Instance.Environment = Constants.ENVIRONMENT_LANDED;
+                        gliding = false;
                     }
                     else
                     {

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -293,6 +293,7 @@ namespace EddiStatusMonitor
 
                     // Calculated data
                     SetFuelExtras(status);
+                    SetSlope(status);
 
                     return status;
                 }
@@ -578,6 +579,28 @@ namespace EddiStatusMonitor
                 fuel_seconds = (fuelPerSecond is null || fuelPerSecond == 0) ? null : (int?)(srvFuelTankCapacity / fuelPerSecond);
             }
             return; // At present, fighters do not appear to consume fuel.
+        }
+
+        private void SetSlope(Status status)
+        {
+            status.slope = null;
+            if (lastStatus.planetradius != null && lastStatus?.altitude != null && lastStatus?.latitude != null && lastStatus?.longitude != null)
+            {
+                double radius = (double)status.planetradius / 1000;
+                double currentLat = (double)(status.latitude ?? 0) * Math.PI / 180;
+                double currentLong = (double)(status.longitude ?? 0) * Math.PI / 180;
+                double lastLat = (double)(lastStatus.latitude ?? 0) * Math.PI / 180;
+                double lastLong = (double)(lastStatus.longitude ?? 0) * Math.PI / 180;
+                double deltaAlt = (double)((status.altitude ?? 0) - (lastStatus.altitude ?? 0)) / 1000;
+
+                // Calculate distance traveled using Law of Haversines
+                double a = Math.Pow(Math.Sin((currentLat - lastLat) / 2), 2)
+                    + Math.Cos(currentLat) * Math.Cos(lastLat) * Math.Pow(Math.Sin((currentLong - lastLong) / 2), 2);
+                double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+                double distance = c * radius;
+                double slope = Math.Atan2(deltaAlt, distance) * 180 / Math.PI;
+                status.slope = Math.Round((decimal)slope, 1);
+            }
         }
     }
 }

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -424,9 +424,12 @@ namespace EddiStatusMonitor
                     if (!gliding && lastEnteredNormalSpaceEvent != null)
                     {
                         // We're not already gliding and we have data from a prior `EnteredNormalSpace` event
-                        if (currentStatus.fsd_status == "ready" && currentStatus.altitude < 25000 && currentStatus.altitude < lastStatus.altitude)
+                        if (currentStatus.fsd_status == "ready" 
+                            && currentStatus.slope >= -60 && currentStatus.slope <= -5
+                            && currentStatus.altitude < 100000
+                            && currentStatus.altitude < lastStatus.altitude)
                         {
-                            // The FSD status is `ready`, altitude is less than 25000 meters, and we are dropping
+                            // The FSD status is `ready`, altitude is less than 100000 meters, and we are dropping
                             gliding = true;
                             EnteredNormalSpaceEvent theEvent = lastEnteredNormalSpaceEvent;
                             EDDI.Instance.enqueueEvent(new GlideEvent(DateTime.UtcNow, gliding, theEvent.systemname, theEvent.systemAddress, theEvent.bodyname, theEvent.bodyType) { fromLoad = theEvent.fromLoad });

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -589,18 +589,23 @@ namespace EddiStatusMonitor
             status.slope = null;
             if (lastStatus.planetradius != null && lastStatus?.altitude != null && lastStatus?.latitude != null && lastStatus?.longitude != null)
             {
+                double square(double x) => x * x;
+
                 double radius = (double)status.planetradius / 1000;
-                double currentLat = (double)(status.latitude ?? 0) * Math.PI / 180;
-                double currentLong = (double)(status.longitude ?? 0) * Math.PI / 180;
-                double lastLat = (double)(lastStatus.latitude ?? 0) * Math.PI / 180;
-                double lastLong = (double)(lastStatus.longitude ?? 0) * Math.PI / 180;
                 double deltaAlt = (double)((status.altitude ?? 0) - (lastStatus.altitude ?? 0)) / 1000;
 
+                // Convert latitude & longitude to radians
+                double currentLat = (double)(status.latitude ?? 0) * Math.PI / 180;
+                double lastLat = (double)(lastStatus.latitude ?? 0) * Math.PI / 180;
+                double deltaLat = currentLat - lastLat;
+                double deltaLong = (double)((status.longitude ?? 0) - (lastStatus.longitude ?? 0)) * Math.PI / 180;
+
                 // Calculate distance traveled using Law of Haversines
-                double a = Math.Pow(Math.Sin((currentLat - lastLat) / 2), 2)
-                    + Math.Cos(currentLat) * Math.Cos(lastLat) * Math.Pow(Math.Sin((currentLong - lastLong) / 2), 2);
+                double a = square(Math.Sin(deltaLat / 2)) + Math.Cos(currentLat) * Math.Cos(lastLat) * square(Math.Sin(deltaLong / 2));
                 double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
                 double distance = c * radius;
+
+                // Calculate the slope angle
                 double slope = Math.Atan2(deltaAlt, distance) * 180 / Math.PI;
                 status.slope = Math.Round((decimal)slope, 1);
             }

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -965,6 +965,7 @@ namespace EddiVoiceAttackResponder
                 vaProxy.SetDecimal(prefix + " longitude", status?.longitude);
                 vaProxy.SetDecimal(prefix + " altitude", status?.altitude);
                 vaProxy.SetDecimal(prefix + " heading", status?.heading);
+                vaProxy.SetDecimal(prefix + " slope", status?.slope);
                 vaProxy.SetDecimal(prefix + " fuel", status?.fuel);
                 vaProxy.SetDecimal(prefix + " fuel percent", status?.fuel_percent);
                 vaProxy.SetInt(prefix + " fuel rate", status?.fuel_seconds);

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -76,6 +76,7 @@ EDDI makes a large number of values available to augment your existing scripts. 
   * {DEC:Status longitude} a decimal value indicating the ship's current longitude (if near a surface)
   * {DEC:Status altitude} a decimal value indicating the ship's current altitude (if in flight near a surface)
   * {DEC:Status heading} a decimal value indicating the ship's current heading (if near a surface)
+  * {DEC:Status slope} a decimal value indicating the ship's current slope relative to the horizon (if near a surface)
   * {DEC:Status fuel} a decimal value indicating the tons of fuel currently carried by your ship, if known
   * {DEC:Status fuel percent} a decimal value indicating the current percentage of your total fuel capacity remaining, if known
   * {INT:Status fuel rate} an integer value indicating the projected number of seconds of fuel remaining, if known


### PR DESCRIPTION
Incorporating @Hoodathunk 's shiny new slope calculations.

Why is this necessary? Glide can occur at altitudes > 25 km. The old algorithm discarded possible glide signals above this altitude. 
- glide events were documented as only occurring under 25 km altitude and 
- the under 25 km was born out by prior testing. 
Since the 3.5 update, glide has been observed to occur at altitudes as high as 60 km.

Slope has been added to the algorithm to make sure that we do not confuse gliding into a planet and crashing into the planet.