### PR TITLE
Fix docs to remove reference to `Missions route` script

### DIFF
--- a/SpeechResponder/Help.md
+++ b/SpeechResponder/Help.md
@@ -391,7 +391,7 @@ This function will produce a destination/route for valid mission destinations, d
   * `update` Update to the next mission route destination, once all 
 missions in current system are completed.
 
-Upon success of the query, a 'Missions route' event is triggered, providing a following event data:
+Upon success of the query, a 'Route details' event is triggered, providing a following event data:
 
   * `routetype` Type of route query (see above).
   * `destination` Destination system.


### PR DESCRIPTION
Fix an incorrect reference to a `Missions route` script in the wiki / help.md. Should be referencing the `Route details` script.