### PR TITLE
Fix commander object losing data when refreshing from the Front…

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -615,7 +615,7 @@ namespace EddiCompanionAppService
 
             if (json["commander"] != null)
             {
-                Commander Commander = new Commander
+                FrontierApiCommander Commander = new FrontierApiCommander
                 {
                     name = (string)json["commander"]["name"],
 

--- a/CompanionAppService/Profile.cs
+++ b/CompanionAppService/Profile.cs
@@ -12,7 +12,7 @@ namespace EddiCompanionAppService
         public JObject json { get; set; }
 
         /// <summary>The commander</summary>
-        public Commander Cmdr { get; set; }
+        public FrontierApiCommander Cmdr { get; set; }
 
         /// <summary>The current starsystem</summary>
         public StarSystem CurrentStarSystem { get; set; }

--- a/DataDefinitions/Commander.cs
+++ b/DataDefinitions/Commander.cs
@@ -1,23 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using Utilities;
 
 namespace EddiDataDefinitions
 {
     /// <summary>
     /// Details about a commander
     /// </summary>
-    public class Commander : INotifyPropertyChanged
+
+    public class FrontierApiCommander
     {
+        // Parameters obtained from the Frontier API
+
         /// <summary>The commander's name</summary>
         public string name { get; set; }
-        /// <summary>The commander's name as spoken</summary>
-        public string phoneticname { get; set; }
-
-        /// <summary> The commander's title.  This is dependent on the current system</summary>
-        public string title { get; set; }
-
-        /// <summary> The commander's gender.  This is set in EDDI's configuration</summary>
-        public string gender { get; set; }
 
         /// <summary>The commander's combat rating</summary>
         public CombatRating combatrating { get; set; }
@@ -43,14 +40,35 @@ namespace EddiDataDefinitions
         /// <summary>The commander's service rating</summary>
         public int servicerating { get; set; }
 
+        /// <summary>The commander's powerplay rating (if pledged)</summary>
+        public int powerrating { get; set; }
+
+        /// <summary>The number of credits the commander holds</summary>
+        public long credits { get; set; }
+
+        /// <summary>The amount of debt the commander owes</summary>
+        public long debt { get; set; }
+    }
+
+    public class Commander : FrontierApiCommander, INotifyPropertyChanged
+    {
+        // Parameters not obtained from the Frontier API
+        // Note: Any information not updated from the Frontier API will need to be reset when the Frontier API refreshes the commander definition.
+
+        /// <summary>The commander's name as spoken</summary>
+        public string phoneticname { get; set; }
+
+        /// <summary> The commander's title.  This is dependent on the current system</summary>
+        public string title { get; set; }
+
+        /// <summary> The commander's gender.  This is set in EDDI's configuration</summary>
+        public string gender { get; set; }
+
         /// <summary>The commander's powerplay power (if pledged)</summary>
         public Power Power { get; set; }
 
         /// <summary>The commander's powerplay power (localized) (if pledged)</summary>
         public string power => (Power ?? Power.None)?.localizedName;
-
-        /// <summary>The commander's powerplay rating (if pledged)</summary>
-        public int powerrating { get; set; }
 
         /// <summary>The commander's powerplay merits (if pledged)</summary>
         public int? powermerits { get; set; }
@@ -73,12 +91,6 @@ namespace EddiDataDefinitions
         /// <summary>The commander's squadron faction</summary>
         public string squadronfaction { get; set; }
 
-        /// <summary>The number of credits the commander holds</summary>
-        public long credits { get; set; }
-
-        /// <summary>The amount of debt the commander owes</summary>
-        public long debt { get; set; }
-
         /// <summary>The insurance excess percentage the commander has to pay</summary>
         public decimal? insurance { get; set; }
 
@@ -93,6 +105,66 @@ namespace EddiDataDefinitions
         public void NotifyPropertyChanged(string propName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
+        }
+
+        public Commander()
+        { }
+
+        // Copy constructor
+        public Commander(Commander commander)
+        {
+            name = commander.name;
+            combatrating = commander.combatrating;
+            traderating = commander.traderating;
+            explorationrating = commander.explorationrating;
+            cqcrating = CQCRating.FromRank(commander.cqcrating.rank);
+        }
+
+        public static Commander FromFrontierApiCmdr(Commander currentCmdr, FrontierApiCommander frontierApiCommander, DateTime apiTimeStamp, DateTime journalTimeStamp, out bool cmdrMatches)
+        {
+            // Copy our current commander to a new commander object
+            Commander Cmdr = currentCmdr.Copy();
+
+            // Set our commander name if it hadn't already been set
+            Cmdr.name = string.IsNullOrEmpty(Cmdr.name) ? frontierApiCommander.name : Cmdr.name;
+
+            // Verify that the profile information matches the current Cmdr name
+            if (frontierApiCommander.name != Cmdr.name)
+            {
+                Logging.Warn("Frontier API incorrectly configured: Returning information for Commander " +
+                    frontierApiCommander.name + " rather than for " + Cmdr.name + ". Disregarding incorrect information.");
+                cmdrMatches = false;
+                return Cmdr;
+            }
+            cmdrMatches = true;
+
+            // Update our commander object with information exclusively available from the Frontier API
+            Cmdr.crimerating = frontierApiCommander.crimerating;
+            Cmdr.servicerating = frontierApiCommander.servicerating;
+            Cmdr.credits = frontierApiCommander.credits;
+            Cmdr.debt = frontierApiCommander.debt;
+
+            // Update our commander object with information obtainable from the journal
+            // Since the parameters below only increase, we will take any that are higher in rank than we had before
+            Cmdr.combatrating = frontierApiCommander.combatrating.rank > Cmdr.combatrating.rank
+                ? frontierApiCommander.combatrating : Cmdr.combatrating;
+            Cmdr.traderating = frontierApiCommander.traderating.rank > Cmdr.traderating.rank
+                ? frontierApiCommander.traderating : Cmdr.traderating;
+            Cmdr.explorationrating = frontierApiCommander.explorationrating.rank > Cmdr.explorationrating.rank
+                ? frontierApiCommander.explorationrating : Cmdr.explorationrating;
+            Cmdr.cqcrating = frontierApiCommander.cqcrating.rank > Cmdr.cqcrating.rank
+                ? frontierApiCommander.cqcrating : Cmdr.cqcrating;
+            Cmdr.empirerating = frontierApiCommander.empirerating.rank > Cmdr.empirerating.rank
+                ? frontierApiCommander.empirerating : Cmdr.empirerating;
+            Cmdr.federationrating = frontierApiCommander.federationrating.rank > Cmdr.federationrating.rank
+                ? frontierApiCommander.federationrating : Cmdr.federationrating;
+            // Power rating is also updated from the journal but may decrease so we check the timestamp
+            if (apiTimeStamp > journalTimeStamp)
+            {
+                Cmdr.powerrating = frontierApiCommander.powerrating;
+            }
+
+            return Cmdr;
         }
     }
 }

--- a/DataDefinitions/Commander.cs
+++ b/DataDefinitions/Commander.cs
@@ -16,6 +16,9 @@ namespace EddiDataDefinitions
         /// <summary>The commander's name</summary>
         public string name { get; set; }
 
+        /// <summary>The commander's Frontier ID</summary>
+        public string EDID { get; set; }
+
         /// <summary>The commander's combat rating</summary>
         public CombatRating combatrating { get; set; }
 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1572,30 +1572,25 @@ namespace Eddi
 
         private void updateCurrentSystem(string name)
         {
-            if (name == null)
+            if (name == null || CurrentStarSystem?.systemname == name) { return; }
+
+            // We have changed system so update the old one as to when we left
+            StarSystemSqLiteRepository.Instance.LeaveStarSystem(CurrentStarSystem);
+
+            LastStarSystem = CurrentStarSystem;
+            if (NextStarSystem?.systemname == name)
             {
-                return;
+                CurrentStarSystem = NextStarSystem;
+                NextStarSystem = null;
             }
-            if (CurrentStarSystem == null || CurrentStarSystem.systemname != name)
+            else
             {
-                if (CurrentStarSystem != null && CurrentStarSystem.systemname != name)
-                {
-                    // We have changed system so update the old one as to when we left
-                    StarSystemSqLiteRepository.Instance.LeaveStarSystem(CurrentStarSystem);
-                }
-                LastStarSystem = CurrentStarSystem;
-                if (NextStarSystem?.systemname == name)
-                {
-                    CurrentStarSystem = NextStarSystem;
-                    NextStarSystem = null;
-                }
-                else
-                {
-                    CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(name);
-                }
-                setSystemDistanceFromHome(CurrentStarSystem);
-                setSystemDistanceFromDestination(CurrentStarSystem);
+                CurrentStarSystem = StarSystemSqLiteRepository.Instance.GetOrCreateStarSystem(name);
             }
+
+            setSystemDistanceFromHome(CurrentStarSystem);
+            setSystemDistanceFromDestination(CurrentStarSystem);
+            setCommanderTitle();
         }
 
         private void updateCurrentStellarBody(string bodyName, string systemName, long? systemAddress = null)
@@ -1768,10 +1763,6 @@ namespace Eddi
             CurrentStarSystem.visitLog.Add(theEvent.timestamp);
             CurrentStarSystem.updatedat = Dates.fromDateTimeToSeconds(theEvent.timestamp);
             StarSystemSqLiteRepository.Instance.SaveStarSystem(CurrentStarSystem);
-
-            setSystemDistanceFromHome(CurrentStarSystem);
-            setSystemDistanceFromDestination(CurrentStarSystem);
-            setCommanderTitle();
 
             // After jump has completed we are always in supercruise
             Environment = Constants.ENVIRONMENT_SUPERCRUISE;
@@ -2231,7 +2222,6 @@ namespace Eddi
                     // Save a timestamp when the API refreshes, so that we can compare whether events are more or less recent
                     ApiTimeStamp = DateTime.UtcNow;
 
-                    long profileTime = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
                     Profile profile = CompanionAppService.Instance.Profile();
                     if (profile != null)
                     {
@@ -2249,7 +2239,7 @@ namespace Eddi
                             CurrentStarSystem = profile?.CurrentStarSystem;
                             setSystemDistanceFromHome(CurrentStarSystem);
                             setSystemDistanceFromDestination(CurrentStarSystem);
-
+                            setCommanderTitle();
 
                             if (profile.docked && profile.CurrentStarSystem?.systemname == CurrentStarSystem.systemname && CurrentStarSystem.stations != null)
                             {
@@ -2258,7 +2248,7 @@ namespace Eddi
                                 {
                                     // Only set the current station if it is not present, otherwise we leave it to events
                                     Logging.Debug("Set current station to " + CurrentStation.name);
-                                    CurrentStation.updatedat = profileTime;
+                                    CurrentStation.updatedat = Dates.fromDateTimeToSeconds(DateTime.UtcNow);
                                     updatedCurrentStarSystem = true;
                                 }
                             }
@@ -2275,9 +2265,7 @@ namespace Eddi
                             };
                             updateThread.Start();
                         }
-
-                        setCommanderTitle();
-
+                        
                         if (updatedCurrentStarSystem)
                         {
                             Logging.Debug("Star system information updated from remote server; updating local copy");

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -186,6 +186,7 @@ namespace Eddi
                 }
 
                 // Tasks we can start asynchronously and don't need to wait for
+                Cmdr.name = configuration.CommanderName;
                 Cmdr.gender = configuration.Gender;
                 Task.Run(() => updateDestinationSystemStation(configuration));
                 Task.Run(() =>
@@ -734,6 +735,10 @@ namespace Eddi
                     {
                         passEvent = eventEnteredNormalSpace((EnteredNormalSpaceEvent)@event);
                     }
+                    else if (@event is CommanderLoadingEvent)
+                    {
+                        passEvent = eventCommanderLoading((CommanderLoadingEvent)@event);
+                    }
                     else if (@event is CommanderContinuedEvent)
                     {
                         passEvent = eventCommanderContinued((CommanderContinuedEvent)@event);
@@ -902,7 +907,7 @@ namespace Eddi
                 }
             }
         }
