### PR TITLE
Spacialise(): Improve handling of complex strings

### DIFF
--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -287,6 +287,7 @@ namespace EddiSpeechResponder
 
             store["Spacialise"] = new NativeFunction((values) =>
             {
+                if (values[0].AsString == null) { return null; }
 
                 if (useSSML)
                 {

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -648,14 +648,24 @@ namespace EddiSpeechService
 
         public static string sayAsLettersOrNumbers(string part)
         {
-            if (int.TryParse(part, out _))
+            string result = null;
+            foreach (var c in part)
             {
-                return @"<say-as interpret-as=""number"">" + part + @"</say-as>";
+                var s = c.ToString();
+                if (new Regex(@"\d").IsMatch(s))
+                {
+                    result += @"<say-as interpret-as=""number"">" + s + @"</say-as>";
+                }
+                else if (new Regex(@"\w").IsMatch(s))
+                {
+                    result += @"<say-as interpret-as=""characters"">" + s + @"</say-as>";
+                }
+                else
+                {
+                    result += s;
+                }
             }
-            else
-            {
-                return @"<say-as interpret-as=""characters"">" + part + @"</say-as>";
-            }
+            return result;
         }
 
         public static string Humanize(decimal? value)

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -648,24 +648,24 @@ namespace EddiSpeechService
 
         public static string sayAsLettersOrNumbers(string part)
         {
-            string result = null;
+            StringBuilder sb = new StringBuilder();
             foreach (var c in part)
             {
                 var s = c.ToString();
                 if (new Regex(@"\d").IsMatch(s))
                 {
-                    result += @"<say-as interpret-as=""number"">" + s + @"</say-as>";
+                    sb.Append(@"<say-as interpret-as=""number"">" + s + @"</say-as>");
                 }
                 else if (new Regex(@"\w").IsMatch(s))
                 {
-                    result += @"<say-as interpret-as=""characters"">" + s + @"</say-as>";
+                    sb.Append(@"<say-as interpret-as=""characters"">" + s + @"</say-as>");
                 }
                 else
                 {
-                    result += s;
+                    sb.Append(s);
                 }
             }
-            return result;
+            return sb.ToString();
         }
 
         public static string Humanize(decimal? value)


### PR DESCRIPTION
Fixes #1657. Improves handling of complex strings with the `Spacialise()` function (and wherever else our `sayAsLettersOrNumbers` method is applied). Prevents "space" and other whitespace characters from being vocalized.