### PR TITLE
Hotfix/1659 environment vehicle data

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1294,14 +1294,21 @@ namespace Eddi
             }
             else if (theEvent.bodyname != null)
             {
-                Environment = Constants.ENVIRONMENT_NORMAL_SPACE;
-
                 // If we are not at a station then our station information is invalid 
                 CurrentStation = null;
 
                 // Update the body 
                 Logging.Debug("Now at body " + theEvent.bodyname);
                 updateCurrentStellarBody(theEvent.bodyname, theEvent.systemname, theEvent.systemAddress);
+
+                if (theEvent.latitude != null && theEvent.longitude != null)
+                {
+                    Environment = Constants.ENVIRONMENT_LANDED;
+                }
+                else
+                {
+                    Environment = Constants.ENVIRONMENT_NORMAL_SPACE;
+                }
             }
             else
             {
@@ -1841,6 +1848,16 @@ namespace Eddi
 
         private bool eventCommanderContinued(CommanderContinuedEvent theEvent)
         {
+            // Set Vehicle state from ship model
+            if (theEvent.ship == "SRV")
+            {
+                Vehicle = Constants.VEHICLE_SRV;
+            }
+            else
+            {
+                Vehicle = Constants.VEHICLE_SHIP;
+            }
+
             // If we see this it means that we aren't in CQC
             inCQC = false;
 

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1848,7 +1848,7 @@ namespace Eddi
 
         private bool eventCommanderContinued(CommanderContinuedEvent theEvent)
         {
-            // Set Vehicle state from ship model
+            // Set Vehicle state for commander from ship model
             if (theEvent.ship == "SRV")
             {
                 Vehicle = Constants.VEHICLE_SRV;
@@ -1856,6 +1856,16 @@ namespace Eddi
             else
             {
                 Vehicle = Constants.VEHICLE_SHIP;
+            }
+
+            // Set Environment state for the ship if 'startlanded' is present in the event
+            if (theEvent.startlanded ?? false)
+            {
+                Environment = Constants.ENVIRONMENT_LANDED;
+            }
+            else if (theEvent.startlanded != null)
+            {
+                Environment = Constants.ENVIRONMENT_NORMAL_SPACE;
             }
 
             // If we see this it means that we aren't in CQC

--- a/Events/CommanderContinuedEvent.cs
+++ b/Events/CommanderContinuedEvent.cs
@@ -79,7 +79,7 @@ namespace EddiEvents
             this.frontierID = frontierID;
             this.horizons = horizons;
             this.shipid = shipId;
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
+            this.ship = ship == "TestBuggy" ? "SRV" : ShipDefinitions.FromEDModel(ship).model;
             this.shipname = shipName;
             this.shipident = shipIdent;
             this.startlanded = startedLanded;


### PR DESCRIPTION
Added `Environment` and `Vehicle` setters to the `LoadGame` and `Location` event handlers to support property availability early in the startup process.