### PR TITLE
Hotfix/tidy xaml

### DIFF
--- a/CargoMonitor/ConfigurationWindow.xaml
+++ b/CargoMonitor/ConfigurationWindow.xaml
@@ -9,7 +9,7 @@
              xmlns:utility="clr-namespace:Utilities;assembly=Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5, 0" Text="{x:Static resx:CargoMonitor.para1}" />
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5" Text="{x:Static resx:CargoMonitor.para2}" />
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5" Text="{x:Static resx:CargoMonitor.para3}" />

--- a/CrimeMonitor/ConfigurationWindow.xaml
+++ b/CrimeMonitor/ConfigurationWindow.xaml
@@ -9,7 +9,7 @@
              xmlns:utility="clr-namespace:Utilities;assembly=Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <Grid DockPanel.Dock="Top" Margin="0,5" >
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="250" />

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -12,17 +12,21 @@
         mc:Ignorable="d"
         Title="EDDI" ResizeMode="CanResizeWithGrip" Width="928" Height="600" MinWidth="928" MinHeight="600">
     <Window.Resources>
+        <!-- Colors and simple brushes -->
+        <Color x:Key="DeepPurple" A="0xff" R="0x43" G="0x35" B="0x5d"/>
+        <SolidColorBrush x:Key="NeutralBackgroundBrush" Color="{x:Static SystemColors.ControlLightColor}"/>
         <SolidColorBrush x:Key="DataGridLineBrush" Color="LightGray"/>
+        <!-- Gradients -->
+        <LinearGradientBrush x:Key="DockPanelBackgroundBrush" EndPoint="0.5,1.0" MappingMode="RelativeToBoundingBox" StartPoint="0.5,0.0">
+            <GradientStop Color="Black" Offset="0.0"/>
+            <GradientStop Color="{StaticResource DeepPurple}" Offset="1.0"/>
+        </LinearGradientBrush>
+        <!-- Styles -->
         <Style TargetType="DataGrid">
             <Setter Property="AlternatingRowBackground" Value="AliceBlue"/>
             <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
             <Setter Property="VerticalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
         </Style>
-        <Color x:Key="DeepPurple" A="0xff" R="0x43" G="0x35" B="0x5d"></Color>
-        <LinearGradientBrush x:Key="DockPanelBackgroundBrush" EndPoint="0.5,1.0" MappingMode="RelativeToBoundingBox" StartPoint="0.5,0.0">
-            <GradientStop Color="Black" Offset="0.0"/>
-            <GradientStop Color="{StaticResource DeepPurple}" Offset="1.0"/>
-        </LinearGradientBrush>
     </Window.Resources>
     <DockPanel LastChildFill="True" Background="{StaticResource DockPanelBackgroundBrush}">
         <TabControl x:Name="tabControl" DockPanel.Dock="Top" TabStripPlacement="Left">
@@ -33,8 +37,8 @@
                 </Style>
             </TabControl.Resources>
             <TabItem Header="EDDI">
-                <DockPanel LastChildFill="True" Background="#FFE5E5E5">
-                    <DockPanel LastChildFill="True" Background="#FFE5E5E5" DockPanel.Dock="Bottom" Margin="5">
+                <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
+                    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" DockPanel.Dock="Bottom" Margin="5">
                         <TextBlock DockPanel.Dock="Left" VerticalAlignment="Center" Text="{x:Static resx:MainWindow.EDDI_status_label}"/>
                         <TextBlock x:Name="versionText" VerticalAlignment="Center" DockPanel.Dock="Right"/>
                         <Label Height="28" Margin="0,0,0,0" Name="Version" DockPanel.Dock="Right" VerticalAlignment="Center">
@@ -45,8 +49,8 @@
                         <Button x:Name="upgradeButton" VerticalAlignment="Center" DockPanel.Dock="Left" Visibility="Collapsed" Margin="10,0,10,0" Foreground="Orange" Click="upgradeClicked" Content="{x:Static resx:MainWindow.upgrade_button}"></Button>
                         <TextBlock x:Name="statusText" VerticalAlignment="Center" DockPanel.Dock="Left" Text="{x:Static resx:EddiResources.operational}"/>
                     </DockPanel>
-                    <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-                        <FlowDocument Background="#FFE5E5E5">
+                    <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+                        <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                             <Paragraph>
                                 <Hyperlink Click="EDDIClicked">EDDI</Hyperlink>
                                 <Run Text="{x:Static resx:MainWindow.paragraph_0}" />
@@ -96,7 +100,7 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="{x:Static resx:MainWindow.tab_commander_details_header}">
-                <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+                <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
                     <Grid Margin="5">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="120" />
