### PR TITLE
Ship swapped and hull health

### DIFF
--- a/DataDefinitions/Module.cs
+++ b/DataDefinitions/Module.cs
@@ -47,7 +47,7 @@ namespace EddiDataDefinitions
         [JsonProperty]
         public decimal power { get; set; }
         [JsonProperty]
-        public decimal health { get; set; }
+        public decimal health { get; set; } = 100M;
         [JsonProperty]
         public bool hot { get; set; } // False = `clean', true = `hot`
 

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -318,6 +318,15 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
+            bulkheads = new Module();
+            powerplant = new Module();
+            thrusters = new Module();
+            powerdistributor = new Module();
+            frameshiftdrive = new Module();
+            lifesupport = new Module();
+            sensors = new Module();
+            fueltank = new Module();
+            cargohatch = new Module();
         }
 
         public Ship(long EDID, string EDName, string Manufacturer, List<Translation> PhoneticManufacturer, string Model, List<Translation> PhoneticModel, string Size, int? MilitarySize, decimal reservoirFuelTankSize)
@@ -334,6 +343,15 @@ namespace EddiDataDefinitions
             hardpoints = new List<Hardpoint>();
             compartments = new List<Compartment>();
             launchbays = new List<LaunchBay>();
+            bulkheads = new Module();
+            powerplant = new Module();
+            thrusters = new Module();
+            powerdistributor = new Module();
+            frameshiftdrive = new Module();
+            lifesupport = new Module();
+            sensors = new Module();
+            fueltank = new Module();
+            cargohatch = new Module();
             this.activeFuelReservoirCapacity = reservoirFuelTankSize;
         }
 


### PR DESCRIPTION
Record hull health from the `Ship loadout` event, capture hull and module health from the Frontier API profile, and use the Frontier API profile refresh to update hull and module health before swapping ships. This should ensure accurate voice distortion when voice distortion for ship damage is enabled.
Resolves #1698.