### PR TITLE
Prefer PLINQ for parallel processing

### DIFF
--- a/BgsService/BgsFactionData.cs
+++ b/BgsService/BgsFactionData.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Utilities;
 
 namespace EddiBgsService
@@ -67,29 +66,16 @@ namespace EddiBgsService
 
                 if (responses?.Count > 0)
                 {
-                    List<Faction> factions = ParseFactionsAsync(responses);
+                    List<Faction> factions = ParseFactionsParallel(responses);
                     return factions.OrderBy(x => x.name).ToList();
                 }
             }
             return null;
         }
 
-        private List<Faction> ParseFactionsAsync(List<object> responses)
+        private List<Faction> ParseFactionsParallel(List<object> responses)
         {
-            List<Task<Faction>> factionTasks = new List<Task<Faction>>();
-            foreach (object response in responses)
-            {
-                factionTasks.Add(Task.Run(() => ParseFaction(response)));
-            }
-            Task.WhenAll(factionTasks.ToArray());
-
-            List<Faction> factions = new List<Faction>();
-            foreach (Task<Faction> task in factionTasks)
-            {
-                Faction faction = task.Result;
-                if (faction != null) { factions.Add(faction); };
-            }
-
+            List<Faction> factions = responses.AsParallel().Select(ParseFaction).ToList();
             return factions;
         }
 

--- a/BgsService/BgsFactionData.cs
+++ b/BgsService/BgsFactionData.cs
@@ -75,6 +75,7 @@ namespace EddiBgsService
 
         private List<Faction> ParseFactionsParallel(List<object> responses)
         {
+            // it is OK to allow nulls into this list; they will be handled upstream
             List<Faction> factions = responses.AsParallel().Select(ParseFaction).ToList();
             return factions;
         }

--- a/Tests/BgsDataTests.cs
+++ b/Tests/BgsDataTests.cs
@@ -132,5 +132,25 @@ namespace UnitTests
             Assert.AreEqual(Superpower.None, faction2.Allegiance);
             Assert.AreEqual(DateTime.MinValue, faction2.updatedAt);
         }
+        [TestMethod]
+
+        public void TestParseNoFactions()
+        {
+            // Setup
+            string endpoint = "v4/factions?";
+            string json = "";
+            RestRequest data = new RestRequest();
+            fakeBgsRestClient.Expect(endpoint, json, data);
+            var queryList = new List<KeyValuePair<string, object>>()
+            {
+                new KeyValuePair<string, object>(BgsService.FactionParameters.factionName, "")
+            };
+
+            // Act
+            List<Faction> factions = fakeBgsService.GetFactions(endpoint, queryList);
+
+            // Assert
+            Assert.IsNull(factions);
+        }
     }
 }


### PR DESCRIPTION
PLINQ takes care of all the bookkeeping for us, and splits the collection over a number of tasks determined at runtime based on the number of cores/logical processors on the hardware.

[PLINQ docs](https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/parallel-linq-plinq?view=netframework-4.8)