@@ -197,7 +201,7 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="{x:Static resx:MainWindow.tab_frontier_header}">
-                <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+                <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
                     <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5" Text="{x:Static resx:MainWindow.tab_frontier_desc}" VerticalAlignment="Top"/>
                     <Grid DockPanel.Dock="Top">
                         <Grid.ColumnDefinitions>
@@ -229,7 +233,7 @@
                 </DockPanel>
             </TabItem>
             <TabItem Header="{x:Static resx:MainWindow.tab_tts_header}">
-                <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+                <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
                     <TextBlock x:Name="ttsText" DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5" Text="{x:Static resx:MainWindow.tab_tts_desc}" />
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -18,14 +18,12 @@
             <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
             <Setter Property="VerticalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
         </Style>
+        <LinearGradientBrush x:Key="DockPanelBackgroundBrush" EndPoint="0.5,1.0" MappingMode="RelativeToBoundingBox" StartPoint="0.5,0.0">
+            <GradientStop Color="Black" Offset="0.0"/>
+            <GradientStop Color="#FF4E355D" Offset="1.0"/>
+        </LinearGradientBrush>
     </Window.Resources>
-    <DockPanel LastChildFill="True">
-        <DockPanel.Background>
-            <LinearGradientBrush EndPoint="0.5,1" MappingMode="RelativeToBoundingBox" StartPoint="0.5,0">
-                <GradientStop Color="Black"/>
-                <GradientStop Color="#FF4E355D" Offset="1"/>
-            </LinearGradientBrush>
-        </DockPanel.Background>
+    <DockPanel LastChildFill="True" Background="{StaticResource DockPanelBackgroundBrush}">
         <TabControl x:Name="tabControl" DockPanel.Dock="Top" TabStripPlacement="Left">
             <TabControl.Resources>
                 <Style TargetType="TabItem">

--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -18,9 +18,10 @@
             <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
             <Setter Property="VerticalGridLinesBrush" Value="{StaticResource DataGridLineBrush}"/>
         </Style>
+        <Color x:Key="DeepPurple" A="0xff" R="0x43" G="0x35" B="0x5d"></Color>
         <LinearGradientBrush x:Key="DockPanelBackgroundBrush" EndPoint="0.5,1.0" MappingMode="RelativeToBoundingBox" StartPoint="0.5,0.0">
             <GradientStop Color="Black" Offset="0.0"/>
-            <GradientStop Color="#FF4E355D" Offset="1.0"/>
+            <GradientStop Color="{StaticResource DeepPurple}" Offset="1.0"/>
         </LinearGradientBrush>
     </Window.Resources>
     <DockPanel LastChildFill="True" Background="{StaticResource DockPanelBackgroundBrush}">

--- a/EDDI/PluginSkeleton.xaml
+++ b/EDDI/PluginSkeleton.xaml
@@ -7,7 +7,7 @@
              xmlns:resx="clr-namespace:Eddi.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="400">
-    <DockPanel x:Name="panel" LastChildFill="False" Background="#FFE5E5E5">
+    <DockPanel x:Name="panel" LastChildFill="False" Background="{StaticResource NeutralBackgroundBrush}">
         <TextBlock DockPanel.Dock="Top" x:Name="plugindescription" TextWrapping="Wrap" Margin="5" />
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="5">
             <CheckBox x:Name="pluginenabled" Checked="pluginenabled_Checked" Unchecked="pluginenabled_Unchecked"></CheckBox>

--- a/EDDPMonitor/ConfigurationWindow.xaml
+++ b/EDDPMonitor/ConfigurationWindow.xaml
@@ -9,7 +9,7 @@
              xmlns:resx="clr-namespace:EddiEddpMonitor.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5, 0, 0, 10"  Text="{x:Static resx:EddpResources.p1}" VerticalAlignment="Top"/>
         <UniformGrid DockPanel.Dock="Bottom" Rows="1" Margin="0,5">
             <Button Margin="10" HorizontalAlignment="Center" Click="eddpAddWatch" Content="{x:Static resx:EddpResources.new_watch}" />

--- a/EDSMResponder/ConfigurationWindow.xaml
+++ b/EDSMResponder/ConfigurationWindow.xaml
@@ -7,7 +7,7 @@
              xmlns:resx="clr-namespace:EddiEdsmResponder.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/GalnetMonitor/ConfigurationWindow.xaml
+++ b/GalnetMonitor/ConfigurationWindow.xaml
@@ -6,7 +6,7 @@
              xmlns:resx="clr-namespace:EddiGalnetMonitor.Properties"
             mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="600">
-    <DockPanel LastChildFill="False" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="False" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -19,7 +19,7 @@
             </Grid.RowDefinitions>
             <StackPanel DockPanel.Dock="Top" Grid.Row="0" Grid.ColumnSpan="2" Orientation="Horizontal" VerticalAlignment="Top" Height="22">
                 <TextBlock Margin="5,0" TextWrapping="Wrap" Text="{x:Static resx:GalnetMonitor.language_label}" VerticalAlignment="Center"/>
