### PR TITLE
Allow user to disable TTS voice effect based on used ship.

### DIFF
--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -287,12 +287,13 @@
                             <RowDefinition Height="auto" />
                             <RowDefinition Height="auto" />
                             <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
                         </Grid.RowDefinitions>
                         <Label x:Name="ttsVoiceLabel" Grid.Column="0" Grid.Row="0" Margin="0, 5" VerticalContentAlignment="Center" Content="{x:Static resx:MainWindow.tab_tts_voice_label}" />
                         <ComboBox x:Name="ttsVoiceDropDown" Grid.Column="1" Grid.Row="0" Margin="5" VerticalContentAlignment="Center" SelectionChanged="ttsVoiceDropDownUpdated"/>
                         <Label x:Name="ttsVolumeLabel" Grid.Column="0" Grid.Row="1" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_volume_label}" />
                         <DockPanel LastChildFill="True" Grid.Column="1" Grid.Row="1" Margin="5" VerticalAlignment="Center">
-                            <TextBox x:Name="ttsVolumeText"  DockPanel.Dock="Right" Text="{Binding ElementName=ttsVolumeSlider, Path=Value, UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="40" Margin="5,0,0,0"/>
+                            <TextBox x:Name="ttsVolumeText"  DockPanel.Dock="Right" Text="{Binding ElementName=ttsVolumeSlider, Path=Value, UpdateSourceTrigger=PropertyChanged}" TextAlignment="Right" Width="40"/>
                             <Slider x:Name="ttsVolumeSlider" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickFrequency="1" ValueChanged="ttsVolumeUpdated"/>
                         </DockPanel>
                         <Label x:Name="ttsRateLabel" Grid.Column="0" Grid.Row="2" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_rate_label}" />
@@ -307,22 +308,24 @@
                         </DockPanel>
                         <Label x:Name="ttsDistortLabel" Grid.Column="0" Grid.Row="4" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_distort_label}" />
                         <CheckBox x:Name="ttsDistortCheckbox" Grid.Column="1" Grid.Row="4" Margin="5" VerticalAlignment="Center" Checked="ttsDistortionLevelUpdated" Unchecked="ttsDistortionLevelUpdated"/>
-                        <TextBlock Grid.Column="0" Grid.Row="5" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_test_desc}" />
-                        <Label x:Name="ttsTestShipLabel" Grid.Column="0" Grid.Row="6" Margin="0, 5" VerticalContentAlignment="Center" Content="{x:Static resx:MainWindow.tab_tts_test_ship_label}" />
-                        <ComboBox x:Name="ttsTestShipDropDown" Grid.Column="1" Grid.Row="6" Margin="5" VerticalContentAlignment="Center"/>
-                        <UniformGrid Grid.Column="0" Grid.Row="7" Grid.ColumnSpan="2" Margin="5" Columns="2">
+                        <Label x:Name="ttsDisableVoiceEffectsLabel" Grid.Column="0" Grid.Row="5" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_disable_voice_effects_label}" />
+                        <CheckBox x:Name="ttsDisableVoiceEffectsCheckbox" Grid.Column="1" Grid.Row="5" Margin="5" VerticalAlignment="Center" Checked="ttsDisableVoiceEffectsUpdated" Unchecked="ttsDisableVoiceEffectsUpdated"/>
+                        <TextBlock Grid.Column="0" Grid.Row="6" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_test_desc}" />
+                        <Label x:Name="ttsTestShipLabel" Grid.Column="0" Grid.Row="7" Margin="0, 5" VerticalContentAlignment="Center" Content="{x:Static resx:MainWindow.tab_tts_test_ship_label}" />
+                        <ComboBox x:Name="ttsTestShipDropDown" Grid.Column="1" Grid.Row="7" Margin="5" VerticalContentAlignment="Center"/>
+                        <UniformGrid Grid.Column="0" Grid.Row="8" Grid.ColumnSpan="2" Margin="5" Columns="2">
                             <Button x:Name="ttsTestButton" Margin="0,0,5,0" Content="{x:Static resx:MainWindow.tab_tts_test_button}" Click="ttsTestVoiceButtonClicked" />
                             <Button x:Name="ttsTestDamagedButton" Margin="5,0,0,0" Content="{x:Static resx:MainWindow.tab_tts_test_damaged_button}" Click="ttsTestDamagedVoiceButtonClicked" />
                         </UniformGrid>
