### PR TITLE
Fix xml escaping around Cereproc unique ssml tags

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -480,11 +480,15 @@ namespace EddiSpeechService
             result = Regex.Replace(result, "(<.+?src=\")(.:)(.*?" + @"\/>)", "$1" + "$2SSSSS" + "$3");
 
             // Our valid SSML elements are audio, break, emphasis, play, phoneme, & prosody so encode these differently for now
-            // Also escape any double quotes inside the elements
+            // Also escape any double quotes or single quotes inside the elements
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
             result = Regex.Replace(result, "<(audio.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(break.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(play.*?)>", "XXXXX$1YYYYY");
@@ -500,6 +504,13 @@ namespace EddiSpeechService
             result = Regex.Replace(result, "<(/voice)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(say-as.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(/say-as)>", "XXXXX$1YYYYY");
+
+            // Cereproc uses some additional custom SSML tags (documented in https://www.cereproc.com/files/CereVoiceCloudGuide.pdf)
+            result = Regex.Replace(result, "<(usel.*?)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "<(/usel)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "<(spurt.*?)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "<(/spurt)>", "XXXXX$1YYYYY");
+
             // Now escape anything that is still present
             result = SecurityElement.Escape(result);
 

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -471,7 +471,7 @@ namespace EddiSpeechService
             }
         }
 
-        private string escapeSsml(string text)
+        public static string escapeSsml(string text)
         {
             // Our input text might have SSML elements in it but the rest needs escaping
             string result = text;
@@ -485,14 +485,14 @@ namespace EddiSpeechService
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
             result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1ZZZZZ");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
             result = Regex.Replace(result, "<(audio.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(break.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(play.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(phoneme.*?)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "<(phoneme.*?)>", "XXXXX$1YYYYY");   
             result = Regex.Replace(result, "<(/phoneme)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(prosody.*?)>", "XXXXX$1YYYYY");
             result = Regex.Replace(result, "<(/prosody)>", "XXXXX$1YYYYY");
@@ -518,6 +518,7 @@ namespace EddiSpeechService
             result = Regex.Replace(result, "XXXXX", "<");
             result = Regex.Replace(result, "YYYYY", ">");
             result = Regex.Replace(result, "ZZZZZ", "\"");
+            result = Regex.Replace(result, "WWWWW", "\'");
             result = Regex.Replace(result, "SSSSS", @"\");
             return result;
         }

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -512,7 +512,7 @@ namespace EddiSpeechService
             result = Regex.Replace(result, "<(/spurt)>", "XXXXX$1YYYYY");
 
             // Now escape anything that is still present
-            result = SecurityElement.Escape(result);
+            result = SecurityElement.Escape(result) ?? "";
 
             // Put back the characters we hid
             result = Regex.Replace(result, "XXXXX", "<");

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -318,13 +318,6 @@ namespace SpeechTests
         }
 
         [TestMethod, TestCategory("Speech")]
-        public void TestSpeechServiceEscaping()
-        {
-            Logging.Verbose = true;
-            SpeechService.Instance.Say(null, "<phoneme alphabet=\"ipa\" ph=\"ʃɪnˈrɑːrtə\">Shinrarta</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈdezɦrə\">Dezhra</phoneme> & Co's shop");
-        }
-
-        [TestMethod, TestCategory("Speech")]
         public void TestSpeechServiceRadio()
         {
             Logging.Verbose = true;

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -438,5 +438,41 @@ namespace UnitTests
             }
             privateObject.Invoke("DequeueAllSpeech", System.Array.Empty<object>());
         }
+
+        [TestMethod]
+        public void TestSpeechServiceEscaping1()
+        {
+            // Test escaping for invalid ssml.
+            var line = @"<invalid>test</invalid> <invalid withattribute='attribute'>test2</invalid>";
+            var result = SpeechService.escapeSsml(line);
+            Assert.AreEqual("&lt;invalid&gt;test&lt;/invalid&gt; &lt;invalid withattribute='attribute'&gt;test2&lt;/invalid&gt;", result);
+        }
+
+        [TestMethod]
+        public void TestSpeechServiceEscaping2()
+        {
+            // Test escaping for double quotes, single quotes, and <phoneme> ssml commands. XML characters outside of ssml elements are escaped.
+            var line = @"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet='ipa' ph='ˈdezɦrə'>Dezhra</phoneme> & Co's shop";
+            var result = SpeechService.escapeSsml(line);
+            Assert.AreEqual("<phoneme alphabet=\"ipa\" ph=\"ʃɪnˈrɑːrtə\">Shinrarta</phoneme> <phoneme alphabet='ipa' ph='ˈdezɦrə'>Dezhra</phoneme> &amp; Co&apos;s shop", result);
+        }
+
+        [TestMethod]
+        public void TestSpeechServiceEscaping3()
+        {
+            // Test escaping for <break> elements. XML characters outside of ssml elements are escaped.
+            var line = @"<break time=""100ms""/>He said ""Foo"".";
+            var result = SpeechService.escapeSsml(line);
+            Assert.AreEqual("<break time=\"100ms\"/>He said &quot;Foo&quot;.", result);
+        }
+
+        [TestMethod]
+        public void TestSpeechServiceEscaping4()
+        {
+            // Test escaping for Cereproc unique <usel> and <spurt> elements
+            var line = @"<spurt audio='g0001_004'>cough</spurt> This is a <usel variant=""1"">test</usel> sentence.";
+            var result = SpeechService.escapeSsml(line);
+            Assert.AreEqual(line, result);
+        }
     }
 }


### PR DESCRIPTION
Resolves #1655.
Supports escaping for the Cereproc custom tags `<usel>` and `<spurt>`.
Supports escaping for single quoted values inside an ssml tag.