### PR TITLE
Feature/edsmtimeout

### DIFF
--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -163,7 +163,7 @@ namespace EddiDataProviderService
         public StarSystem GetOrFetchStarSystem(string name, bool fetchIfMissing = true, bool refreshIfOutdated = true)
         {
             if (name == string.Empty) { return null; }
-            return GetOrFetchStarSystems(new[] { name }, fetchIfMissing, refreshIfOutdated).FirstOrDefault();
+            return GetOrFetchStarSystems(new[] { name }, fetchIfMissing, refreshIfOutdated)?.FirstOrDefault();
         }
 
         public List<StarSystem> GetOrFetchStarSystems(string[] names, bool fetchIfMissing = true, bool refreshIfOutdated = true)
@@ -171,6 +171,7 @@ namespace EddiDataProviderService
             if (!names.Any()) { return null; }
 
             List<StarSystem> systems = GetStarSystems(names, refreshIfOutdated);
+            if (systems == null) { return null; }
 
             // If a system isn't found after we've read our local database, we need to fetch it.
             List<string> fetchSystems = new List<string>();
@@ -272,6 +273,7 @@ namespace EddiDataProviderService
             if (systemsToUpdate.Count > 0)
             {
                 List<StarSystem> updatedSystems = dataProviderService.GetSystemsData(systemsToUpdate.Select(s => s.Key).ToArray());
+                if (updatedSystems == null) { return null; }
 
                 // If the newly fetched star system is an empty object except (for the object name), reject it
                 // Return old results when new results have been rejected

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -38,7 +38,10 @@ namespace EddiStarMapService
 
             public EdsmRestClient(string baseUrl)
             {
-                restClient = new RestClient(baseUrl);
+                restClient = new RestClient(baseUrl)
+                {
+                    Timeout = 10000, // milliseconds
+                };
             }
 
             public Uri BuildUri(IRestRequest request) => restClient.BuildUri(request);

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -22,6 +22,9 @@ namespace EddiStarMapService
         // Set the maximum batch size we will use for syncing before we write systems to our sql database
         public const int syncBatchSize = 50;
 
+        // The default timeout for requests to EDSM. Requests can override this by setting `RestRequest.Timeout`. Both are in milliseconds.
+        private const int DefaultTimeoutMilliseconds = 10000;
+
         public static string commanderFrontierApiName { get; set; }
 
         private string commanderName { get; set; }
@@ -40,7 +43,7 @@ namespace EddiStarMapService
             {
                 restClient = new RestClient(baseUrl)
                 {
-                    Timeout = 10000, // milliseconds
+                    Timeout = DefaultTimeoutMilliseconds
                 };
             }
 


### PR DESCRIPTION
Default to a 10 second timeout for EDSM API calls, and handle null responses in case of timeout.

Stops the UI event loop blocking forever when the EDSM servers are having a bad time.

RestRequests can opt for a longer timeout by setting `RestRequest.Timeout`.
