### PR TITLE
Fix `Sagittarius A*` pronunciation in Cereproc voices

### DIFF
--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -50,7 +50,7 @@ namespace EddiSpeechService
         private static readonly Dictionary<string, string> STAR_SYSTEM_FIXES = new Dictionary<string, string>()
         {
             { "VESPER-M4", "Vesper M 4" }, // Stop Vesper being treated as a sector
-            { "Sagittarius A*", "Sagittarius A- Star" }, // Allow the * to be parsed out
+            { "Sagittarius A*", "Sagittarius " + sayAsLettersOrNumbers("A") + " Star" }, // Allow the * to be parsed out
         };
 
         // Fixes to avoid issues with pronunciation of station model names


### PR DESCRIPTION
Fix `Sagittarius A*` being pronounced `Sagittarius A minus star` rather than `Sagittarius A star` in some Cereproc voices.

Replaces https://github.com/EDCD/EDDI/commit/a225c4035bec38aa166166b09c2cc2bfcf20abb0 from PR #1606.