### PR TITLE
Enhance access to the Script resolver from VoiceAttack, improve documentation

### DIFF
--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -54,7 +54,7 @@ namespace EddiSpeechResponder
         public int priority(string name)
         {
             scripts.TryGetValue(name, out Script script);
-            return (script == null ? 5 : script.Priority);
+            return script?.Priority ?? 5;
         }
 
         /// <summary> From a custom dictionary of variable values in the default store </summary>
@@ -1227,8 +1227,8 @@ namespace EddiSpeechResponder
                 if (curr?.x != null && dest?.x != null)
                 {
                     result = (decimal)Math.Round(Math.Sqrt(square((double)(curr.x - dest.x))
-                                + square((double)(curr.y - dest.y))
-                                + square((double)(curr.z - dest.z))), 2);
+                                + square((double)(curr.y ?? 0 - dest.y ?? 0))
+                                + square((double)(curr.z ?? 0 - dest.z ?? 0))), 2);
                 }
 
                 return new ReflectionValue(result);
@@ -1360,9 +1360,9 @@ namespace EddiSpeechResponder
             if (system == null) { return; }
             if (EDDI.Instance.HomeStarSystem != null && EDDI.Instance.HomeStarSystem.x != null && system.x != null)
             {
-                system.distancefromhome = (decimal)Math.Round(Math.Sqrt(Math.Pow((double)(system.x - EDDI.Instance.HomeStarSystem.x), 2)
-                                                                      + Math.Pow((double)(system.y - EDDI.Instance.HomeStarSystem.y), 2)
-                                                                      + Math.Pow((double)(system.z - EDDI.Instance.HomeStarSystem.z), 2)), 2);
+                system.distancefromhome = (decimal)Math.Round(Math.Sqrt(Math.Pow((double)(system.x ?? 0 - EDDI.Instance.HomeStarSystem.x ?? 0), 2)
+                                                                      + Math.Pow((double)(system.y ?? 0 - EDDI.Instance.HomeStarSystem.y ?? 0), 2)
+                                                                      + Math.Pow((double)(system.z ?? 0 - EDDI.Instance.HomeStarSystem.z ?? 0), 2)), 2);
                 Logging.Debug("Distance from home is " + system.distancefromhome);
             }
         }

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -7,15 +7,19 @@ using Cottle.Values;
 using Eddi;
 using EddiBgsService;
 using EddiCargoMonitor;
+using EddiCompanionAppService;
 using EddiCrimeMonitor;
 using EddiDataDefinitions;
 using EddiDataProviderService;
+using EddiEvents;
 using EddiMaterialMonitor;
 using EddiMissionMonitor;
 using EddiNavigationService;
 using EddiShipMonitor;
 using EddiSpeechService;
+using EddiStatusMonitor;
 using GalnetMonitor;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -47,18 +51,20 @@ namespace EddiSpeechResponder
             };
         }
 
-        public string resolve(string name, Dictionary<string, Cottle.Value> vars, bool master = true)
-        {
-            return resolve(name, buildStore(vars), master);
-        }
-
         public int priority(string name)
         {
             scripts.TryGetValue(name, out Script script);
             return (script == null ? 5 : script.Priority);
         }
 
-        public string resolve(string name, BuiltinStore store, bool master = true)
+        /// <summary> From a custom dictionary of variable values in the default store </summary>
+        public string resolveFromName(string name, Dictionary<string, Cottle.Value> vars, bool master = true)
+        {
+            return resolveFromName(name, buildStore(vars), master);
+        }
+
+        /// <summary> From a custom store </summary>
+        public string resolveFromName(string name, BuiltinStore store, bool master = true)
         {
             Logging.Debug("Resolving script " + name);
             scripts.TryGetValue(name, out Script script);
@@ -74,13 +80,23 @@ namespace EddiSpeechResponder
                 return null;
             }
 
-            return resolveScript(script.Value, store, master, script);
+            return resolveFromValue(script.Value, store, master, script);
         }
 