-                        <TextBlock Grid.Column="0" Grid.Row="8" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_phonetic_speech_desc}" />
-                        <Label x:Name="disableSsmltLabel" VerticalAlignment="Top" Grid.Column="0" Grid.Row="9" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_disable_phonetic_speech_label}" />
-                        <DockPanel Grid.Column="1" Grid.Row="9" Margin="0, 5">
+                        <TextBlock Grid.Column="0" Grid.Row="9" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_phonetic_speech_desc}" />
+                        <Label x:Name="disableSsmltLabel" VerticalAlignment="Top" Grid.Column="0" Grid.Row="10" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_disable_phonetic_speech_label}" />
+                        <DockPanel Grid.Column="1" Grid.Row="10" Margin="0, 5">
                             <CheckBox Grid.Column="1" x:Name="disableSsmlCheckbox" Margin="5" VerticalAlignment="Top" Checked="disableSsmlUpdated" Unchecked="disableSsmlUpdated"/>
                             <TextBlock Margin="5" HorizontalAlignment="Stretch" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_disable_phonetic_speech_note}" />
                         </DockPanel>
-                        <TextBlock Grid.Column="0" Grid.Row="10" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_icao_desc}" />
-                        <Label x:Name="enableIcaoLabel" Grid.Column="0" Grid.Row="11" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_icao_label}" />
-                        <CheckBox x:Name="enableIcaoCheckbox" Grid.Column="1" Grid.Row="11" Margin="5" VerticalAlignment="Center" Checked="enableICAOUpdated" Unchecked="enableICAOUpdated"/>
+                        <TextBlock Grid.Column="0" Grid.Row="11" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_icao_desc}" />
+                        <Label x:Name="enableIcaoLabel" Grid.Column="0" Grid.Row="12" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_icao_label}" RenderTransformOrigin="0.518,1.501" />
+                        <CheckBox x:Name="enableIcaoCheckbox" Grid.Column="1" Grid.Row="12" Margin="5" VerticalAlignment="Center" Checked="enableICAOUpdated" Unchecked="enableICAOUpdated"/>
                     </Grid>
                 </DockPanel>
             </TabItem>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -428,6 +428,7 @@ namespace Eddi
             ttsRateSlider.Value = speechServiceConfiguration.Rate;
             ttsEffectsLevelSlider.Value = speechServiceConfiguration.EffectsLevel;
             ttsDistortCheckbox.IsChecked = speechServiceConfiguration.DistortOnDamage;
+            ttsDisableVoiceEffectsCheckbox.IsChecked = speechServiceConfiguration.DisableVoiceEffects;
             disableSsmlCheckbox.IsChecked = speechServiceConfiguration.DisableSsml;
             enableIcaoCheckbox.IsChecked = speechServiceConfiguration.EnableIcao;
 
@@ -1022,6 +1023,11 @@ namespace Eddi
             ttsUpdated();
         }
 
+        private void ttsDisableVoiceEffectsUpdated(object sender, RoutedEventArgs e)
+        {
+            ttsUpdated();
+        }
+
         private void ttsRateUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             ttsUpdated();
@@ -1070,6 +1076,7 @@ namespace Eddi
                 Rate = (int)ttsRateSlider.Value,
                 EffectsLevel = (int)ttsEffectsLevelSlider.Value,
                 DistortOnDamage = ttsDistortCheckbox.IsChecked.Value,