-                <ComboBox x:Name="languageComboBox" Background="#FFE5E5E5" SelectionChanged="onLanguageChanged" SelectedValue="Key"/>
+                <ComboBox x:Name="languageComboBox" Background="{StaticResource NeutralBackgroundBrush}" SelectionChanged="onLanguageChanged" SelectedValue="Key"/>
             </StackPanel>
             <TextBlock Grid.Row="1"  Grid.ColumnSpan="2" Margin="5,5,5,0" TextWrapping="Wrap" Text="{x:Static resx:GalnetMonitor.p1}" VerticalAlignment="Top" Height="32"/>
             <CheckBox x:Name="galnetAlwaysOn" Grid.Row="2"  Grid.Column="0" Margin="5,26" HorizontalAlignment="Right" VerticalAlignment="Center" Checked="galnetAlwaysOnChecked" Unchecked="galnetAlwaysOnUnchecked" Height="14"/>

--- a/InaraResponder/ConfigurationWindow.xaml
+++ b/InaraResponder/ConfigurationWindow.xaml
@@ -7,7 +7,7 @@
              xmlns:resx="clr-namespace:EddiInaraResponder.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/MaterialMonitor/ConfigurationWindow.xaml
+++ b/MaterialMonitor/ConfigurationWindow.xaml
@@ -9,7 +9,7 @@
              xmlns:utility="clr-namespace:Utilities;assembly=Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5,0" Text="{x:Static resx:MaterialMonitor.p1}"/>
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin ="5" Text="{x:Static resx:MaterialMonitor.p2}"/>
         <UniformGrid DockPanel.Dock="Bottom" Rows="1" Columns="2" Margin="240,5">

--- a/MissionMonitor/ConfigurationWindow.xaml
+++ b/MissionMonitor/ConfigurationWindow.xaml
@@ -9,7 +9,7 @@
              xmlns:utility="clr-namespace:Utilities;assembly=Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0,5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0,5">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5,5" Text="{x:Static resx:MissionMonitor.para1}" />
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5,5" Text="{x:Static resx:MissionMonitor.para2}" />
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" VerticalAlignment="Top">

--- a/ShipMonitor/ConfigurationWindow.xaml
+++ b/ShipMonitor/ConfigurationWindow.xaml
@@ -10,10 +10,10 @@
              xmlns:utility="clr-namespace:Utilities;assembly=Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5"  Text="{x:Static resx:ShipMonitor.p1}" VerticalAlignment="Top"/>
-        <RichTextBox DockPanel.Dock="Top" Margin="0"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-            <FlowDocument Background="#FFE5E5E5">
+        <RichTextBox DockPanel.Dock="Top" Margin="0"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+            <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                 <Paragraph >
                     <Run Text="{x:Static resx:ShipMonitor.p2}" />
                     <Hyperlink Click="ipaClicked" >
@@ -33,7 +33,7 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock TextWrapping="Wrap" Text="{x:Static resx:ShipMonitor.p5}" Margin="5, 0, 0, 0" VerticalAlignment="Top"/>
-            <ComboBox x:Name="exportComboBox" Grid.Column="1" Margin="5, 0, 0, 0" Background="#FFE5E5E5" SelectionChanged="onExportTargetChanged" SelectedValuePath="Content" IsEditable="False" IsReadOnly="True" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Right">
+            <ComboBox x:Name="exportComboBox" Grid.Column="1" Margin="5, 0, 0, 0" Background="{StaticResource NeutralBackgroundBrush}" SelectionChanged="onExportTargetChanged" SelectedValuePath="Content" IsEditable="False" IsReadOnly="True" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Right">
                 <ComboBoxItem>Coriolis</ComboBoxItem>
                 <ComboBoxItem>EDShipyard</ComboBoxItem>
             </ComboBox>

--- a/ShipMonitor/IpaResources.xaml
+++ b/ShipMonitor/IpaResources.xaml
@@ -13,9 +13,9 @@
              MaxHeight="450"
              SizeToContent="WidthAndHeight"
              d:DesignHeight="300" d:DesignWidth="400">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="0">
-        <RichTextBox DockPanel.Dock="Top" Margin="0"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-            <FlowDocument Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="0">
+        <RichTextBox DockPanel.Dock="Top" Margin="0"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+            <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                 <Paragraph >
                     <Run Text="{x:Static resx:ShipMonitor.ipa_page_p1}" />
                     <Hyperlink Click="pageClicked" >
