### PR TITLE
Add static context menus in XAML to Cottle views

### DIFF
--- a/SpeechResponder/EditScriptWindow.xaml
+++ b/SpeechResponder/EditScriptWindow.xaml
@@ -112,7 +112,22 @@
                                    WordWrap="True"
                                    ShowLineNumbers="True"
                                    SyntaxHighlighting="Cottle"
-                                   />
+                                   >
+                <avalonEdit:TextEditor.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Command="ApplicationCommands.Undo"/>
+                        <MenuItem Command="ApplicationCommands.Redo"/>
+                        <Separator/>
+                        <MenuItem Command="ApplicationCommands.Cut"/>
+                        <MenuItem Command="ApplicationCommands.Copy"/>
+                        <MenuItem Command="ApplicationCommands.Paste"/>
+                        <MenuItem Command="ApplicationCommands.Delete"/>
+                        <MenuItem Header="{x:Static resx:Tooltips.delete_line_no_shortcut}" Command="avalonEdit:AvalonEditCommands.DeleteLine"/>
+                        <Separator/>
+                        <MenuItem Command="ApplicationCommands.Find"/>
+                    </ContextMenu>
+                </avalonEdit:TextEditor.ContextMenu>
+            </avalonEdit:TextEditor>
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Rows="1" Columns="3" Width="770" Margin="0,0,0,10" HorizontalAlignment="Center">
                 <Button x:Name="testButton" FontSize="18" Content="{x:Static resx:SpeechResponder.test_script_button}" VerticalAlignment="Top" Click="testButtonClick" Margin="0,0,5,0"/>
                 <Button x:Name="resetToDefaultButton" FontSize="18" Content="{x:Static resx:SpeechResponder.reset_script_button}" VerticalAlignment="Top" Click="resetButtonClick" Margin="5,0,5,0"/>

--- a/SpeechResponder/Properties/Tooltips.Designer.cs
+++ b/SpeechResponder/Properties/Tooltips.Designer.cs
@@ -97,6 +97,15 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete Line.
+        /// </summary>
+        public static string delete_line_no_shortcut {
+            get {
+                return ResourceManager.GetString("delete_line_no_shortcut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Find (Ctrl+F).
         /// </summary>
         public static string find {

--- a/SpeechResponder/Properties/Tooltips.resx
+++ b/SpeechResponder/Properties/Tooltips.resx
@@ -129,6 +129,9 @@
   <data name="delete_line" xml:space="preserve">
     <value>Delete Line (Ctrl+D)</value>
   </data>
+  <data name="delete_line_no_shortcut" xml:space="preserve">
+    <value>Delete Line</value>
+  </data>
   <data name="find" xml:space="preserve">
     <value>Find (Ctrl+F)</value>
   </data>

--- a/SpeechResponder/ShowDiffWindow.xaml
+++ b/SpeechResponder/ShowDiffWindow.xaml
@@ -19,5 +19,11 @@
                            WordWrap="True"
                            ShowLineNumbers="False"
                            SyntaxHighlighting="Cottle"
-                           />
+                           >
+        <avalonEdit:TextEditor.ContextMenu>
+            <ContextMenu>
+                <MenuItem Command="ApplicationCommands.Copy"/>
+            </ContextMenu>
+        </avalonEdit:TextEditor.ContextMenu>
+    </avalonEdit:TextEditor>
 </Window>

--- a/SpeechResponder/ViewScriptWindow.xaml
+++ b/SpeechResponder/ViewScriptWindow.xaml
@@ -35,7 +35,13 @@
                 WordWrap="True"
                 ShowLineNumbers="True"
                 SyntaxHighlighting="Cottle"
-                />
+                >
+                <avalonEdit:TextEditor.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Command="ApplicationCommands.Copy"/>
+                    </ContextMenu>
+                </avalonEdit:TextEditor.ContextMenu>
+            </avalonEdit:TextEditor>
             <UniformGrid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Rows="1" Columns="1" Width="770" Margin="0,0,0,10" HorizontalAlignment="Center">
                 <Button x:Name="okButton" IsCancel="True" IsDefault="True" FontSize="18" Content="{x:Static resx:SpeechResponder.button_ok}" VerticalAlignment="Top" Click="okButtonClick" Margin="0,0,5,0"/>
             </UniformGrid>


### PR DESCRIPTION
My XAML-based alternative to #1645. 
Implements the ContextMenus in XAML rather than code-behind, which is generally easier to maintain, and I think it's probably more like what the WPF framework designers intended.