+                DisableVoiceEffects = ttsDisableVoiceEffectsCheckbox.IsChecked.Value,
                 DisableSsml = disableSsmlCheckbox.IsChecked.Value,
                 EnableIcao = enableIcaoCheckbox.IsChecked.Value
             };

--- a/EDDI/Properties/MainWindow.Designer.cs
+++ b/EDDI/Properties/MainWindow.Designer.cs
@@ -412,6 +412,15 @@ namespace Eddi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disable ship effects on voice:.
+        /// </summary>
+        public static string tab_tts_disable_voice_effects_label {
+            get {
+                return ResourceManager.GetString("tab_tts_disable_voice_effects_label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Distort the voice on ship damage:.
         /// </summary>
         public static string tab_tts_distort_label {

--- a/EDDI/Properties/MainWindow.resx
+++ b/EDDI/Properties/MainWindow.resx
@@ -175,6 +175,9 @@
   <data name="tab_tts_distort_label" xml:space="preserve">
     <value>Distort the voice on ship damage:</value>
   </data>
+  <data name="tab_tts_disable_voice_effects_label" xml:space="preserve">
+    <value>Disable ship effects on voice:</value>
+  </data>
   <data name="tab_tts_header" xml:space="preserve">
     <value>Text-to-Speech</value>
   </data>

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -128,7 +128,7 @@ namespace EddiSpeechResponder
             subtitles = configuration.Subtitles;
             subtitlesOnly = configuration.SubtitlesOnly;
             Logging.Debug($"Reloaded {ResponderName()}");
-    }
+        }
 
         public void Handle(Event @event)
         {

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -227,7 +227,7 @@ namespace EddiSpeechService
                     stream.Seek(0, SeekOrigin.Begin);
 
                     IWaveSource source = new WaveFileReader(stream);
-                    if (!isAudio && !configuration.DisableVoiceEffects)
+                    if (!isAudio && (!configuration.DisableVoiceEffects || isRadio))
                     {
                         source = addEffectsToSource(source, chorusLevel, reverbLevel, echoDelay, distortionLevel, isRadio);
                     }

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -227,7 +227,7 @@ namespace EddiSpeechService
                     stream.Seek(0, SeekOrigin.Begin);
 
                     IWaveSource source = new WaveFileReader(stream);
-                    if (!isAudio)
+                    if (!isAudio && !configuration.DisableVoiceEffects)
                     {
                         source = addEffectsToSource(source, chorusLevel, reverbLevel, echoDelay, distortionLevel, isRadio);
                     }

--- a/SpeechService/SpeechServiceConfiguration.cs
+++ b/SpeechService/SpeechServiceConfiguration.cs
@@ -22,6 +22,9 @@ namespace EddiSpeechService
         [JsonProperty("distortOnDamage")]
         public bool DistortOnDamage { get; set; } = true;
 
+        [JsonProperty("disableVoiceEffects")]
+        public bool DisableVoiceEffects { get; set; } = false;
+
         [JsonProperty("rate")]
         public int Rate { get; set; } = 0;
 
@@ -83,6 +86,7 @@ namespace EddiSpeechService
             Volume = 100;
             EffectsLevel = 50;
             DistortOnDamage = true;
+            DisableVoiceEffects = false;
             DisableSsml = false;
             EnableIcao = false;
         }


### PR DESCRIPTION
In short, I don't like the TTS voice in EDDI and how it uses the type of ship to change the TTS voice.  You can put it to very low, but the difference is still noticeable. I also use a lot of TTS in VoiceAttack and want to divert all TTS to EDDI instead of VA TTS.  But then I get this changed TTS voice that I don't like. So added the option to disable it. The ship voice is enabled by default, so normal users will not notice anything until they disabled it.

- Added checkbox 'Disable ship effects on voice:' on the 'Text-to-speech' tab.
- English text only.
- The option is off by default (allow ship effects).

Tiny fix:
- Removed margin from Volume of speech slider, because when putting all sliders
  in the middle (50, 0, 50), volume of speech slider didn't align (and was a
  few pixels shorter next to the input box).