### PR TITLE
Standardize and fix timestamp parsing

### DIFF
--- a/DataDefinitions/Mission.cs
+++ b/DataDefinitions/Mission.cs
@@ -219,7 +219,7 @@ namespace EddiDataDefinitions
 
         public DateTime? expiry { get; set; }
         [JsonIgnore]
-        public long? expiryseconds => (long?)expiry?.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+        public long? expiryseconds => expiry != null ? (long?)Utilities.Dates.fromDateTimeToSeconds((DateTime)expiry) : null;
         [JsonIgnore]
         public bool expiring { get; set; }
 

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -224,7 +224,7 @@ namespace EddiDataDefinitions
 
         /// <summary>Time of last visit, expressed as a Unix timestamp in seconds</summary>
         [JsonIgnore]
-        public long? lastVisitSeconds => lastvisit > DateTime.MinValue ? (long?)((DateTime)lastvisit).Subtract(new DateTime(1970, 1, 1)).TotalSeconds : null;
+        public long? lastVisitSeconds => lastvisit > DateTime.MinValue ? (long?)Utilities.Dates.fromDateTimeToSeconds((DateTime)lastvisit) : null;
 
         /// <summary>comment on this starsystem</summary>
         public string comment;

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1457,12 +1457,12 @@ namespace Eddi
 
                     if (quotes != null && info.Items.Count == quotes.Count)
                     {
-                        if (CurrentStation?.marketId == theEvent.marketId)
+                        if (CurrentStation?.marketId != null && CurrentStation?.marketId == theEvent.marketId)
                         {
                             // Update the current station commodities
                             allowMarketUpdate = false;
                             CurrentStation.commodities = quotes;
-                            CurrentStation.commoditiesupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                            CurrentStation.commoditiesupdatedat = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
 
                             // Update the current station information in our backend DB
                             Logging.Debug("Star system information updated from remote server; updating local copy");
@@ -1502,12 +1502,12 @@ namespace Eddi
 
                     if (modules != null && info.Items.Count == modules.Count)
                     {
-                        if (CurrentStation?.marketId == theEvent.marketId)
+                        if (CurrentStation?.marketId != null && CurrentStation?.marketId == theEvent.marketId)
                         {
                             // Update the current station outfitting
                             allowOutfittingUpdate = false;
                             CurrentStation.outfitting = modules;
-                            CurrentStation.outfittingupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                            CurrentStation.outfittingupdatedat = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
 
                             // Update the current station information in our backend DB
                             Logging.Debug("Star system information updated from remote server; updating local copy");
@@ -1547,12 +1547,12 @@ namespace Eddi
 
                     if (ships != null && info.PriceList.Count == ships.Count)
                     {
-                        if (CurrentStation?.marketId == theEvent.marketId)
+                        if (CurrentStation?.marketId != null && CurrentStation?.marketId == theEvent.marketId)
                         {
                             // Update the current station shipyard
                             allowShipyardUpdate = false;
                             CurrentStation.shipyard = ships;
-                            CurrentStation.shipyardupdatedat = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                            CurrentStation.shipyardupdatedat = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
 
                             // Update the current station information in our backend DB
                             Logging.Debug("Star system information updated from remote server; updating local copy");
@@ -1766,7 +1766,7 @@ namespace Eddi
 
             // Update to most recent information
             CurrentStarSystem.visitLog.Add(theEvent.timestamp);
-            CurrentStarSystem.updatedat = (long)theEvent.timestamp.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+            CurrentStarSystem.updatedat = Dates.fromDateTimeToSeconds(theEvent.timestamp);
             StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
 
             setSystemDistanceFromHome(CurrentStarSystem);
@@ -2210,7 +2210,7 @@ namespace Eddi
                     // Save a timestamp when the API refreshes, so that we can compare whether events are more or less recent
                     ApiTimeStamp = DateTime.UtcNow;
 
-                    long profileTime = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                    long profileTime = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
                     Profile profile = CompanionAppService.Instance.Profile();
                     if (profile != null)
                     {
@@ -2543,7 +2543,7 @@ namespace Eddi
                             if (profile.docked && Environment == Constants.ENVIRONMENT_DOCKED)
                             {
                                 ApiTimeStamp = DateTime.UtcNow;
-                                long profileTime = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                                long profileTime = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
 
                                 Logging.Debug("Fetching station profile");
                                 Profile stationProfile = CompanionAppService.Instance.Station(CurrentStarSystem.systemname);

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1471,7 +1471,7 @@ namespace Eddi
 
                         // Post an update event for new market data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1516,7 +1516,7 @@ namespace Eddi
 
                         // Post an update event for new outfitting data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1561,7 +1561,7 @@ namespace Eddi
 
                         // Post an update event for new shipyard data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timeStamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
                         enqueueEvent(@event);
                     }
                     return true;

--- a/EDDI/MarketInfoReader.cs
+++ b/EDDI/MarketInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class MarketInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp);
+        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/MarketInfoReader.cs
+++ b/EDDI/MarketInfoReader.cs
@@ -8,8 +8,7 @@ namespace Eddi
 {
     public class MarketInfoReader
     {
-        public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
+        public DateTime timestamp { get; set; }
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/OutfittingInfoReader.cs
+++ b/EDDI/OutfittingInfoReader.cs
@@ -8,8 +8,7 @@ namespace Eddi
 {
     public class OutfittingInfoReader
     {
-        public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
+        public DateTime timestamp { get; set; }
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/OutfittingInfoReader.cs
+++ b/EDDI/OutfittingInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class OutfittingInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp);
+        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/ShipyardInfoReader.cs
+++ b/EDDI/ShipyardInfoReader.cs
@@ -8,8 +8,7 @@ namespace Eddi
 {
     public class ShipyardInfoReader
     {
-        public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
+        public DateTime timestamp { get; set; }
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/EDDI/ShipyardInfoReader.cs
+++ b/EDDI/ShipyardInfoReader.cs
@@ -9,7 +9,7 @@ namespace Eddi
     public class ShipyardInfoReader
     {
         public string timestamp { get; set; }
-        public DateTime timeStamp => DateTime.Parse(timestamp);
+        public DateTime timeStamp => DateTime.Parse(timestamp).ToUniversalTime();
         public long MarketID { get; set; }
         public string StationName { get; set; }
         public string StarSystem { get; set; }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -78,18 +78,11 @@ namespace EddiJournalMonitor
 
                     // Every event has a timestamp field
                     DateTime timestamp = DateTime.UtcNow;
-                    if (data.ContainsKey("timestamp"))
+                    try
                     {
-                        if (data["timestamp"] is DateTime)
-                        {
-                            timestamp = ((DateTime)data["timestamp"]).ToUniversalTime();
-                        }
-                        else
-                        {
-                            timestamp = DateTime.Parse(JsonParsing.getString(data, "timestamp")).ToUniversalTime();
-                        }
+                        timestamp = JsonParsing.getDateTime("timestamp", data);
                     }
-                    else
+                    catch
                     {
                         Logging.Warn("Event without timestamp; using current time");
                     }

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -519,7 +519,7 @@ namespace EddiSpeechResponder
                 {
                     return null;
                 }
-                long? now = (long?)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc))).TotalSeconds;
+                long? now = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
 
                 return now - date;
             }, 1);

--- a/StarMapService/EdsmBodyData.cs
+++ b/StarMapService/EdsmBodyData.cs
@@ -136,8 +136,8 @@ namespace EddiStarMapService
 
                 Body Body = new Body(bodyname, bodyId, parents, distanceLs, stellarclass, stellarsubclass, stellarMass, radiusKm, absolutemagnitude, ageMegaYears, temperatureKelvin, luminosityclass, semimajoraxisLs, eccentricity, orbitalInclinationDegrees, periapsisDegrees, orbitalPeriodDays, rotationPeriodDays, axialTiltDegrees, rings, true, false, systemName, null);
                 Body.EDSMID = EDSMID;
-                DateTime updatedAt = DateTime.SpecifyKind(DateTime.Parse((string)body["updateTime"]), DateTimeKind.Utc);
-                Body.updatedat = updatedAt == null ? null : (long?)(updatedAt.Subtract(new DateTime(1970, 1, 1, 0, 0, 0))).TotalSeconds;
+                DateTime updatedAt = JsonParsing.getDateTime("updateTime", body);
+                Body.updatedat = updatedAt == null ? null : (long?)Dates.fromDateTimeToSeconds(updatedAt);
 
                 return Body;
             }
@@ -232,11 +232,11 @@ namespace EddiStarMapService
                 }
                 ReserveLevel reserveLevel = ReserveLevel.FromName((string)body["reserveLevel"]) ?? ReserveLevel.None;
 
-                DateTime updatedAt = DateTime.SpecifyKind(DateTime.Parse((string)body["updateTime"]), DateTimeKind.Utc);
+                DateTime updatedAt = JsonParsing.getDateTime("updateTime", body);
                 Body Body = new Body(bodyname, bodyId, parents, distanceLs, tidallylocked, terraformState, planetClass, atmosphereClass, atmosphereCompositions, volcanism, earthmass, radiusKm, (decimal)gravity, temperatureKelvin, pressureAtm, landable, materials, solidCompositions, semimajoraxisLs, eccentricity, orbitalInclinationDegrees, periapsisDegrees, orbitalPeriodDays, rotationPeriodDays, axialTiltDegrees, rings, reserveLevel, true, true, systemName, null)
                 {
                     EDSMID = EDSMID,
-                    updatedat = updatedAt == null ? null : (long?)(updatedAt.Subtract(new DateTime(1970, 1, 1, 0, 0, 0))).TotalSeconds
+                    updatedat = updatedAt == null ? null : (long?)Dates.fromDateTimeToSeconds(updatedAt)
                 };
 
                 return Body;

--- a/StarMapService/EdsmFactionData.cs
+++ b/StarMapService/EdsmFactionData.cs
@@ -67,6 +67,7 @@ namespace EddiStarMapService
 
         private static Faction ParseStarMapFaction(JObject faction, string systemName)
         {
+            if (faction is null) { return null; }
             Faction Faction = new Faction
             {
                 name = (string)faction["name"],
@@ -74,7 +75,7 @@ namespace EddiStarMapService
                 Allegiance = Superpower.FromName((string)faction["allegiance"]) ?? Superpower.None,
                 Government = Government.FromName((string)faction["government"]) ?? Government.None,
                 isplayer = (bool?)faction["isPlayer"],
-                updatedAt = (DateTime)Dates.fromTimestamp((long?)faction["lastUpdate"])
+                updatedAt = Dates.fromTimestamp((long?)faction["lastUpdate"]) ?? DateTime.MinValue
             };
 
             Faction.presences.Add(new FactionPresence()

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -175,20 +175,14 @@ namespace EddiStatusMonitor
                     IDictionary<string, object> data = Deserializtion.DeserializeData(line);
 
                     // Every status event has a timestamp field
-                    if (data.ContainsKey("timestamp"))
+                    status.timestamp = DateTime.UtcNow;
+                    try
                     {
-                        if (data["timestamp"] is DateTime)
-                        {
-                            status.timestamp = ((DateTime)data["timestamp"]).ToUniversalTime();
-                        }
-                        else
-                        {
-                            status.timestamp = DateTime.Parse(JsonParsing.getString(data, "timestamp")).ToUniversalTime();
-                        }
+                        status.timestamp = JsonParsing.getDateTime("timestamp", data);
                     }
-                    else
+                    catch
                     {
-                        Logging.Warn("Status event without timestamp; using current time");
+                        Logging.Warn("Status without timestamp; using current time");
                     }
 
                     status.flags = (Status.Flags)(JsonParsing.getOptionalLong(data, "Flags") ?? 0);

--- a/Utilities/JsonParsing.cs
+++ b/Utilities/JsonParsing.cs
@@ -51,7 +51,7 @@ namespace Utilities
                     // Journal format ("2019-09-24T02:40:34Z")
                     return result;
                 }
-                if (DateTime.TryParseExact(str, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out result))
+                if (DateTime.TryParseExact(str, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out result))
                 {
                     // EDSM format ("2018-03-28 22:12:20")
                     return result;

--- a/Utilities/JsonParsing.cs
+++ b/Utilities/JsonParsing.cs
@@ -10,6 +10,31 @@ namespace Utilities
         /// Provide helper functions for parsing json files
         /// </summary>
 
+        public static DateTime getDateTime(string key, IDictionary<string, object> data)
+        {
+            data.TryGetValue(key, out object val);
+            return getDateTime(key, val);
+        }
+
+        public static DateTime getDateTime(string key, object val)
+        {
+            // DateTime.Parse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal)
+            // and (DateTime.Parse(timestamp).ToUniversalTime() are equivalent and both return a TimeStamp in UTC.
+            if (val == null)
+            {
+                throw new ArgumentNullException("Expected value for " + key + " not present");
+            }
+            if (val is DateTime dtime)
+            {
+                return dtime.ToUniversalTime();
+            }
+            if (val is string str)
+            {
+                return DateTime.Parse(str).ToUniversalTime();
+            }
+            throw new ArgumentException("Unparseable value for " + key);
+        }
+
         public static decimal getDecimal(IDictionary<string, object> data, string key)
         {
             data.TryGetValue(key, out object val);

--- a/Utilities/JsonParsing.cs
+++ b/Utilities/JsonParsing.cs
@@ -34,6 +34,10 @@ namespace Utilities
             }
             if (val is DateTime dtime)
             {
+                if (dtime.Kind is DateTimeKind.Utc)
+                {
+                    return dtime;
+                }
                 return dtime.ToUniversalTime();
             }
             if (val is JToken jToken)
@@ -42,17 +46,17 @@ namespace Utilities
             }
             if (val is string str)
             {
-                if (DateTime.TryParseExact(str, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var result))
+                if (DateTime.TryParseExact(str, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var result))
                 {
                     // Journal format ("2019-09-24T02:40:34Z")
-                    return result.ToUniversalTime();
+                    return result;
                 }
-                if (DateTime.TryParseExact(str, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out result))
+                if (DateTime.TryParseExact(str, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out result))
                 {
                     // EDSM format ("2018-03-28 22:12:20")
-                    return result.ToUniversalTime();
+                    return result;
                 }
-                return DateTime.Parse(str).ToUniversalTime();
+                return DateTime.Parse(str, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
             }
             throw new ArgumentException("Unparseable value for " + key);
         }


### PR DESCRIPTION
Resolves #1571
Replaces #1572 

- Centralizes DateTime parsing to a new `getDateTime` method in Utilities.cs
- Centralizes conversion from DateTime to epoch seconds to the already existing `fromDateTimeToSeconds` method in Utilities.cs.
- Simplifies MarketInfoReader.cs, OutfittingInfoReader.cs, and ShipyardInfoReader.cs to deserialize directly to the DateTime rather than deserializing to a string and then converting to a DateTime.