### PR TITLE
Feature/1661 add hardpoints event to status monitor

### DIFF
--- a/EDDI/ChangeLog.md
+++ b/EDDI/ChangeLog.md
@@ -2,6 +2,10 @@
 
 Full details of the variables available for each noted event, and VoiceAttack integrations, are available in the individual [event pages](https://github.com/EDCD/EDDI/wiki/Events).
 
+### 3.5.3
+  * Events
+    * Added new event `Hardpoints`, triggered when you deploy or retract your hardpoints.
+
 ### 3.5.2
   * Speech responder
     * UI

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -884,6 +884,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -885,7 +885,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -866,6 +866,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -867,7 +867,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -894,7 +894,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -893,6 +893,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 1,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -884,6 +884,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -885,7 +885,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -884,6 +884,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -885,7 +885,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.ja.json
+++ b/SpeechResponder/eddi.ja.json
@@ -866,6 +866,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.ja.json
+++ b/SpeechResponder/eddi.ja.json
@@ -867,7 +867,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -883,6 +883,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,
@@ -963,15 +972,6 @@
       "default": true,
       "name": "Killed",
       "description": "Triggered when you kill another player"
-    },
-    "Hardpoints": {
-	  "enabled": true,
-      "priority": 3,
-      "responder": true,
-      "script": null,
-      "default": true,
-      "name": "Hardpoints",
-      "description": "Triggered when you deploy or retract your landing gear"
     },
     "Landing gear": {
       "enabled": true,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -884,7 +884,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -964,6 +964,15 @@
       "name": "Killed",
       "description": "Triggered when you kill another player"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Hardpoint",
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your landing gear"
+    },
     "Landing gear": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -968,7 +968,7 @@
 	  "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Hardpoint",
+      "script": null,
       "default": true,
       "name": "Hardpoints",
       "description": "Triggered when you deploy or retract your landing gear"

--- a/SpeechResponder/eddi.pt-BR.json
+++ b/SpeechResponder/eddi.pt-BR.json
@@ -1011,7 +1011,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/SpeechResponder/eddi.pt-BR.json
+++ b/SpeechResponder/eddi.pt-BR.json
@@ -1010,6 +1010,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -884,6 +884,15 @@
       "name": "Glide",
       "description": "Triggered when your ship enters or exits glide"
     },
+    "Hardpoints": {
+	  "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": null,
+      "default": true,
+      "name": "Hardpoints",
+      "description": "Triggered when you deploy or retract your hardpoints"
+    },
     "Heat damage": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -885,7 +885,7 @@
       "description": "Triggered when your ship enters or exits glide"
     },
     "Hardpoints": {
-	  "enabled": true,
+      "enabled": true,
       "priority": 3,
       "responder": true,
       "script": null,

--- a/StatusMonitor/EddiStatusMonitor.csproj
+++ b/StatusMonitor/EddiStatusMonitor.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShipCargoScoopEvent.cs" />
     <Compile Include="ShipFsdEvent.cs" />
+    <Compile Include="ShipHardpointsEvent.cs" />
     <Compile Include="ShipLandingGearEvent.cs" />
     <Compile Include="ShipLightsEvent.cs" />
     <Compile Include="ShipLowFuelEvent.cs" />

--- a/StatusMonitor/ShipHardpointsEvent.cs
+++ b/StatusMonitor/ShipHardpointsEvent.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class ShipHardpointsEvent : Event
+    {
+        public const string NAME = "Hardpoints";
+        public const string DESCRIPTION = "Triggered when you deploy or retract your hardpoints";
+        public const string SAMPLE = "null";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static ShipHardpointsEvent()
+        {
+            VARIABLES.Add("deployed", "A boolean value. True if you hardpoints are deployed.");
+        }
+
+        [JsonProperty("deployed")]
+        public bool deployed { get; private set; }
+
+        public ShipHardpointsEvent(DateTime timestamp, bool deployed) : base(timestamp, NAME)
+        {
+            this.deployed = deployed;
+        }
+    }
+}

--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -415,6 +415,10 @@ namespace EddiStatusMonitor
                 {
                     EDDI.Instance.enqueueEvent(new ShipLightsEvent(thisStatus.timestamp, thisStatus.lights_on));
                 }
+                if (thisStatus.hardpoints_deployed != lastStatus.hardpoints_deployed)
+                {
+                    EDDI.Instance.enqueueEvent(new ShipHardpointsEvent(thisStatus.timestamp, thisStatus.hardpoints_deployed));
+                }
                 if (gliding && thisStatus.fsd_status == "cooldown")
                 {
                     gliding = false;


### PR DESCRIPTION
This PR adds a new event to the `StatusMonitor` which is triggered when the ship's hardpoints are deployed or retracted. 

Resolves #1661.