-
+        
         private bool eventPowerVoucherReceived(PowerVoucherReceivedEvent @event)
         {
             Cmdr.Power = @event.Power;
@@ -1832,16 +1837,22 @@ namespace Eddi
             return true;
         }
 
+        private bool eventCommanderLoading(CommanderLoadingEvent theEvent) 
+        {
+            // Set our commander name and ID
+            Cmdr.name = theEvent.name;
+            Cmdr.EDID = theEvent.frontierID;
+            return true;
+        }
+
         private bool eventCommanderContinued(CommanderContinuedEvent theEvent)
         {
             // If we see this it means that we aren't in CQC
             inCQC = false;
 
-            // Set our commander name
-            if (Cmdr.name == null)
-            {
-                Cmdr.name = theEvent.commander;
-            }
+            // Set our commander name and ID
+            Cmdr.name = theEvent.commander;
+            Cmdr.EDID = theEvent.frontierID;
 
             // Set game version
             inHorizons = theEvent.horizons;

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -2224,22 +2224,11 @@ namespace Eddi
                     Profile profile = CompanionAppService.Instance.Profile();
                     if (profile != null)
                     {
-                        // Use the profile as primary information for our commander and shipyard
-                        Cmdr = profile.Cmdr;
+                        // Update our commander object
+                        Cmdr = Commander.FromFrontierApiCmdr(Cmdr, profile.Cmdr, ApiTimeStamp, JournalTimeStamp, out bool cmdrMatches);
 
-                        // Reinstate information not obtained from the Companion API (gender settings)
-                        EDDIConfiguration configuration = EDDIConfiguration.FromFile();
-                        if (configuration != null)
-                        {
-                            Cmdr.gender = configuration.Gender;
-                            Cmdr.powermerits = configuration.powerMerits;
-                            Cmdr.squadronname = configuration.SquadronName;
-                            Cmdr.squadronid = configuration.SquadronID;
-                            Cmdr.squadronrank = configuration.SquadronRank;
-                            Cmdr.squadronallegiance = configuration.SquadronAllegiance;
-                            Cmdr.squadronpower = configuration.SquadronPower;
-                            Cmdr.squadronfaction = configuration.SquadronFaction;
-                        }
+                        // Stop if the commander returned from the profile does not match our expected commander name
+                        if (!cmdrMatches) { return false; }
 
                         bool updatedCurrentStarSystem = false;
 

--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -165,6 +165,9 @@ namespace Eddi
         [JsonProperty("OverrideCulture")]
         public string OverrideCulture { get; set; }
 
+        [JsonProperty("CommanderName")]
+        public string CommanderName { get; set; }
+
         [JsonIgnore]
         private string dataPath;
 

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -123,7 +123,7 @@ namespace EddiJournalMonitor
 
                                     // Get station services data
                                     data.TryGetValue("StationServices", out object val);
-                                    List<string> stationservices = (val as List<object>)?.Cast<string>()?.ToList();
+                                    List<string> stationservices = (val as List<object>)?.Cast<string>()?.ToList() ?? new List<string>();
                                     List<StationService> stationServices = new List<StationService>();
                                     foreach (string service in stationservices)
                                     {
@@ -132,7 +132,7 @@ namespace EddiJournalMonitor
 
                                     // Get station economies and their shares
                                     data.TryGetValue("StationEconomies", out object val2);
-                                    List<object> economies = val2 as List<object>;
+                                    List<object> economies = val2 as List<object> ?? new List<object>();
                                     List<EconomyShare> Economies = new List<EconomyShare>();
                                     foreach (Dictionary<string, object> economyshare in economies)
                                     {
@@ -3280,7 +3280,7 @@ namespace EddiJournalMonitor
                                     List<CargoInfo> inventory = new List<CargoInfo>();
 
                                     string vessel = JsonParsing.getString(data, "Vessel") ?? EDDI.Instance?.Vehicle;
-                                    int cargocarried = JsonParsing.getInt(data, "Count");
+                                    int cargocarried = JsonParsing.getOptionalInt(data, "Count") ?? 0;
                                     data.TryGetValue("Inventory", out object val);
                                     if (val != null)
                                     {

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using EddiDataDefinitions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
@@ -302,6 +303,104 @@ namespace UnitTests
             Assert.AreEqual("Interstellar Factors Contact", journal.invariantName);
             Assert.AreEqual(journal.edname, edsm.edname);
             Assert.AreEqual(journal.invariantName, edsm.invariantName);
+        }
+
+        [TestMethod]
+        public void FrontierApiCmdrTest()
+        {
+            Commander commander = new Commander()
+            {
+                name = "Marty McFly",
+                title = "Serf",
+                combatrating = CombatRating.FromRank(3),
+                traderating = TradeRating.FromRank(3),
+                explorationrating = ExplorationRating.FromRank(2),
+                cqcrating = CQCRating.FromRank(2),
+                empirerating = EmpireRating.FromRank(2),
+                federationrating = FederationRating.FromRank(1),
+                crimerating = 0,
+                servicerating = 0,
+                powerrating = 2,
+                credits = 0,
+                debt = 0
+            };
+            FrontierApiCommander frontierApiCommander = new FrontierApiCommander()
+            {
+                name = "Marty McFly",
+                combatrating = CombatRating.FromRank(3),
+                traderating = TradeRating.FromRank(2),
+                explorationrating = ExplorationRating.FromRank(2),
+                cqcrating = CQCRating.FromRank(2),
+                empirerating = EmpireRating.FromRank(4),
+                federationrating = FederationRating.FromRank(2),
+                crimerating = 2,
+                servicerating = 2,
+                powerrating = 3,
+                credits = 246486105,
+                debt = 24684
+            };
+            FrontierApiCommander frontierApiCommander2 = new FrontierApiCommander()
+            {
+                name = "Doc Brown",
+                combatrating = CombatRating.FromRank(0),
+                traderating = TradeRating.FromRank(6),
+                explorationrating = ExplorationRating.FromRank(7),
+                cqcrating = CQCRating.FromRank(0),
+                empirerating = EmpireRating.FromRank(1),
+                federationrating = FederationRating.FromRank(2),
+                crimerating = 1,
+                servicerating = 1,
+                powerrating = 7,
+                credits = 189687,
+                debt = 0
+            };
+
+            DateTime apiDateTime = DateTime.UtcNow;
+            DateTime journalDateTime = DateTime.UtcNow.AddHours(1);
+
+            Commander test1 = Commander.FromFrontierApiCmdr(commander, frontierApiCommander, apiDateTime, journalDateTime, out bool cmdr1Matches);
+            
+            Assert.IsTrue(cmdr1Matches);
+            Assert.AreEqual("Marty McFly", test1.name);
+            Assert.AreEqual("Serf", test1.title);
+            Assert.AreEqual(246486105, test1.credits);
+            Assert.AreEqual(24684, test1.debt);
+            Assert.AreEqual(2, test1.crimerating);
+            Assert.AreEqual(3, test1.combatrating.rank);
+            Assert.AreEqual(3, test1.traderating.rank);
+            Assert.AreEqual(2, test1.explorationrating.rank);
+            Assert.AreEqual(2, test1.cqcrating.rank);
+            Assert.AreEqual(4, test1.empirerating.rank);
+            Assert.AreEqual(2, test1.federationrating.rank);
+            Assert.AreEqual(2, test1.crimerating);
+            Assert.AreEqual(2, test1.servicerating);
+            // Since the journal timestamp is greater than the api timestamp, power rating is based off of the journal timestamp
+            Assert.AreEqual(2, test1.powerrating);
+
+            // Make the api timestamp fresher than the journal timestamp and re-check the power rating
+            apiDateTime = DateTime.UtcNow.AddHours(2);
+            Commander test2 = Commander.FromFrontierApiCmdr(commander, frontierApiCommander, apiDateTime, journalDateTime, out bool cmdr2Matches);
+            Assert.IsTrue(cmdr2Matches);
+            Assert.AreEqual(3, test2.powerrating);
+
+            // Test Frontier API commander details that do not match our base commander name
+            // The base commander properties should remain unchanged
+            Commander test3 = Commander.FromFrontierApiCmdr(commander, frontierApiCommander2, apiDateTime, journalDateTime, out bool cmdr3Matches);
+            Assert.IsFalse(cmdr3Matches);
+            Assert.AreEqual("Marty McFly", test3.name);
+            Assert.AreEqual("Serf", test3.title);
+            Assert.AreEqual(0, test3.credits);
+            Assert.AreEqual(0, test3.debt);
+            Assert.AreEqual(0, test3.crimerating);
+            Assert.AreEqual(3, test3.combatrating.rank);
+            Assert.AreEqual(3, test3.traderating.rank);
+            Assert.AreEqual(2, test3.explorationrating.rank);
+            Assert.AreEqual(2, test3.cqcrating.rank);
+            Assert.AreEqual(2, test3.empirerating.rank);
+            Assert.AreEqual(1, test3.federationrating.rank);
+            Assert.AreEqual(0, test3.crimerating);
+            Assert.AreEqual(0, test3.servicerating);
+            Assert.AreEqual(2, test3.powerrating);
         }
     }
 }

--- a/Utilities/ObjectExtensions.cs
+++ b/Utilities/ObjectExtensions.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.ArrayExtensions;
+
+namespace System
+{
+    // Source: https://github.com/Burtsev-Alexey/net-object-deep-copy
+
+    // Source code is released under the MIT license.
+    //
+    // The MIT License(MIT)
+    // Copyright(c) 2014 Burtsev Alexey
+    //
+    // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+    // associated documentation files (the "Software"), to deal in the Software without restriction, including
+    // without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    // sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject
+    // to the following conditions:
+    //
+    // The above copyright notice and this permission notice shall be included in all copies or substantial
+    // portions of the Software.
+    //
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    // LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    // IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    public static class ObjectExtensions
+    {
+        private static readonly MethodInfo CloneMethod = typeof(Object).GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static bool IsPrimitive(this Type type)
+        {
+            if (type == typeof(String)) return true;
+            return (type.IsValueType & type.IsPrimitive);
+        }
+
+        public static Object Copy(this Object originalObject)
+        {
+            return InternalCopy(originalObject, new Dictionary<Object, Object>(new ReferenceEqualityComparer()));
+        }
+        private static Object InternalCopy(Object originalObject, IDictionary<Object, Object> visited)
+        {
+            if (originalObject == null) return null;
+            var typeToReflect = originalObject.GetType();
+            if (IsPrimitive(typeToReflect)) return originalObject;
+            if (visited.ContainsKey(originalObject)) return visited[originalObject];
+            if (typeof(Delegate).IsAssignableFrom(typeToReflect)) return null;
+            var cloneObject = CloneMethod.Invoke(originalObject, null);
+            if (typeToReflect.IsArray)
+            {
+                var arrayType = typeToReflect.GetElementType();
+                if (IsPrimitive(arrayType) == false)
+                {
+                    Array clonedArray = (Array)cloneObject;
+                    clonedArray.ForEach((array, indices) => array.SetValue(InternalCopy(clonedArray.GetValue(indices), visited), indices));
+                }
+
+            }
+            visited.Add(originalObject, cloneObject);
+            CopyFields(originalObject, visited, cloneObject, typeToReflect);
+            RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect);
+            return cloneObject;
+        }
+
+        private static void RecursiveCopyBaseTypePrivateFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect)
+        {
+            if (typeToReflect.BaseType != null)
+            {
+                RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect.BaseType);
+                CopyFields(originalObject, visited, cloneObject, typeToReflect.BaseType, BindingFlags.Instance | BindingFlags.NonPublic, info => info.IsPrivate);
+            }
+        }
+
+        private static void CopyFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect, BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy, Func<FieldInfo, bool> filter = null)
+        {
+            foreach (FieldInfo fieldInfo in typeToReflect.GetFields(bindingFlags))
+            {
+                if (filter != null && filter(fieldInfo) == false) continue;
+                if (IsPrimitive(fieldInfo.FieldType)) continue;
+                var originalFieldValue = fieldInfo.GetValue(originalObject);
+                var clonedFieldValue = InternalCopy(originalFieldValue, visited);
+                fieldInfo.SetValue(cloneObject, clonedFieldValue);
+            }
+        }
+        public static T Copy<T>(this T original)
+        {
+            return (T)Copy((Object)original);
+        }
+    }
+
+    public class ReferenceEqualityComparer : EqualityComparer<Object>
+    {
+        public override bool Equals(object x, object y)
+        {
+            return ReferenceEquals(x, y);
+        }
+        public override int GetHashCode(object obj)
+        {
+            if (obj == null) return 0;
+            return obj.GetHashCode();
+        }
+    }
+
+    namespace ArrayExtensions
+    {
+        public static class ArrayExtensions
+        {
+            public static void ForEach(this Array array, Action<Array, int[]> action)
+            {
+                if (array.LongLength == 0) return;
+                ArrayTraverse walker = new ArrayTraverse(array);
+                do action(array, walker.Position);
+                while (walker.Step());
+            }
+        }
+
+        internal class ArrayTraverse
+        {
+            public int[] Position;
+            private int[] maxLengths;
+
+            public ArrayTraverse(Array array)
+            {
+                maxLengths = new int[array.Rank];
+                for (int i = 0; i < array.Rank; ++i)
+                {
+                    maxLengths[i] = array.GetLength(i) - 1;
+                }
+                Position = new int[array.Rank];
+            }
+
+            public bool Step()
+            {
+                for (int i = 0; i < Position.Length; ++i)
+                {
+                    if (Position[i] < maxLengths[i])
+                    {
+                        Position[i]++;
+                        for (int j = 0; j < i; j++)
+                        {
+                            Position[j] = 0;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -89,6 +89,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Probability.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="DataGridNumericColumn.cs" />


### PR DESCRIPTION
- Ensure that data added to the commander object isn't inadvertantly lost when the commander object is refreshed with Frontier API profile data.
- Clearly separate commander data affected by the Frontier API from commander data not affected by the Frontier API.
- Various code tidy ups