### PR TITLE
Engage the ssml function `SayAsLettersOrNumbers` to render spacialised text when ssml is enabled.

### DIFF
--- a/SpeechResponder/Help.md
+++ b/SpeechResponder/Help.md
@@ -475,9 +475,9 @@ If you have not set up a name for your ship it will just return "your ship".
 
 ### Spacialise()
 
-This function will add spaces between letters in a string & convert to uppercase, in order to allow letters in a string to be pronounced individually.
+This function will allow letters and numbers in a string to be pronounced individually. If SSML is enabled, this function will render the text using SSML. If not, it will add spaces between letters in a string & convert to uppercase to assist the voice with achieving the proper pronunciation. 
 
-Spacialise() takes one argument: the number to Spacialise.
+Spacialise() takes one argument: the string of characters to Spacialise.
 
 Common usage of this is to provide a more human-sounding reading of a string of letters that are not a part of known word:
 

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -162,6 +162,7 @@ namespace EddiSpeechResponder
 
             // TODO fetch this from configuration
             bool useICAO = SpeechServiceConfiguration.FromFile().EnableIcao;
+            bool useSSML = !SpeechServiceConfiguration.FromFile().DisableSsml;
 
             // Function to call another script
             store["F"] = new NativeFunction((values) =>
@@ -286,16 +287,24 @@ namespace EddiSpeechResponder
 
             store["Spacialise"] = new NativeFunction((values) =>
             {
-                string Entree = values[0].AsString;
-                if (Entree == "")
-                { return ""; }
-                string Sortie = "";
-                foreach (char c in Entree)
+
+                if (useSSML)
                 {
-                    Sortie = Sortie + c + " ";
+                    return Translations.sayAsLettersOrNumbers(values[0].AsString);
                 }
-                var UpperSortie = Sortie.ToUpper();
-                return UpperSortie.Trim();
+                else
+                {
+                    string Entree = values[0].AsString;
+                    if (Entree == "")
+                    { return ""; }
+                    string Sortie = "";
+                    foreach (char c in Entree)
+                    {
+                        Sortie = Sortie + c + " ";
+                    }
+                    var UpperSortie = Sortie.ToUpper();
+                    return UpperSortie.Trim();
+                }
             }, 1);
 
             store["Emphasize"] = new NativeFunction((values) =>

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -646,7 +646,7 @@ namespace EddiSpeechService
             return String.Join(" ", elements).Trim();
         }
 
-        private static string sayAsLettersOrNumbers(string part)
+        public static string sayAsLettersOrNumbers(string part)
         {
             if (int.TryParse(part, out _))
             {
@@ -769,7 +769,7 @@ namespace EddiSpeechService
                         return Properties.Phrases.nearly + " " + minus + (number + 1) + order;
                 }
             }
-            // Describe (less precisely) decimal values for more complex numbers
+            // Describe (less precisely) decimal values for more complex numbers    
             else
             {
                 if (nextDigit < 2)


### PR DESCRIPTION
Corrects `Star class is {event.stellarclass}.` with some voices (particularly, MS Hazel).