### PR TITLE
Make body & star scanned 'scantype` property user-facing

### DIFF
--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -14,6 +14,7 @@ namespace EddiEvents
 
         static BodyScannedEvent()
         {
+            VARIABLES.Add("scantype", "The type of scan event (AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail)");
             VARIABLES.Add("bodyname", "The name of the body that has been scanned");
             VARIABLES.Add("systemname", "The name of the system containing the scanned body");
             VARIABLES.Add("shortname", "The short name of the body, less the system name");
@@ -61,6 +62,9 @@ namespace EddiEvents
         }
 
         // Variable names for this event should match the class property names for maximum compatibility with the BodyDetails() function in Cottle
+
+        public string scantype { get; private set; } // One of AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail
+                                                     // AutoScan events are detailed scans triggered via proximity. 
 
         public string bodyname => body.bodyname;
 
@@ -163,8 +167,6 @@ namespace EddiEvents
         public AtmosphereClass atmosphereclass => body.atmosphereclass;
         public PlanetClass planetClass => body.planetClass;
         public TerraformState terraformState => body.terraformState;
-        public string scantype { get; private set; } // One of AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail
-                                                     // AutoScan events are detailed scans triggered via proximity. 
 
         // Deprecated, maintained for compatibility with user scripts
         [JsonIgnore, Obsolete("Use bodyname instead")]

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -15,9 +15,11 @@ namespace EddiEvents
 
         static StarScannedEvent()
         {
+            VARIABLES.Add("scantype", "The type of scan event (AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail)");
             VARIABLES.Add("bodyname", "The name of the star that has been scanned");
             VARIABLES.Add("chromaticity", "The apparent colour of the star that has been scanned");
             VARIABLES.Add("stellarclass", "The stellar class of the star that has been scanned (O, G, etc)");
+            VARIABLES.Add("scoopable", "True if the star is scoopable (K, G, B, F, O, A, M)");
             VARIABLES.Add("solarmass", "The mass of the star that has been scanned, relative to Sol's mass");
             VARIABLES.Add("massprobability", "The probablility of finding a star of this class with this mass");
             VARIABLES.Add("radius", "The radius of the star that has been scanned, in metres");
@@ -58,9 +60,14 @@ namespace EddiEvents
 
         // Variable names for this event should match the class property names for maximum compatibility with the BodyDetails() function in Cottle
 
+        public string scantype { get; private set; } // One of AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail
+                                                     // AutoScan events are detailed scans triggered via proximity. 
+
         public string bodyname => star.bodyname;
 
         public string stellarclass => star.stellarclass;
+
+        public bool scoopable => star.scoopable;
 
         public int? stellarsubclass => star.stellarsubclass;
 
@@ -147,8 +154,6 @@ namespace EddiEvents
         // Variables below are not intended to be user facing
         public long? bodyId { get; private set; }
         public List<IDictionary<string, object>> parents { get; private set; }
-        public string scantype { get; private set; } // One of AutoScan, Basic, Detailed, NavBeacon, NavBeaconDetail
-                                                     // AutoScan events are detailed scans triggered via proximity. 
         public Body star { get; private set; }
 
         // Deprecated, maintained for compatibility with user scripts


### PR DESCRIPTION
Resolution to Issue #1525.
* Make `scantype` user-facing to to support filtering of scan types in body and star reports.
* Add `scoopable` to `Star scanned` event.