@@ -26,8 +26,8 @@
             </FlowDocument>
         </RichTextBox>
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="5"  Text="{x:Static resx:ShipMonitor.ipa_page_comments}" VerticalAlignment="Top"/>
-        <RichTextBox DockPanel.Dock="Bottom" Margin="0, 10"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-            <FlowDocument Background="#FFE5E5E5">
+        <RichTextBox DockPanel.Dock="Bottom" Margin="0, 10"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+            <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                 <Paragraph >
                     <Hyperlink Click="resource1Clicked" >
                         <Run Text="{x:Static resx:ShipMonitor.ipa_resource1_title}" />

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -7,7 +7,7 @@
              xmlns:resx="clr-namespace:EddiSpeechResponder.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5" Margin="-10">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}" Margin="-10">
         <Grid DockPanel.Dock="Top" Margin="0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -23,8 +23,8 @@
                     <CheckBox x:Name="subtitlesOnlyCheckbox" Margin="0" VerticalAlignment="Center" Checked="subtitlesOnlyEnabled" Unchecked="subtitlesOnlyDisabled"/>
                 </StackPanel>
             </StackPanel>
-            <RichTextBox x:Name="speechResponderHelp" DockPanel.Dock="Left" Grid.Column="1" Width="Auto" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-                <FlowDocument Background="#FFE5E5E5">
+            <RichTextBox x:Name="speechResponderHelp" DockPanel.Dock="Left" Grid.Column="1" Width="Auto" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+                <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                     <Paragraph>
                         <TextBlock TextWrapping="Wrap">
                             <Run Text="{x:Static resx:SpeechResponder.speechResponderHelp}"/>

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -12,7 +12,7 @@
         WindowStyle="ToolWindow"
         Height="200" Width="300"
         >
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/SpeechResponder/EditScriptWindow.xaml
+++ b/SpeechResponder/EditScriptWindow.xaml
@@ -9,7 +9,7 @@
         Title="Edit script" 
         ResizeMode="CanResizeWithGrip"
         Height="600" Width="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/SpeechResponder/ShowDiffWindow.xaml
+++ b/SpeechResponder/ShowDiffWindow.xaml
@@ -8,7 +8,7 @@
              Title="{x:Static resx:SpeechResponder.compare_script_title}" 
              ResizeMode="CanResizeWithGrip"
              Height="600" Width="800"
-             Background="#FFE5E5E5" >
+             Background="{StaticResource NeutralBackgroundBrush}" >
     <RichTextBox x:Name="scriptText" Background="Transparent" BorderThickness="0" Margin="5" IsReadOnly="True" FontFamily="Consolas">
         <RichTextBox.Resources>
             <Style TargetType="{x:Type Paragraph}">

--- a/SpeechResponder/ViewScriptWindow.xaml
+++ b/SpeechResponder/ViewScriptWindow.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         ResizeMode="CanResizeWithGrip"
         Title="{x:Static resx:SpeechResponder.view_script_title}" Height="600" Width="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />

--- a/VoiceAttackResponder/ConfigurationWindow.xaml
+++ b/VoiceAttackResponder/ConfigurationWindow.xaml
@@ -7,12 +7,12 @@
              xmlns:resx="clr-namespace:EddiVoiceAttackResponder.Properties"
              mc:Ignorable="d" 
              d:DesignHeight="600" d:DesignWidth="800">
-    <DockPanel LastChildFill="True" Background="#FFE5E5E5">
+    <DockPanel LastChildFill="True" Background="{StaticResource NeutralBackgroundBrush}">
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="10" Text="{x:Static resx:VoiceAttack.p1}" VerticalAlignment="Top"/>
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="10" Text="{x:Static resx:VoiceAttack.p2}" VerticalAlignment="Top"/>
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Margin="10" Text="{x:Static resx:VoiceAttack.p3}" VerticalAlignment="Top"/>
-        <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-            <FlowDocument Background="#FFE5E5E5">
+        <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+            <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                 <Paragraph>
                     <Run Text="{x:Static resx:VoiceAttack.p4}" />
                     <Hyperlink Click="VAVariablesClicked">
@@ -20,8 +20,8 @@
                     </Hyperlink>.</Paragraph>
             </FlowDocument>
         </RichTextBox>
-        <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="#FFE5E5E5" BorderThickness="0">
-            <FlowDocument Background="#FFE5E5E5">
+        <RichTextBox DockPanel.Dock="Top" Margin="5"  IsReadOnly="True" IsDocumentEnabled="True" Background="{StaticResource NeutralBackgroundBrush}" BorderThickness="0">
+            <FlowDocument Background="{StaticResource NeutralBackgroundBrush}">
                 <Paragraph>
                     <Run Text="{x:Static resx:VoiceAttack.p5}" />
                     <Hyperlink Click="VAVariablesClicked">


### PR DESCRIPTION
* Replace all hard-coded color values with named `Brush` or `Color` XAML resources, to make it easier to ensure consistency across the app.
* Hoist all such resources into the `Window.Resources` section, since MS document that this is best practice and reduces memory pressure by making them shared objects.
