### PR TITLE
Fix a possible null reference exception with the `MaxFuelPerJump` method

### DIFF
--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1693,7 +1693,7 @@ namespace EddiShipMonitor
         {
             // Max fuel per jump calculated using unladen mass and max jump range w/ just enough fuel to complete max jump
             decimal boostConstant = 0;
-            Module module = ship.compartments.FirstOrDefault(c => c.module.edname.Contains("Int_GuardianFSDBooster"))?.module;
+            Module module = ship.compartments.FirstOrDefault(c => c?.module?.edname != null && c.module.edname.Contains("Int_GuardianFSDBooster"))?.module;
             if (module != null)
             {
                 Constants.guardianBoostFSD.TryGetValue(module.@class, out boostConstant);


### PR DESCRIPTION
Fixes exceptions like:
```
Object reference not set to an instance of an object.
at EddiShipMonitor.ShipMonitor.<>c.<MaxFuelPerJump>b__85_0(Compartment c)
at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
at EddiShipMonitor.ShipMonitor.MaxFuelPerJump(Ship ship)
at EddiShipMonitor.ShipMonitor.ParseShipLoadoutEvent(ShipLoadoutEvent event)
at EddiShipMonitor.ShipMonitor.handleShipLoadoutEvent(ShipLoadoutEvent event)
at EddiShipMonitor.ShipMonitor.PreHandle(Event event)
at Eddi.EDDI.passToMonitorPreHandlers(Event event)
```
https://rollbar.com/EDCD/EDDI/items/16004/?item_page=0&#instances