### PR TITLE
Fix `Ship sold` script for local ship sales

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1051,7 +1051,7 @@ namespace EddiJournalMonitor
                                     string ship = JsonParsing.getString(data, "ShipType");
                                     data.TryGetValue("ShipPrice", out val);
                                     long price = (long)val;
-                                    string system = JsonParsing.getString(data, "System");
+                                    string system = JsonParsing.getString(data, "System"); // Only written when the ship is in a different star system
                                     events.Add(new ShipSoldEvent(timestamp, ship, shipId, price, system, marketId) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -1842,7 +1842,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system != system.name:\r\n   in {event.system}\r\n}",
+      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system && event.system != system.name:\r\n   in {event.system}\r\n}",
       "default": true,
       "name": "Ship sold",
       "description": "Triggered when you sell a ship"

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -1842,7 +1842,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system != system.name:\r\n   in {event.system}\r\n}",
+      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system && event.system != system.name:\r\n   in {event.system}\r\n}",
       "default": true,
       "name": "Ship sold",
       "description": "Triggered when you sell a ship"

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -1842,7 +1842,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system != system.name:\r\n   in {event.system}\r\n}",
+      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system && event.system != system.name:\r\n   in {event.system}\r\n}",
       "default": true,
       "name": "Ship sold",
       "description": "Triggered when you sell a ship"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1841,7 +1841,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system != system.name:\r\n   in {event.system}\r\n}",
+      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system && event.system != system.name:\r\n   in {event.system}\r\n}",
       "default": true,
       "name": "Ship sold",
       "description": "Triggered when you sell a ship"

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -1842,7 +1842,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system != system.name:\r\n   in {event.system}\r\n}",
+      "script": "{OneOf(\"Retired {ShipName(event.shipid, event.ship)} from active duty\",\r\n             \"Decommissioned {ShipName(event.shipid, event.ship)}\",\r\n             \"Sold {ShipName(event.shipid, event.ship)}\",)}\r\n\r\n{if event.system && event.system != system.name:\r\n   in {event.system}\r\n}",
       "default": true,
       "name": "Ship sold",
       "description": "Triggered when you sell a ship"


### PR DESCRIPTION
Checks `event.system` for null (the system is not written to the player journal when we are in the same system as the ship being sold).
Fixes the script unexpectedly ending in "in ____." when event.system is null and system.name is not.