-        /// <summary>
-        /// Resolve a script with an existing store
-        /// </summary>
-        public string resolveScript(string script, BuiltinStore store, bool master = true, Script scriptObject = null)
+        /// <summary> From the default dictionary of variable values in the default store </summary>
+        public string resolveFromValue(string scriptValue, bool master = true)
+        {
+            return resolveFromValue(scriptValue, createVariables(), master);
+        }
+
+        /// <summary> From a custom dictionary of variable values in the default store </summary>
+        public string resolveFromValue(string scriptValue, Dictionary<string, Cottle.Value> vars, bool master = true)
+        {
+            return resolveFromValue(scriptValue, buildStore(vars), master);
+        }
+
+        /// <summary> From a custom store </summary>
+        public string resolveFromValue(string script, BuiltinStore store, bool master = true, Script scriptObject = null)
         {
             try
             {
@@ -153,6 +169,114 @@ namespace EddiSpeechResponder
                     .Replace("}", "closing curly bracket");
         }
 
+        // Create Cottle variables from the EDDI information
+        protected internal Dictionary<string, Cottle.Value> createVariables(Event theEvent = null)
+        {
+            Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>
+            {
+                ["capi_active"] = CompanionAppService.Instance?.active ?? false,
+                ["destinationdistance"] = EDDI.Instance.DestinationDistanceLy,
+                ["environment"] = EDDI.Instance.Environment,
+                ["horizons"] = EDDI.Instance.inHorizons,
+                ["va_active"] = App.FromVA,
+                ["vehicle"] = EDDI.Instance.Vehicle
+            };
+
+            if (EDDI.Instance.Cmdr != null)
+            {
+                dict["cmdr"] = new ReflectionValue(EDDI.Instance.Cmdr);
+            }
+
+            if (EDDI.Instance.HomeStarSystem != null)
+            {
+                dict["homesystem"] = new ReflectionValue(EDDI.Instance.HomeStarSystem);
+            }
+
+            if (EDDI.Instance.HomeStation != null)
+            {
+                dict["homestation"] = new ReflectionValue(EDDI.Instance.HomeStation);
+            }
+
+            if (EDDI.Instance.SquadronStarSystem != null)
+            {
+                dict["squadronsystem"] = new ReflectionValue(EDDI.Instance.SquadronStarSystem);
+            }
+
+            if (EDDI.Instance.CurrentStarSystem != null)
+            {
+                dict["system"] = new ReflectionValue(EDDI.Instance.CurrentStarSystem);
+            }
+
+            if (EDDI.Instance.LastStarSystem != null)
+            {
+                dict["lastsystem"] = new ReflectionValue(EDDI.Instance.LastStarSystem);
+            }
+
+            if (EDDI.Instance.NextStarSystem != null)
+            {
+                dict["nextsystem"] = new ReflectionValue(EDDI.Instance.NextStarSystem);
+            }
+
+            if (EDDI.Instance.DestinationStarSystem != null)
+            {
+                dict["destinationsystem"] = new ReflectionValue(EDDI.Instance.DestinationStarSystem);
+            }
+
+            if (EDDI.Instance.DestinationStation != null)
+            {
+                dict["destinationstation"] = new ReflectionValue(EDDI.Instance.DestinationStation);
+            }
+
+            if (EDDI.Instance.CurrentStation != null)
+            {
+                dict["station"] = new ReflectionValue(EDDI.Instance.CurrentStation);
+            }
+
+            if (EDDI.Instance.CurrentStellarBody != null)
+            {
+                dict["body"] = new ReflectionValue(EDDI.Instance.CurrentStellarBody);
+            }
+
+            if (((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus != null)
+            {
+                dict["status"] = new ReflectionValue(((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus);
+            }
+
+            if (theEvent != null)
+            {
+                dict["event"] = new ReflectionValue(theEvent);
+            }
+
+            if (EDDI.Instance.State != null)
+            {
+                dict["state"] = ScriptResolver.buildState();
+                Logging.Debug("State is " + JsonConvert.SerializeObject(EDDI.Instance.State));
+            }
+
+            // Obtain additional variables from each monitor
+            foreach (EDDIMonitor monitor in EDDI.Instance.monitors)
+            {
+                IDictionary<string, object> monitorVariables = monitor.GetVariables();
+                if (monitorVariables != null)
+                {
+                    foreach (string key in monitorVariables.Keys)
+                    {
+                        if (monitorVariables[key] == null)
+                        {
+                            dict.Remove(key);
+                        }
+                        else
+                        {
+                            dict[key] = new ReflectionValue(monitorVariables[key]);
+                        }
+                    }
+                }
+            }
+
+            return dict;
+        }
+
+
         /// <summary>
         /// Build a store from a list of variables
         /// </summary>
@@ -167,7 +291,7 @@ namespace EddiSpeechResponder
             // Function to call another script
             store["F"] = new NativeFunction((values) =>
             {
-                return new ScriptResolver(scripts).resolve(values[0].AsString, store, false);
+                return new ScriptResolver(scripts).resolveFromName(values[0].AsString, store, false);
             }, 1);
 
             // Translation functions
@@ -229,14 +353,14 @@ namespace EddiSpeechResponder
             // Helper functions
             store["OneOf"] = new NativeFunction((values) =>
             {
-                return new ScriptResolver(scripts).resolveScript(values[random.Next(values.Count)].AsString, store, false);
+                return new ScriptResolver(scripts).resolveFromValue(values[random.Next(values.Count)].AsString, store, false);
             });
 
             store["Occasionally"] = new NativeFunction((values) =>
             {
                 if (random.Next((int)values[0].AsNumber) == 0)
                 {
-                    return new ScriptResolver(scripts).resolveScript(values[1].AsString, store, false);
+                    return new ScriptResolver(scripts).resolveFromValue(values[1].AsString, store, false);
                 }
                 else
                 {
@@ -370,7 +494,7 @@ namespace EddiSpeechResponder
             {
                 if (values.Count == 1)
                 {
-                    return new ScriptResolver(scripts).resolveScript(@"<transmit>" + values[0].AsString + "</transmit>", store, false);
+                    return new ScriptResolver(scripts).resolveFromValue(@"<transmit>" + values[0].AsString + "</transmit>", store, false);
                 } 
                 return "The Transmit function is used improperly. Please review the documentation for correct usage.";
             }, 1);

--- a/SpeechResponder/SpeechResponder.cs
+++ b/SpeechResponder/SpeechResponder.cs
@@ -1,6 +1,4 @@
-﻿using Cottle.Values;
-using Eddi;
-using EddiCompanionAppService;
+﻿using Eddi;
 using EddiDataDefinitions;
 using EddiEvents;
 using EddiShipMonitor;
@@ -200,8 +198,8 @@ namespace EddiSpeechResponder
         // Say something with a custom resolver
         public void Say(ScriptResolver resolver, Ship ship, string scriptName, Event theEvent = null, int? priority = null, string voice = null, bool sayOutLoud = true, bool invokedFromVA = false)
         {
-            Dictionary<string, Cottle.Value> dict = createVariables(theEvent);
-            string speech = resolver.resolve(scriptName, dict);
+            Dictionary<string, Cottle.Value> dict = resolver.createVariables(theEvent);
+            string speech = resolver.resolveFromName(scriptName, dict);
             if (speech != null)
             {
                 if (subtitles)
@@ -219,114 +217,7 @@ namespace EddiSpeechResponder
                 }
             }
         }
-
-        // Create Cottle variables from the EDDI information
-        private Dictionary<string, Cottle.Value> createVariables(Event theEvent = null)
-        {
-            Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>
-            {
-                ["capi_active"] = CompanionAppService.Instance?.active ?? false,
-                ["destinationdistance"] = EDDI.Instance.DestinationDistanceLy,
-                ["environment"] = EDDI.Instance.Environment,
-                ["horizons"] = EDDI.Instance.inHorizons,
-                ["va_active"] = App.FromVA,
-                ["vehicle"] = EDDI.Instance.Vehicle
-            };
-
-            if (EDDI.Instance.Cmdr != null)
-            {
-                dict["cmdr"] = new ReflectionValue(EDDI.Instance.Cmdr);
-            }
-
-            if (EDDI.Instance.HomeStarSystem != null)
-            {
-                dict["homesystem"] = new ReflectionValue(EDDI.Instance.HomeStarSystem);
-            }
-
-            if (EDDI.Instance.HomeStation != null)
-            {
-                dict["homestation"] = new ReflectionValue(EDDI.Instance.HomeStation);
-            }
-
-            if (EDDI.Instance.SquadronStarSystem != null)
-            {
-                dict["squadronsystem"] = new ReflectionValue(EDDI.Instance.SquadronStarSystem);
-            }
-
-            if (EDDI.Instance.CurrentStarSystem != null)
-            {
-                dict["system"] = new ReflectionValue(EDDI.Instance.CurrentStarSystem);
-            }
-
-            if (EDDI.Instance.LastStarSystem != null)
-            {
-                dict["lastsystem"] = new ReflectionValue(EDDI.Instance.LastStarSystem);
-            }
-
-            if (EDDI.Instance.NextStarSystem != null)
-            {
-                dict["nextsystem"] = new ReflectionValue(EDDI.Instance.NextStarSystem);
-            }
-
-            if (EDDI.Instance.DestinationStarSystem != null)
-            {
-                dict["destinationsystem"] = new ReflectionValue(EDDI.Instance.DestinationStarSystem);
-            }
-
-            if (EDDI.Instance.DestinationStation != null)
-            {
-                dict["destinationstation"] = new ReflectionValue(EDDI.Instance.DestinationStation);
-            }
-
-            if (EDDI.Instance.CurrentStation != null)
-            {
-                dict["station"] = new ReflectionValue(EDDI.Instance.CurrentStation);
-            }
-
-            if (EDDI.Instance.CurrentStellarBody != null)
-            {
-                dict["body"] = new ReflectionValue(EDDI.Instance.CurrentStellarBody);
-            }
-
-            if (((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus != null)
-            {
-                dict["status"] = new ReflectionValue(((StatusMonitor)EDDI.Instance.ObtainMonitor("Status monitor"))?.currentStatus);
-            }
-
-            if (theEvent != null)
-            {
-                dict["event"] = new ReflectionValue(theEvent);
-            }
-
-            if (EDDI.Instance.State != null)
-            {
-                dict["state"] = ScriptResolver.buildState();
-                Logging.Debug("State is " + JsonConvert.SerializeObject(EDDI.Instance.State));
-            }
-
-            // Obtain additional variables from each monitor
-            foreach (EDDIMonitor monitor in EDDI.Instance.monitors)
-            {
-                IDictionary<string, object> monitorVariables = monitor.GetVariables();
-                if (monitorVariables != null)
-                {
-                    foreach (string key in monitorVariables.Keys)
-                    {
-                        if (monitorVariables[key] == null)
-                        {
-                            dict.Remove(key);
-                        }
-                        else
-                        {
-                            dict[key] = new ReflectionValue(monitorVariables[key]);
-                        }
-                    }
-                }
-            }
-
-            return dict;
-        }
-
+        
         public UserControl ConfigurationTabItem()
         {
             return new ConfigurationWindow();

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -96,8 +96,10 @@ namespace UnitTests
             ScriptResolver resolver = new ScriptResolver(scripts);
             Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>();
             dict["name"] = "world";
-            string result = resolver.resolve("test", dict);
+            string result = resolver.resolveFromName("test", dict);
             Assert.AreEqual("Hello world", result);
+            string result2 = resolver.resolveFromValue(scripts["test"].Value, dict);
+            Assert.AreEqual("Hello world", result2);
         }
 
         [TestMethod]
@@ -109,8 +111,10 @@ namespace UnitTests
             ScriptResolver resolver = new ScriptResolver(scripts);
             Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>();
             dict["name"] = "world";
-            string result = resolver.resolve("test", dict);
+            string result = resolver.resolveFromName("test", dict);
             Assert.AreEqual("Well Hello world", result);
+            string result2 = resolver.resolveFromValue(scripts["test"].Value, dict);
+            Assert.AreEqual("Well Hello world", result2);
         }
 
         [TestMethod]

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -897,6 +897,10 @@ namespace EddiVoiceAttackResponder
                 string[] options = res.Split(';');
                 res = options[random.Next(0, options.Length)];
             }
+
+            // Step 3 - pass it through the script resolver
+            res = new ScriptResolver(null).resolveFromValue(res);
+
             return res;
         }
 

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -927,7 +927,7 @@ namespace EddiVoiceAttackResponder
 
                     // Store in EDSM
                     IEdsmService edsmService = new StarMapService();
-                    edsmService?.sendStarMapComment(currentSystemName, comment);
+                    edsmService.sendStarMapComment(currentSystemName, comment);
                 }
             }
             catch (Exception e)

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -318,64 +318,156 @@ EDDI's VoiceAttack plugin allows you to access its features in your own profile.
 
 ![](../images/VoiceAttack-PluginView.jpg)
 
-## say
+Note: Though the examples in this section show variables being passed as parameters within the plugin interface, it is no longer necessary to do so. Rather, when the plugin is invoked then the plugin will search for variables matching the plugin context and set prior to invoking the plugin.
 
-This function uses EDDI's voice to read a script. It takes one mandatory and two optional parameters.
+## Speech functions
+
+### say
+
+This function uses EDDI's voice to read a script. It takes one mandatory and two optional variables as parameters.
+
 - 'Script' (text variable) is a mandatory parameter containing the script to be read. 
 - 'Priority' (integer variable) is an optional parameter defining the priority of the invoked speech (defaults to 3).
 - 'Voice' (text variable) is an optional parameter defining the name of the voice you want to use.  Note that when you set this variable it will continue to be used until you unset it, at which point EDDI will use the voice configured in its text-to-speech settings.
 
-To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'say' and passing the parameters described above.
+To use this function in your own commands set the 'Script' variable and optionally the 'Priority' and 'Voice' variables, then use the 'Execute an external plugin function' command with the plugin context set to 'say'.
 
-## speech
+### speech
 
-This function uses EDDI's voice to read a Speech Responder script. It takes one mandatory and two optional parameters.
+This function uses EDDI's voice to read a Speech Responder script. It takes one mandatory and two optional variables as parameters.
+
 - 'Script' (text variable) is a mandatory parameter containing the name of the script to invoke. 
 - 'Priority' (integer variable) is an optional parameter defining the priority of the invoked speech (defaults to 3).
 - 'Voice' (text variable) is an optional parameter defining the name of the voice you want to use.  Note that when you set this variable it will continue to be used until you unset it, at which point EDDI will use the voice configured in its text-to-speech settings.
  
-To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'say' and passing the parameters described above.
+To use this function in your own commands set the 'Script' variable and optionally the 'Priority' and 'Voice' variables, then use the 'Execute an external plugin function' command with the plugin context set to 'speech'.
 
-## shutup
+### transmit
+
+This function uses EDDI's voice to read a Speech Responder script with a radio effect. It takes one mandatory and two optional variables as parameters.
+
+- 'Script' (text variable) is a mandatory parameter containing the name of the script to invoke. 
+- 'Priority' (integer variable) is an optional parameter defining the priority of the invoked speech (defaults to 3).
+- 'Voice' (text variable) is an optional parameter defining the name of the voice you want to use.  Note that when you set this variable it will continue to be used until you unset it, at which point EDDI will use the voice configured in its text-to-speech settings.
+ 
+To use this function in your own commands set the 'Script' variable and optionally the 'Priority' and 'Voice' variables, then use the 'Execute an external plugin function' command with the plugin context set to 'transmit'.
+
+### shutup
 
 This function stops any active EDDI speech. There are no parameters.
 
 To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'shutup'.
 
-## disablespeechresponder
+### disablespeechresponder
 
 This function tells the speech responder to not talk unless specifically asked for information. There are no parameters. This lasts until either VoiceAttack is restarted or an enablespeechresponder call is made.
 
 To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'disablespeechresponder'.
 
-## enablespeechresponder
+### enablespeechresponder
 
 This function tells the speech responder to respond normally to events. There are no parameters.
 
 To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'enablespeechresponder'.
 
-## setspeechresponderpersonality
+### setspeechresponderpersonality
 
-This function changes the speech responder's personality. It takes one mandatory parameter.
+This function changes the speech responder's personality. It takes one mandatory variable as a parameter.
+
 - 'Personality' (text variable) is a mandatory parameter containing the name of the personality to invoke.
 
 Note that unlike enablespeechresponder and disablespeechresponder any changes made here are persistent.
 
-To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'setspeechresponderpersonality' and passing the 'Personality' parameter.
+To use this function in your own commands set the 'Personality' parameter then use the 'Execute an external plugin function' command with the plugin context set to 'setspeechresponderpersonality'.
 
-## setstate
+## Information functions
 
-This function pushes a state variable to EDDI's internal session state, allowing it to be shared with other responders. It takes two mandatory parameters.
+### coriolis, edshipyard, eddbsystem, or eddbstation
+
+Looks up the current ship, the current starsystem, or the current station (as applicable). A web uri is written to '\{TXT: EDDI uri\}' and, unless '\{BOOL:EDDI open uri in browser\}' has been set to false, the uri is opened in the default browser.
+
+### inara
+
+Looks up a named commander on the website Inara.cz. It takes one mandatory variable as a parameter.
+
+- 'Name' (text variable) is a mandatory parameter containing the name of the commander to look up on Inara.cz.
+
+A web uri is written to '\{TXT: EDDI uri\}' and, unless '\{BOOL:EDDI open uri in browser\}' has been set to false, the uri is opened in the default browser.
+
+To use this function in your own commands set the 'Name' parameter then use the 'Execute an external plugin function' command with the plugin context set to 'inara'.
+
+### jumpdetails
+
+This function will provide jump information based on your ship loadout and current fuel level. It takes one mandatory variable as a parameter.
+
+- 'Type variable' (text variable) is a mandatory parameter containing the type of the information to return.
+
+  * `next` range of next jump at current fuel mass and current laden mass
+  * `max` maximum jump range at minimum fuel mass and current laden mass
+  * `total` total range of multiple jumps from current fuel mass and current laden mass
+  * `full` total range of multiple jumps from maximum fuel mass and current laden mass
+
+When this function is used, the following variables will be updated and made available for use in VoiceAttack:
+
+- \{DEC:Ship jump detail distance\}
+- \{INT:Ship jump detail jumps\}
+
+To use this function in your own commands set the 'Type variable' parameter then use the 'Execute an external plugin function' command with the plugin context set to 'jumpdetails'.
+
+### route
+
+This function will produce a destination/route for valid mission destinations. It takes one mandatory and two optional variables as parameters.
+
+- 'Type variable' (text variable) is a mandatory parameter containing the type of update to execute.
+
+  * `cancel` Cancel the currently stored route.
+  * `encoded` Nearest encoded materials trader.
+  * `expiring` Destination of your next expiring mission.
+  * `facilitator` Nearest 'Legal Facilities' contact.
+  * `farthest` Mission destination farthest from your current location.
+  * `guardian` Nearest guardian technology broker.
+  * `human` Nearest human technology broker.
+  * `manufactured` Nearest manufactured materials trader.
+  * `most` Nearest system with the most missions.
+  * `nearest` Mission destination nearest to your current location.
+  * `next` Next destination in the currently stored route.
+  * `raw` Nearest raw materials trader.
+  * `route` 'Traveling Salesman' (RNNA) route for all active missions.
+  * `scoop` Nearest scoopable star system.
+  * `set` Set destination route to a single system.
+  * `source` Destination to nearest mission 'cargo source'.
+  * `update` Update to the next mission route destination (use this once all missions in the current system are completed).
+
+- 'System variable' (text variable) is an optional parameter for the following route update types. 
+
+  * `most` If set, the resulting route shall be plotted relative to the specified star system rather than relative to the current star system.
+  * `route` If set, the resulting route shall be plotted relative to the specified star system rather than relative to the current star system.
+  * `set` If set, the resulting route shall proceed directly to the specified single star system rather than to the last star system identified in a route search.
+  * `source` If set, the resulting route shall be plotted relative to the specified star system rather than relative to the current star system.
+  * `update` If set, the specified star system shall be removed from the route rather than removing the prior mission route destination.
+
+- 'Station variable' (text variable) is an optional parameter for the following route update types
+
+  * `set` If set, the resulting route shall proceed directly to the specified single star system and station rather than to the last star system and station identified in a route search.
+
+To use this function in your own commands set the 'Type variable' parameter and when appropriate the `System variable` and 'Station variable' parameters then use the 'Execute an external plugin function' command with the plugin context set to 'route'. Upon success, a '((EDDI route details))' event is triggered, providing event data as described [in the appropriate wiki page](https://github.com/EDCD/EDDI/wiki/Route-details-event).
+
+## Utility functions
+
+### setstate
+
+This function pushes a state variable to EDDI's internal session state, allowing it to be shared with other responders. It takes two mandatory variables as parameters.
+
 - 'State variable' (text variable) is a mandatory parameter containing the name of the VoiceAttack variable to store in EDDI.
 - The variable to store in EDDI (integer, boolean, decimal, or text variable), as referenced by the 'State variable' parameter.
 
-To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'setstate' and passing the parameters described above. This function will read the text variable 'State variable' and store the VoiceAttack variable named in there as a state variable.  
+To use this function in your own commands set the variables described above then use the 'Execute an external plugin function' command with the plugin context set to 'setstate'. This function will read the text variable 'State variable' and store the VoiceAttack variable named in there as a state variable.  
 
 For example, if you wanted to store the VoiceAttack boolean variable "Verbose" as a state variable you would:
 
     * set the boolean variable "Verbose" to the desired value
     * set the text variable "State variable" to "Verbose"
-    * call EDDI with the context set to "setstate" and passing the text variable parameter "State variable"
+    * call EDDI with the context set to "setstate"
 
 ![](../images/VoiceAttack-PluginView-SetState.jpg)
 
@@ -387,11 +479,40 @@ To access the same variable from within EDDI's Speech Responder, you would call 
 
 Please note that state is transient, and is purposefully not persisted beyond the running instance of EDDI.  This means that every time you start VoiceAttack the state will be empty.  Also, because EDDI responders run asynchronously and concurrently there is no guarantee that, for example, the speech responder for an event will finish before the VoiceAttack responder for an event starts (or vice versa).
 
-## coriolis, edshipyard, eddbsystem, or eddbstation
-Looks up the current ship, the current starsystem, or the current station (as applicable). A web uri is written to {TXT: EDDI uri} and, unless {BOOL:EDDI open uri in browser} has been set to false, the uri is opened in the default browser.
+### configuration
 
-## inara
-Looks up a named commander on the website Inara.cz. It takes one mandatory parameter.
-- 'Name' (text variable) is a mandatory parameter containing the name of the commander to look up on Inara.cz.
+This function opens or restores EDDI's UI. There are no parameters.
 
-A web uri is written to {TXT: EDDI uri} and, unless {BOOL:EDDI open uri in browser} has been set to false, the uri is opened in the default browser.
+To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'configuration'.
+
+### configurationminimize
+
+This function minimizes EDDI's UI. There are no parameters.
+
+To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'configurationminimize'.
+
+### configurationmaximize
+
+This function maximizes EDDI's UI. There are no parameters.
+
+To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'configurationmaximize'.
+
+### configurationrestore
+
+This function restores EDDI's UI to a normal window. There are no parameters.
+
+To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'configurationrestore'.
+
+### configurationclose
+
+This function closes EDDI's UI. There are no parameters.
+
+To use this function in your own commands use the 'Execute an external plugin function' command with the plugin context set to 'configurationclose'.
+
+### system comment
+
+Sets a comment on the current star system on the website EDSM.net. You must have entered your EDSM credentials in EDDI's EDSM responder for this to work. It takes one mandatory variable as a parameter.
+
+- 'EDDI system comment' (text variable) is a mandatory parameter containing the comment to add to the current star system on EDSM.net.
+
+To use this function in your own commands set the 'EDDI system comment' parameter then use the 'Execute an external plugin function' command with the plugin context set to 'system comment'.


### PR DESCRIPTION
- Text from the VoiceAttack plugin is now passed through our EDDI's script resolver, making all of EDDI's Speech responder functions invokable from VoiceAttack.
- VoiceAttack-Integration.md updated for clarity and to document previously undocumented plugin functions (particularly `route` and `jumpdetails`). 

@Hoodathunk , I'm not sure that I've got everything right with respect to the  `route` and `jumpdetails` plugin commands so please look these over and let me know if and where I might need to make adjustments.