### PR TITLE
Improve EDDI startup speed

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -66,7 +66,7 @@ namespace EddiCompanionAppService
         public event StateChangeHandler StateChanged;
 
         public CompanionAppCredentials Credentials;
-        public bool inBeta { get; set; } = false;
+        public bool gameIsBeta { get; set; } = false;
         public bool active => CurrentState == State.Authorized;
 
         private static CompanionAppService instance;
@@ -133,7 +133,7 @@ namespace EddiCompanionAppService
 
         private string ServerURL()
         {
-            return inBeta ? BETA_SERVER : LIVE_SERVER;
+            return gameIsBeta ? BETA_SERVER : LIVE_SERVER;
         }
 
         ///<summary>Log in. Throws an exception if it fails</summary>

--- a/DataProviderService/DatabaseStarSystem.cs
+++ b/DataProviderService/DatabaseStarSystem.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace EddiDataProviderService
+{
+    internal class DatabaseStarSystem
+    {
+        // Data as read from columns in our database
+        public string systemName { get; private set; }
+        public long? systemAddress { get; private set; }
+        public long? edsmId { get; private set; }
+        public string systemJson { get; set; }
+        public string comment { get; set; }
+        public DateTime lastUpdated { get; set; }
+        public DateTime? lastVisit { get; set; }
+        public int totalVisits { get; set; }
+
+        public DatabaseStarSystem(string systemName, long? systemAddress, long? edsmId, string systemJson)
+        {
+            this.systemName = systemName;
+            this.systemAddress = systemAddress;
+            this.edsmId = edsmId;
+            this.systemJson = systemJson;
+        }
+    }
+}

--- a/DataProviderService/EddiDataProviderService.csproj
+++ b/DataProviderService/EddiDataProviderService.csproj
@@ -75,6 +75,7 @@
     <Reference Include="System.Data.SQLite.Linq, Version=1.0.108.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Linq.1.0.108.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -83,8 +84,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DatabaseStarSystem.cs" />
     <Compile Include="LegacyEddpService.cs" />
     <Compile Include="DataProviderService.cs" />
+    <Compile Include="StarSystemCache.cs" />
     <Compile Include="StarSystemSqLiteRepository.cs" />
     <Compile Include="StarSystemRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/DataProviderService/StarSystemCache.cs
+++ b/DataProviderService/StarSystemCache.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Caching;
+using EddiDataDefinitions;
+
+namespace EddiDataProviderService
+{
+    public class StarSystemCache
+    {
+        private readonly CacheItemPolicy cacheItemPolicy = new CacheItemPolicy();
+        private readonly ObjectCache starSystemCache = new MemoryCache("StarSystemCache");
+
+        // Store deserialized star systems in short term memory for this amount of time.
+        // Storage time is reset whenever the cached value is accessed.
+        public StarSystemCache(int expirationSeconds)
+        {
+            cacheItemPolicy.SlidingExpiration = TimeSpan.FromSeconds(expirationSeconds);
+        }
+
+        public void Add(StarSystem starSystem)
+        {
+            starSystemCache.Add(starSystem.systemname, starSystem, cacheItemPolicy);
+        }
+
+        public bool Contains(string systemName)
+        {
+            return starSystemCache.Contains(systemName);
+        }
+
+        public StarSystem Get(string systemName)
+        {
+            return starSystemCache.Get(systemName) as StarSystem;
+        }
+
+        public void Remove(string systemName)
+        {
+            starSystemCache.Remove(systemName);
+        }
+    }
+}

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -212,8 +212,10 @@ namespace EddiDataProviderService
             List<DatabaseStarSystem> dataSets = Instance.ReadStarSystems(names);
 
             bool needToUpdate = false;
-            foreach (DatabaseStarSystem dbStarSystem in dataSets)
+
+            for (int i = 0; i < dataSets.Count; i++)
             {
+                DatabaseStarSystem dbStarSystem = dataSets[i];
                 if (dbStarSystem.systemJson != null)
                 {
                     // Old versions of the data could have a string "No volcanism" for volcanism.  If so we remove it
@@ -235,7 +237,7 @@ namespace EddiDataProviderService
                             needToUpdate = true;
                         }
                     }
