### PR TITLE
Fix `Engineer progressed` reporting rank but not stage when an engineer is unlocked.

### DIFF
--- a/DataDefinitions/Engineer.cs
+++ b/DataDefinitions/Engineer.cs
@@ -90,15 +90,13 @@ namespace EddiDataDefinitions
 
         public static void AddOrUpdate(Engineer engineer)
         {
-            Engineer result = Engineer.FromNameOrId(engineer.name, engineer.id);
-            if (result == null)
+            int index = ENGINEERS.FindIndex(candidate => candidate.id == engineer.id);
+            if (index != -1)
             {
-                ENGINEERS.Add(engineer);
+                ENGINEERS[index] = engineer;
             }
             else
             {
-                Engineer oldEngineer = ENGINEERS.FirstOrDefault(eng => eng.id == engineer.id);
-                if (oldEngineer != null) { ENGINEERS.Remove(oldEngineer); }
                 ENGINEERS.Add(engineer);
             }
         }

--- a/DataDefinitions/Engineer.cs
+++ b/DataDefinitions/Engineer.cs
@@ -97,8 +97,8 @@ namespace EddiDataDefinitions
             }
             else
             {
-                int? index = ENGINEERS.FindIndex(eng => eng.id == engineer.id);
-                if (index != null) { ENGINEERS.RemoveAt((int)index); }
+                Engineer oldEngineer = ENGINEERS.FirstOrDefault(eng => eng.id == engineer.id);
+                if (oldEngineer != null) { ENGINEERS.Remove(oldEngineer); }
                 ENGINEERS.Add(engineer);
             }
         }

--- a/Events/EngineerProgressedEvent.cs
+++ b/Events/EngineerProgressedEvent.cs
@@ -17,7 +17,7 @@ namespace EddiEvents
             VARIABLES.Add("engineer", "The name of the engineer with whom you have progressed");
             VARIABLES.Add("rank", "The rank of your relationship with the engineer");
             VARIABLES.Add("stage", "The current stage of your relations with the engineer (Invited/Known/Unlocked/Barred)");
-            VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer");
+            // VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer"); // "rankprogress" is omitted as it has never been written to the player journal.
             VARIABLES.Add("progresstype", "The type of progress that is applicable (Rank/Stage)");
         }
 

--- a/Events/EngineerProgressedEvent.cs
+++ b/Events/EngineerProgressedEvent.cs
@@ -17,7 +17,7 @@ namespace EddiEvents
             VARIABLES.Add("engineer", "The name of the engineer with whom you have progressed");
             VARIABLES.Add("rank", "The rank of your relationship with the engineer");
             VARIABLES.Add("stage", "The current stage of your relations with the engineer (Invited/Known/Unlocked/Barred)");
-            // VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer"); // "rankprogress" is omitted as it has never been written to the player journal.
+            VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer (only written at startup)");
             VARIABLES.Add("progresstype", "The type of progress that is applicable (Rank/Stage)");
         }
 

--- a/Events/EngineerProgressedEvent.cs
+++ b/Events/EngineerProgressedEvent.cs
@@ -7,18 +7,18 @@ namespace EddiEvents
     public class EngineerProgressedEvent : Event
     {
         public const string NAME = "Engineer progressed";
-        public const string DESCRIPTION = "Triggered when you reach a new rank with an engineer";
+        public const string DESCRIPTION = "Triggered at startup and when you reach a new rank with an engineer";
         public const string SAMPLE = @"{ ""timestamp"":""2018-01-16T09:34:36Z"", ""event"":""EngineerProgress"", ""Engineer"":""Zacariah Nemo"", ""EngineerID"":300050, ""Rank"":4, ""RankProgress"":0 }";
 
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
         static EngineerProgressedEvent()
         {
-            VARIABLES.Add("engineer", "The name of the engineer with whom you have progressed");
-            VARIABLES.Add("rank", "The rank of your relationship with the engineer");
-            VARIABLES.Add("stage", "The current stage of your relations with the engineer (Invited/Known/Unlocked/Barred)");
-            VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer (only written at startup)");
-            VARIABLES.Add("progresstype", "The type of progress that is applicable (Rank/Stage)");
+            VARIABLES.Add("engineer", "The name of the engineer with whom you have progressed (not written at startup)");
+            VARIABLES.Add("rank", "The rank of your relationship with the engineer (not written at startup)");
+            VARIABLES.Add("stage", "The current stage of your relations with the engineer (Invited/Known/Unlocked/Barred) (not written at startup)");
+            // VARIABLES.Add("rankprogress", "The percentage towards your next rank with the engineer"); // Omitted, only written at startup and for an array of engineers rather than for a single engineer.
+            VARIABLES.Add("progresstype", "The type of progress that is applicable (Rank/Stage) (not written at startup)");
         }
 
         public string engineer => Engineer?.name;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2246,7 +2246,6 @@ namespace EddiJournalMonitor
                                     string ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip().model;
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
-                                    
                                     List<CommodityAmount> commodities = new List<CommodityAmount>();
                                     List<MaterialAmount> materials = new List<MaterialAmount>();
                                     if (data.TryGetValue("Ingredients", out val))

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2246,22 +2246,7 @@ namespace EddiJournalMonitor
                                     string ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip().model;
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
-
-                                    // Our progress with this engineer may have changed. Fire off any appropriate `EngineerProgress` events.
-                                    Engineer Engineer = Engineer.FromNameOrId(engineer, engineerId);
-                                    if (Engineer is null)
-                                    {
-                                        Engineer = new Engineer(engineer, engineerId, "Unlocked", null, null);
-                                        Engineer.AddOrUpdate(Engineer);
-                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
-                                    }
-                                    if (level > Engineer.rank)
-                                    {
-                                        Engineer.rank = level;
-                                        Engineer.AddOrUpdate(Engineer);
-                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
-                                    }
-
+                                    
                                     List<CommodityAmount> commodities = new List<CommodityAmount>();
                                     List<MaterialAmount> materials = new List<MaterialAmount>();
                                     if (data.TryGetValue("Ingredients", out val))

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2247,6 +2247,15 @@ namespace EddiJournalMonitor
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
 
+                                    // Our rank with this engineer may have changed. Fire an `EngineerProgress` event if appropriate.
+                                    Engineer Engineer = Engineer.FromNameOrId(engineer, engineerId);
+                                    if (Engineer != null && level > Engineer.rank)
+                                    {
+                                        Engineer.rank = level;
+                                        Engineer.AddOrUpdate(Engineer);
+                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
+                                    }
+
                                     List<CommodityAmount> commodities = new List<CommodityAmount>();
                                     List<MaterialAmount> materials = new List<MaterialAmount>();
                                     if (data.TryGetValue("Ingredients", out val))

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2255,6 +2255,13 @@ namespace EddiJournalMonitor
                                         Engineer.AddOrUpdate(Engineer);
                                         events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
                                     }
