### PR TITLE
Fix changes to EDSM credentials not reloading the StarMapService

### DIFF
--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -63,15 +63,21 @@ namespace EddiEdsmResponder
                 ignoredEvents = edsmService?.getIgnoredEvents();
             }
 
-            if (edsmService != null && updateThread == null)
+            if (edsmService != null)
             {
-                // Spin off a thread to download & sync flight logs & system comments from EDSM in the background 
-                updateThread = new Thread(() => dataProviderService.syncFromStarMapService(StarMapConfiguration.FromFile()?.lastSync))
+                // Renew our credentials for the EDSM API
+                edsmService.Reload();
+
+                if (updateThread == null)
                 {
-                    IsBackground = true,
-                    Name = "EDSM updater"
-                };
-                updateThread.Start();
+                    // Spin off a thread to download & sync flight logs & system comments from EDSM in the background 
+                    updateThread = new Thread(() => dataProviderService.syncFromStarMapService(StarMapConfiguration.FromFile()?.lastSync))
+                    {
+                        IsBackground = true,
+                        Name = "EDSM updater"
+                    };
+                    updateThread.Start();
+                }
             }
         }
 

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -66,7 +66,7 @@ namespace EddiEdsmResponder
             if (edsmService != null)
             {
                 // Renew our credentials for the EDSM API
-                edsmService.Reload();
+                edsmService.SetEdsmCredentials();
 
                 if (updateThread == null)
                 {

--- a/StarMapService/IEdsmService.cs
+++ b/StarMapService/IEdsmService.cs
@@ -6,6 +6,7 @@ namespace EddiStarMapService
 {
     public interface IEdsmService
     {
+        void Reload();
         void sendEvent(string eventData);
         void sendStarMapComment(string systemName, string comment);
         Dictionary<string, string> getStarMapComments();

--- a/StarMapService/IEdsmService.cs
+++ b/StarMapService/IEdsmService.cs
@@ -6,9 +6,9 @@ namespace EddiStarMapService
 {
     public interface IEdsmService
     {
-        void Reload();
         void sendEvent(string eventData);
         void sendStarMapComment(string systemName, string comment);
+        void SetEdsmCredentials();
         Dictionary<string, string> getStarMapComments();
         List<Body> GetStarMapBodies(string system, long? edsmId = null);
         List<StarMapResponseLogEntry> getStarMapLog(DateTime? since = null, string[] systemNames = null);

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -53,12 +53,7 @@ namespace EddiStarMapService
             SetEdsmCredentials();
         }
 
-        public void Reload()
-        {
-            SetEdsmCredentials();
-        }
-
-        private void SetEdsmCredentials()
+        public void SetEdsmCredentials()
         {
             StarMapConfiguration starMapCredentials = StarMapConfiguration.FromFile();
             if (!string.IsNullOrEmpty(starMapCredentials?.apiKey))


### PR DESCRIPTION
Fixes updating EDSM credentials in the EDSM responder UI reloading the EDSM responder but not the associated EDSM credentials in the StarMapService.

I believe that this resolves #1290.