### PR TITLE
Fix shield state events not triggering

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1906,18 +1906,8 @@ namespace EddiJournalMonitor
                                 handled = true;
                                 break;
                             case "ShieldState":
-                                {
-                                    bool shieldsUp = JsonParsing.getBool(data, "ShieldsUp");
-                                    if (shieldsUp == true)
-                                    {
-                                        events.Add(new ShieldsUpEvent(timestamp) { raw = line, fromLoad = fromLogLoad });
-                                    }
-                                    else
-                                    {
-                                        events.Add(new ShieldsDownEvent(timestamp) { raw = line, fromLoad = fromLogLoad });
-                                    }
-                                }
-                                handled = true;
+                                // As of September 2019, this event no longer appears to be written to the Player Journal.
+                                // We still generate an event via the Status Monitor.
                                 break;
                             case "ShipTargeted":
                                 {

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -339,6 +339,19 @@ namespace EddiStatusMonitor
                 EDDI.Instance.Vehicle = thisStatus.vehicle;
 
                 // Trigger events for changed status, as applicable
+                if (thisStatus.shields_up != lastStatus.shields_up && thisStatus.vehicle == lastStatus.vehicle)
+                {
+                    // React to changes in shield state.
+                    // We check the vehicle to make sure that events aren't generated when we switch vehicles, start the game, or stop the game.
+                    if (thisStatus.shields_up)
+                    {
+                        EDDI.Instance.enqueueEvent(new ShieldsUpEvent(thisStatus.timestamp));
+                    }
+                    else
+                    {
+                        EDDI.Instance.enqueueEvent(new ShieldsDownEvent(thisStatus.timestamp));
+                    }
+                }
                 if (thisStatus.srv_turret_deployed != lastStatus.srv_turret_deployed)
                 {
                     EDDI.Instance.enqueueEvent(new SRVTurretEvent(thisStatus.timestamp, thisStatus.srv_turret_deployed));


### PR DESCRIPTION
Fix #1604 by converting shield state events to be generated via the Status Monitor.