### PR TITLE
Improve backwards compatibility of ship phonetic name

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -118,6 +118,7 @@ namespace EddiDataDefinitions
         [JsonIgnore]
         private string _phoneticName;
         /// <summary>the phonetic name of this ship</summary>
+        [JsonProperty("phoneticname")]
         public string phoneticName
         {
             get { return _phoneticName; }
@@ -127,7 +128,7 @@ namespace EddiDataDefinitions
                 {
                     _phoneticName = null;
                 }
-                else
+                else if (IPA.IsValid(value))
                 {
                     NotifyPropertyChanged("phoneticName");
                     _phoneticName = value;
@@ -136,6 +137,7 @@ namespace EddiDataDefinitions
         }
 
         /// <summary>The ship's spoken name (rendered using ssml and IPA)</summary>
+        [JsonIgnore]
         public string phoneticname => SpokenName();
 
         // The type of mission


### PR DESCRIPTION
Add `[JsonProperty("phoneticname")]` to maximize backwards compatibility with prior EDDI versions which used property name "phoneticname" rather than "phoneticName".
(Note that the prior change unfortunately removed ship monitor IPA settings for users that updated their shipyard under 3.5.1)