### PR TITLE
Fix `Exception obtaining profile` errors

### DIFF
--- a/DataDefinitions/CommodityDefinition.cs
+++ b/DataDefinitions/CommodityDefinition.cs
@@ -441,15 +441,12 @@ namespace EddiDataDefinitions
 
         public static CommodityDefinition CommodityDefinitionFromEliteID(long id)
         {
-            try
+            if (CommoditiesByEliteID.TryGetValue(id, out CommodityDefinition commodityDefinition))
             {
-                return CommoditiesByEliteID[id];
+                return commodityDefinition;
             }
-            catch (KeyNotFoundException)
-            {
-                Logging.Info($"Unrecognized Commodity Definition EliteID {id}");
-                throw;
-            }
+            Logging.Info($"Unrecognized Commodity Definition EliteID {id}");
+            return null;
         }
 
         private static string NormalizedName(string rawName)

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -861,7 +861,8 @@ namespace Eddi
 
         private void companionApiStatusChanged(CompanionAppService.State oldState, CompanionAppService.State newState)
         {
-            setStatusInfo();
+            // The calling thread for this method may not have direct access to the MainWindow dispatcher so we invoke the dispatcher here.
+            EDDI.Instance.MainWindow?.Dispatcher?.Invoke(setStatusInfo);
 
             if (oldState == CompanionAppService.State.AwaitingCallback &&
                 newState == CompanionAppService.State.Authorized)


### PR DESCRIPTION
Fixes (or attempts to fix) exceptions like logged here:
https://rollbar.com/EDCD/EDDI/items/16001/
The fix for InvalidOperationsException is speculative - I experimented in both standalone and in VoiceAttack but I have not discovered the precise conditions necessary to trigger that exception.
The two error messages targeted by this PR are ~ 98.6% of all logged `Exception obtaining profile` exceptions (some of the most common exceptions reported to Rollbar).