-
+                    
                     if (needToUpdate)
                     {
                         // We want to update this star system (don't deserialize the old result at this time)
@@ -457,7 +459,7 @@ namespace EddiDataProviderService
             DateTime lastUpdated = DateTime.MinValue;
             DateTime? lastVisit = null;
             int totalVisits = 0;
-
+            
             using (SQLiteDataReader rdr = cmd.ExecuteReader())
             {
                 if (rdr.Read())
@@ -486,11 +488,11 @@ namespace EddiDataProviderService
                         }
                         if (rdr.GetName(i) == "starsystemlastupdated")
                         {
-                            lastUpdated = rdr.IsDBNull(i) ? DateTime.MinValue : rdr.GetDateTime(i);
+                            lastUpdated = rdr.IsDBNull(i) ? DateTime.MinValue : rdr.GetDateTime(i).ToUniversalTime();
                         }
                         if (rdr.GetName(i) == "lastvisit")
                         {
-                            lastVisit = rdr.IsDBNull(i) ? null : (DateTime?)rdr.GetValue(i);
+                            lastVisit = rdr.IsDBNull(i) ? null : (DateTime?)rdr.GetDateTime(i).ToUniversalTime();
                         }
                         if (rdr.GetName(i) == "totalvisits")
                         {

--- a/DataProviderService/packages.config
+++ b/DataProviderService/packages.config
@@ -7,4 +7,5 @@
   <package id="System.Data.SQLite.Core" version="1.0.108.0" targetFramework="net471" />
   <package id="System.Data.SQLite.EF6" version="1.0.108.0" targetFramework="net471" />
   <package id="System.Data.SQLite.Linq" version="1.0.108.0" targetFramework="net471" />
+  <package id="System.Runtime.Caching" version="4.7.0" targetFramework="net471" />
 </packages>

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -81,8 +81,7 @@ namespace Eddi
                 // (Re)configure the CompanionAppService service
                 CompanionAppService.Instance.gameIsBeta = value;
                 // (Re)configure the Inara service
-                void ReconfigureInara() => EddiInaraService.InaraService.Start(value, EddiIsBeta());
-                Task.Run(ReconfigureInara);
+                EddiInaraService.InaraService.Start(value, EddiIsBeta());
             }
         }
         private bool? _gameIsBeta;

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -81,7 +81,8 @@ namespace Eddi
                 // (Re)configure the CompanionAppService service
                 CompanionAppService.Instance.gameIsBeta = value;
                 // (Re)configure the Inara service
-                Task.Run(() => { EddiInaraService.InaraService.Start(value, EddiIsBeta()); });
+                void ReconfigureInara() => EddiInaraService.InaraService.Start(value, EddiIsBeta());
+                Task.Run(ReconfigureInara);
             }
         }
         private bool? _gameIsBeta;

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -220,8 +220,8 @@ namespace Eddi
                     {
                         essentialAsyncTasks.AddRange(new List<Task>()
                         {
-                            Task.Run(ActionUpdateHomeSystemStation),
-                            Task.Run(ActionUpdateSquadronSystem)
+                            Task.Run((Action)ActionUpdateHomeSystemStation),
+                            Task.Run((Action)ActionUpdateSquadronSystem)
                         });
                     }
                 }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -2421,7 +2421,14 @@ namespace Eddi
         /// </summary>
         public List<EDDIMonitor> findMonitors()
         {
-            DirectoryInfo dir = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (string.IsNullOrEmpty(path))
+            {
+                Logging.Warn("Unable to start EDDI Monitors, application directory path not found.");
+                return null;
+            }
+
+            DirectoryInfo dir = new DirectoryInfo(path);
             List<EDDIMonitor> monitors = new List<EDDIMonitor>();
             Type pluginType = typeof(EDDIMonitor);
             foreach (FileInfo file in dir.GetFiles("*Monitor.dll", SearchOption.AllDirectories))
@@ -2492,7 +2499,13 @@ namespace Eddi
         /// </summary>
         public List<EDDIResponder> findResponders()
         {
-            DirectoryInfo dir = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (string.IsNullOrEmpty(path))
+            {
+                Logging.Warn("Unable to start EDDI Responders, application directory path not found.");
+                return null;
+            }
+            DirectoryInfo dir = new DirectoryInfo(path);
             List<EDDIResponder> responders = new List<EDDIResponder>();
             Type pluginType = typeof(EDDIResponder);
             foreach (FileInfo file in dir.GetFiles("*Responder.dll", SearchOption.AllDirectories))

--- a/EddiInaraService/InaraService.cs
+++ b/EddiInaraService/InaraService.cs
@@ -43,15 +43,15 @@ namespace EddiInaraService
             }
         }
 
-        private static bool eddiInBeta;
-        private static bool gameInBeta;
+        private bool eddiInBeta;
+        private bool gameInBeta;
 
         public static void Start(bool gameIsBeta = false, bool eddiIsBeta = false)
         {
             Logging.Debug("Creating new Inara service instance.");
-            eddiInBeta = eddiIsBeta;
-            gameInBeta = gameIsBeta;
             _ = Instance;
+            Instance.eddiInBeta = eddiIsBeta;
+            Instance.gameInBeta = gameIsBeta;
         }
 
         protected InaraService()


### PR DESCRIPTION
- Refactors DataProviderService/StarSystemSqLiteRepository` to reduce deserialization and make better use of database column data.
- Implements a short term cache to hold deserialized star system data.
- Refactors startup tasks so that when the home system and squadron system are the same, these are looked up on the same thread to only deserialize once.