### PR TITLE
#1596 fix crash when EDSM down

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -19,24 +19,24 @@ namespace EddiCompanionAppService
     public class CompanionAppService : IDisposable
     {
         // Implementation instructions from Frontier: http://hosting.zaonce.net/docs/oauth2/instructions.html
-        private static string LIVE_SERVER = "https://companion.orerve.net";
-        private static string BETA_SERVER = "https://pts-companion.orerve.net";
-        private static string AUTH_SERVER = "https://auth.frontierstore.net";
-        private static string CALLBACK_URL = $"{Constants.EDDI_URL_PROTOCOL}://auth/";
-        private static string AUTH_URL = "/auth";
-        private static string DECODE_URL = "/decode";
-        private static string TOKEN_URL = "/token";
-        private static string AUDIENCE = "audience=steam,frontier";
-        private static string SCOPE = "scope=capi";
-        private static string PROFILE_URL = "/profile";
-        private static string MARKET_URL = "/market";
-        private static string SHIPYARD_URL = "/shipyard";
+        private static readonly string LIVE_SERVER = "https://companion.orerve.net";
+        private static readonly string BETA_SERVER = "https://pts-companion.orerve.net";
+        private static readonly string AUTH_SERVER = "https://auth.frontierstore.net";
+        private static readonly string CALLBACK_URL = $"{Constants.EDDI_URL_PROTOCOL}://auth/";
+        private static readonly string AUTH_URL = "/auth";
+        private static readonly string DECODE_URL = "/decode";
+        private static readonly string TOKEN_URL = "/token";
+        private static readonly string AUDIENCE = "audience=steam,frontier";
+        private static readonly string SCOPE = "scope=capi";
+        private static readonly string PROFILE_URL = "/profile";
+        private static readonly string MARKET_URL = "/market";
+        private static readonly string SHIPYARD_URL = "/shipyard";
 
         // We cache the profile to avoid spamming the service
         private Profile cachedProfile;
         private DateTime cachedProfileExpires;
 
-        private CustomURLResponder URLResponder;
+        private readonly CustomURLResponder URLResponder;
         private string verifier;
         private string authSessionID;
 
@@ -70,7 +70,7 @@ namespace EddiCompanionAppService
         public bool active => CurrentState == State.Authorized;
 
         private static CompanionAppService instance;
-        private string clientID; // we are not allowed to check the client ID into version control or publish it to 3rd parties
+        private readonly string clientID; // we are not allowed to check the client ID into version control or publish it to 3rd parties
 
         private static readonly object instanceLock = new object();
         public static CompanionAppService Instance

--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -34,6 +34,8 @@ namespace EddiDataProviderService
             if (systemNames == null || systemNames.Length == 0) { return null; }
 
             List<StarSystem> starSystems = edsmService.GetStarMapSystems(systemNames, showCoordinates, showSystemInformation);
+            if (starSystems == null) { return null; }
+
             List<StarSystem> fullStarSystems = new List<StarSystem>();
             foreach (string systemName in systemNames)
             {

--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -3,7 +3,10 @@
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
 ### 3.5.1-b1
-  * Added back some translation resources that had been overlooked.
+  * Core
+    * Added back some translation resources that had been overlooked.
+  * EDSM responder
+    * Fail gracefully when the EDSM server is temporarily unavailable.
 
 ### 3.5.0
   * Promote 3.5.0-rc1 to final

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -247,7 +247,7 @@ namespace EddiStarMapService
                 return response.logs;
             }
             Logging.Debug("No response received.");
-            throw new EDSMException();
+            throw new EDSMException("No response received."); // not for localization
         }
     }
 

--- a/Tests/VoiceAttackPluginTests.cs
+++ b/Tests/VoiceAttackPluginTests.cs
@@ -183,7 +183,7 @@ namespace UnitTests
 
             Assert.AreEqual(7, vaProxy.vaVars.FirstOrDefault(k => k.Key == "EDDI discovery scan totalbodies").Value);
             Assert.AreEqual(3, vaProxy.vaVars.FirstOrDefault(k => k.Key == "EDDI discovery scan nonbodies").Value);
-            Assert.AreEqual(44, vaProxy.vaVars.FirstOrDefault(k => k.Key == "EDDI discovery scan progress").Value);
+            Assert.AreEqual(44M, vaProxy.vaVars.FirstOrDefault(k => k.Key == "EDDI discovery scan progress").Value);
         }
     }
 }


### PR DESCRIPTION
1. Null-protect `DataProviderService.GetSystemsData()`.
2. Provide a message with the EDSMException for the UI to present.

This can be tested by renaming the SQL DB and changing the EDSM URL in StarMapService.cs to "https://example.com/".

Fixes #1596.