+                                    else if (Engineer is null)
+                                    {
+                                        Engineer = new Engineer(engineer, engineerId, "Unlocked", null, level);
+                                        Engineer.AddOrUpdate(Engineer);
+                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
+                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
+                                    }
 
                                     List<CommodityAmount> commodities = new List<CommodityAmount>();
                                     List<MaterialAmount> materials = new List<MaterialAmount>();

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2249,17 +2249,16 @@ namespace EddiJournalMonitor
 
                                     // Our rank with this engineer may have changed. Fire an `EngineerProgress` event if appropriate.
                                     Engineer Engineer = Engineer.FromNameOrId(engineer, engineerId);
-                                    if (Engineer != null && level > Engineer.rank)
+                                    if (Engineer is null)
+                                    {
+                                        Engineer = new Engineer(engineer, engineerId, "Unlocked", null, null);
+                                        Engineer.AddOrUpdate(Engineer);
+                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
+                                    }
+                                    if (level > Engineer.rank)
                                     {
                                         Engineer.rank = level;
                                         Engineer.AddOrUpdate(Engineer);
-                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
-                                    }
-                                    else if (Engineer is null)
-                                    {
-                                        Engineer = new Engineer(engineer, engineerId, "Unlocked", null, level);
-                                        Engineer.AddOrUpdate(Engineer);
-                                        events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
                                         events.Add(new EngineerProgressedEvent(timestamp, Engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
                                     }
 

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2305,13 +2305,13 @@ namespace EddiJournalMonitor
                                         // This is a progress entry.
                                         Engineer engineer = parseEngineer(data);
                                         Engineer lastEngineer = Engineer.FromNameOrId(engineer.name, engineer.id);
+                                        if (engineer.stage != null && engineer.stage != lastEngineer?.stage)
+                                        {
+                                            events.Add(new EngineerProgressedEvent(timestamp, engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
+                                        }
                                         if (engineer.rank != null && engineer.rank != lastEngineer?.rank)
                                         {
                                             events.Add(new EngineerProgressedEvent(timestamp, engineer, "Rank") { raw = line, fromLoad = fromLogLoad });
-                                        }
-                                        else if (engineer.stage != null && engineer.stage != lastEngineer?.stage)
-                                        {
-                                            events.Add(new EngineerProgressedEvent(timestamp, engineer, "Stage") { raw = line, fromLoad = fromLogLoad });
                                         }
                                         Engineer.AddOrUpdate(engineer);
                                     }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2247,7 +2247,7 @@ namespace EddiJournalMonitor
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
 
-                                    // Our rank with this engineer may have changed. Fire an `EngineerProgress` event if appropriate.
+                                    // Our progress with this engineer may have changed. Fire off any appropriate `EngineerProgress` events.
                                     Engineer Engineer = Engineer.FromNameOrId(engineer, engineerId);
                                     if (Engineer is null)
                                     {


### PR DESCRIPTION
Fixes #1629
We currently look for a change in rank first then we look for a change in stage if the rank is unchanged. We ought to change that so that we look for changes in stage and changes in rank separately (so that each can trigger separately when appropriate).
Also tweaks variable descriptions for `EngineerProgressedEvent` and deprecates unused property `rankprogress`.

Note that this does not resolve a second issue identified by #1629. No journal event is written for rank progression after rank 1. It is only recorded in the `EngineerCraft` journal events (which are not timely for EDDI to use in a script).