### PR TITLE
Update `ship` variables and more efficiently handle ship distance calcs

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -279,6 +279,8 @@ namespace EddiDataDefinitions
             }
         }
 
+        // <summary>the location where this ship is stored; null if the commander is in this ship</summary>
+
         /// <summary>the name of the system in which this ship is stored; null if the commander is in this ship</summary>
         private string _starsystem;
         public string starsystem
@@ -302,11 +304,15 @@ namespace EddiDataDefinitions
         /// <summary>the name of the station in which this ship is stored; null if the commander is in this ship</summary>
         public string station { get; set; }
         public long? marketid { get; set; }
+        public decimal? x { get; set; }
+        public decimal? y { get; set; }
+        public decimal? z { get; set; }
 
         // Other properties for when this ship is stored
         public bool intransit { get; set; }
         public long? transferprice { get; set; }
         public long? transfertime { get; set; }
+        public decimal? distance { get; set; }
 
         public decimal health { get; set; }
         public Module cargohatch { get; set; }
@@ -447,6 +453,21 @@ namespace EddiDataDefinitions
                 }
             }
             return result;
+        }
+
+        /// <summary> Calculates the distance from the specified coordinates to the ship's recorded x, y, and z coordinates </summary>
+        public decimal? Distance(decimal? fromX, decimal? fromY, decimal? fromZ)
+        {
+            // Work out the distance to the system where the ship is stored if we can
+            if (x is null || y is null || z is null || fromX is null || fromY is null || fromZ is null)
+            {
+                // We don't know how far away the ship is
+                return null;
+            }
+            decimal dx = (fromX - x) ?? 0M;
+            decimal dy = (fromY - y) ?? 0M;
+            decimal dz = (fromZ - z) ?? 0M;
+            return (decimal)(Math.Sqrt((double)((dx * dx) + (dy * dy) + (dz * dz))));
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfectly correct    

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -58,6 +58,42 @@ namespace EddiDataDefinitions
             }
         }
 
+        private long? _hullvalue;
+        /// <summary>the value of the ship's hull, in credits</summary>
+        public long? hullvalue
+        {
+            get
+            {
+                return _hullvalue;
+            }
+            set
+            {
+                if (_hullvalue != value)
+                {
+                    _hullvalue = value;
+                    NotifyPropertyChanged("hullvalue");
+                }
+            }
+        }
+
+        private long? _modulesvalue;
+        /// <summary>the value of the ship's hull, in credits</summary>
+        public long? modulesvalue
+        {
+            get
+            {
+                return _modulesvalue;
+            }
+            set
+            {
+                if (_modulesvalue != value)
+                {
+                    _modulesvalue = value;
+                    NotifyPropertyChanged("modulesvalue");
+                }
+            }
+        }
+
         /// <summary>the value of the ship's rebuy, in credits</summary>
         public long rebuy { get; set; }
 
@@ -260,6 +296,8 @@ namespace EddiDataDefinitions
                 }
             }
         }
+        [Obsolete("Please use 'starsystem' instead")]
+        public string system => starsystem; // Legacy Cottle scripts may use `system` rather than `starsystem`. 
 
         /// <summary>the name of the station in which this ship is stored; null if the commander is in this ship</summary>
         public string station { get; set; }
@@ -281,7 +319,6 @@ namespace EddiDataDefinitions
         public Module powerdistributor { get; set; }
         public Module sensors { get; set; }
         public Module fueltank { get; set; }
-        public Module datalinkscanner { get; set; }
         public List<Hardpoint> hardpoints { get; set; }
         public List<Compartment> compartments { get; set; }
         public List<LaunchBay> launchbays { get; set; }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -1122,10 +1122,18 @@ namespace EddiJournalMonitor
                                                     {
                                                         StarSystem systemData = StarSystemSqLiteRepository.Instance.GetStarSystem(starSystem, true);
                                                         ship.station = systemData?.stations?.FirstOrDefault(s => s.marketId == ship.marketid)?.name;
+                                                        ship.x = systemData?.x;
+                                                        ship.y = systemData?.y;
+                                                        ship.z = systemData?.z;
+                                                        ship.distance = ship.Distance(EDDI.Instance?.CurrentStarSystem?.x, EDDI.Instance?.CurrentStarSystem?.y, EDDI.Instance?.CurrentStarSystem?.z);
                                                     }
                                                     else
                                                     {
                                                         ship.station = station;
+                                                        ship.x = EDDI.Instance?.CurrentStarSystem?.x;
+                                                        ship.y = EDDI.Instance?.CurrentStarSystem?.y;
+                                                        ship.z = EDDI.Instance?.CurrentStarSystem?.z;
+                                                        ship.distance = 0;
                                                     }
                                                     shipyard.Add(ship);
                                                 }

--- a/ShipMonitor/EddiShipMonitor.csproj
+++ b/ShipMonitor/EddiShipMonitor.csproj
@@ -132,6 +132,10 @@
       <Project>{0C845B02-E283-43D8-91A7-205AD3397371}</Project>
       <Name>EddiDataDefinitions</Name>
     </ProjectReference>
+    <ProjectReference Include="..\DataProviderService\EddiDataProviderService.csproj">
+      <Project>{C5F48807-921B-456D-A9E4-A0282E5E8CF1}</Project>
+      <Name>EddiDataProviderService</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EDDI\Eddi.csproj">
       <Project>{EC7BA042-A370-447F-8C3E-241358CEBCBB}</Project>
       <Name>Eddi</Name>

--- a/ShipMonitor/FrontierApi.cs
+++ b/ShipMonitor/FrontierApi.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using EddiDataProviderService;
 using Utilities;
 
 namespace EddiShipMonitor
@@ -37,6 +38,12 @@ namespace EddiShipMonitor
                             {
                                 ship.starsystem = (string)shipObj["starsystem"]["name"];
                                 ship.station = (string)shipObj["station"]["name"];
+
+                                // Get the ship's coordinates for distance calculations
+                                StarSystem StoredShipStarSystem = StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(ship.starsystem);
+                                ship.x = StoredShipStarSystem.x;
+                                ship.y = StoredShipStarSystem.y;
+                                ship.z = StoredShipStarSystem.z;
                             }
                             shipyard.Add(ship);
                         }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -140,6 +140,10 @@ namespace EddiShipMonitor
             {
                 handleCommanderContinuedEvent((CommanderContinuedEvent)@event);
             }
+            else if (@event is LocationEvent)
+            {
+                handleLocationEvent((LocationEvent)@event);
+            }
             else if (@event is JumpedEvent)
             {
                 handleJumpedEvent((JumpedEvent)@event);
@@ -305,6 +309,21 @@ namespace EddiShipMonitor
                     }
                     if (!@event.fromLoad) { writeShips(); }
                 }
+            }
+        }
+
+        private void handleLocationEvent(LocationEvent @event)
+        {
+            if (@event.timestamp > updatedAt)
+            {
+                foreach (Ship shipInYard in shipyard)
+                {
+                    // Ignore current ship, since (obviously) it's not stored
+                    if (shipInYard.LocalId == currentShipId) { continue; }
+                    // Otherwise, update the distance to that ship
+                    shipInYard.distance = shipInYard.Distance(@event.x, @event.y, @event.z);
+                }
+                if (!@event.fromLoad) { writeShips(); }
             }
         }
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -140,6 +140,10 @@ namespace EddiShipMonitor
             {
                 handleCommanderContinuedEvent((CommanderContinuedEvent)@event);
             }
+            else if (@event is JumpedEvent)
+            {
+                handleJumpedEvent((JumpedEvent)@event);
+            }
             else if (@event is ShipPurchasedEvent)
             {
                 handleShipPurchasedEvent((ShipPurchasedEvent)@event);
@@ -304,6 +308,21 @@ namespace EddiShipMonitor
             }
         }
 
+        private void handleJumpedEvent(JumpedEvent @event)
+        {
+            if (@event.timestamp > updatedAt)
+            {
+                foreach (Ship shipInYard in shipyard)
+                {
+                    // Ignore current ship, since (obviously) it's not stored
+                    if (shipInYard.LocalId == currentShipId) { continue; }
+                    // Otherwise, update the distance to that ship
+                    shipInYard.distance = shipInYard.Distance(@event.x, @event.y, @event.z);
+                }
+                if (!@event.fromLoad) { writeShips(); }
+            }
+        }
+
         private void handleShipPurchasedEvent(ShipPurchasedEvent @event)
         {
             if (@event.timestamp > updatedAt)
@@ -319,6 +338,10 @@ namespace EddiShipMonitor
                         // Set location of stored ship to the current system
                         storedShip.starsystem = EDDI.Instance?.CurrentStarSystem?.systemname;
                         storedShip.station = EDDI.Instance?.CurrentStation?.name;
+                        storedShip.x = EDDI.Instance?.CurrentStarSystem?.x;
+                        storedShip.y = EDDI.Instance?.CurrentStarSystem?.y;
+                        storedShip.z = EDDI.Instance?.CurrentStarSystem?.z;
+                        storedShip.distance = 0;
                     }
                 }
                 else if (@event.soldshipid != null)
@@ -365,6 +388,10 @@ namespace EddiShipMonitor
                         // Set location of stored ship to the current system
                         storedShip.starsystem = EDDI.Instance?.CurrentStarSystem?.systemname;
                         storedShip.station = EDDI.Instance?.CurrentStation?.name;
+                        storedShip.x = EDDI.Instance?.CurrentStarSystem?.x;
+                        storedShip.y = EDDI.Instance?.CurrentStarSystem?.y;
+                        storedShip.z = EDDI.Instance?.CurrentStarSystem?.z;
+                        storedShip.distance = 0;
                     }
                 }
                 else if (@event.soldshipid != null)
@@ -595,6 +622,10 @@ namespace EddiShipMonitor
                             shipInYard.starsystem = shipInEvent.starsystem;
                             shipInYard.marketid = shipInEvent.marketid;
                             shipInYard.station = shipInEvent.station;
+                            shipInYard.x = shipInEvent.x;
+                            shipInYard.y = shipInEvent.y;
+                            shipInYard.z = shipInEvent.z;
+                            shipInYard.distance = shipInEvent.distance;
                             shipInYard.transferprice = shipInEvent.transferprice;
                             shipInYard.transfertime = shipInEvent.transfertime;
                         }
@@ -1338,6 +1369,10 @@ namespace EddiShipMonitor
                     // Location for the current ship is always null, as it's with us
                     ship.starsystem = null;
                     ship.station = null;
+                    ship.x = null;
+                    ship.y = null;
+                    ship.z = null;
+                    ship.distance = null;
                     EDDI.Instance.CurrentShip = ship;
                 }
             }

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -465,6 +465,8 @@ namespace EddiShipMonitor
             {
                 ship.value = (long)@event.value;
             }
+            ship.hullvalue = @event.hullvalue;
+            ship.modulesvalue = @event.modulesvalue;
             ship.rebuy = @event.rebuy;
             ship.unladenmass = @event.unladenmass;
             ship.maxjumprange = @event.maxjumprange;
@@ -675,10 +677,6 @@ namespace EddiShipMonitor
                     else if (modulename == "CargoHatch" && ship.cargohatch != null)
                     {
                         ship.cargohatch.health = 1;
-                    }
-                    else if (modulename == "DataLinkScanner" && ship.datalinkscanner != null)
-                    {
-                        ship.datalinkscanner.health = 1;
                     }
                     else if (modulename.Contains("Hardpoint"))
                     {

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -337,6 +337,7 @@ Stored ship information
     - `starsystem` system in which the ship is stored
     - `station` station in which the ship is stored
     - `marketid` market ID of the station in which the ship is stored
+    - `distance` the distance to the stored ship, in light years
     - `intransit` true if the ship is in transit
     - `transferprice` price to transfer ship to current location (0 if in transit)
     - `transfertime` time to transfer ship to current location (0 if in transit)

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -315,7 +315,7 @@ Any values might be missing, depending on EDDI's configuration.
     - `phoneticname` the name of the ship, using any phonetic pronunciation that has been set and is supported by the current voice 
     - `ident` the identifier of the ship
     - `role` the role of the ship 
-    - `health` the current health of the hull, from 0 to 100
+    - `health` the last reported health of the hull, from 0 to 100
     - `bulkheads` details of the ship's bulkheads (this is a Module object)
     - `powerplant` details of the ship's powerplant (this is a Module object)
     - `thrusters` details of the ship's thrusters (this is a Module object)
@@ -326,15 +326,15 @@ Any values might be missing, depending on EDDI's configuration.
     - `fueltank` details of the ship's fuel tank (this is a Module object)
     - `fueltankcapacity` the capacity of the main fuel tank
     - `fueltanktotalcapacity` the capacity of the main fuel tank plus all secondary fuel tanks
-    - `maxjump` maximum distance ship has jumped
-    - `maxfuel` fuel used for `max jump` (excluding synthesis)
+    - `maxjumprange` maximum unladen jump range of the ship
+    - `maxfuelperjump` fuel required for `max jump` (excluding synthesis)
     - `hardpoints` the ship's hardpoints (this is an array of HardPoint objects)
     - `compartments` the ship's internal compartments (this is an array of Compartment objects)
     - `launchbays` the ship's internal hangars, containing SRV or Fighter 'vehicles' (this is an array of launchbay objects)
 
 Stored ship information
 
-    - `system` system in which the ship is stored
+    - `starsystem` system in which the ship is stored
     - `station` station in which the ship is stored
     - `marketid` market ID of the station in which the ship is stored
     - `intransit` true if the ship is in transit
@@ -370,7 +370,7 @@ An internal module.
     - `priority` current power priority of the module
     - `position` position of module in 'Modules' panel, according to power usage (highest = 1)
     - `power` power usage, measured in MegaWatts (MW)
-    - `health` current health of the module
+    - `health` last reported health of the module
     - `mount` only for weapons, this defines the type of mount (fixed, gimballed, turreted)
     - `clipcapacity` only for weapons with ammunition, this defines the clip capacity of the loaded weapon
     - `hoppercapacity` only for weapons with ammunition, this defines the hopper capacity of the loaded weapon

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -551,5 +551,33 @@ namespace UnitTests
             Assert.AreEqual(32.000000M, @event2.total);
             Assert.IsTrue(event2.full);
         }
+
+        [TestMethod]
+        public void TestShipJumpedEvent()
+        {
+            // Obtain our ship monitor and save its state
+            ShipMonitor shipMonitor = (ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor");
+            ObservableCollection<Ship> shipyard = shipMonitor.shipyard;
+            PrivateObject privateObject = new PrivateObject(shipMonitor);
+            privateObject.SetFieldOrProperty("updatedAt", DateTime.MinValue);
+
+            // Set up our ship
+            Ship ship = new Ship() { LocalId = 9999, x = 0, y = 0, z = 0 };
+            privateObject.Invoke("RemoveShip", new object[] { 9999 });
+            privateObject.Invoke("AddShip", new object[] { ship });
+
+            // Set up our event
+            string line = @"{ ""timestamp"":""2019-06-30T05:38:53Z"", ""event"":""FSDJump"", ""StarSystem"":""Ogmar"", ""SystemAddress"":84180519395914, ""StarPos"":[-9534.00000,-905.28125,19802.03125], ""SystemAllegiance"":""Independent"", ""SystemEconomy"":""$economy_HighTech;"", ""SystemEconomy_Localised"":""High Tech"", ""SystemSecondEconomy"":""$economy_None;"", ""SystemSecondEconomy_Localised"":""None"", ""SystemGovernment"":""$government_Confederacy;"", ""SystemGovernment_Localised"":""Confederacy"", ""SystemSecurity"":""$SYSTEM_SECURITY_medium;"", ""SystemSecurity_Localised"":""Medium Security"", ""Population"":133000, ""Body"":""Ogmar A"", ""BodyID"":1, ""BodyType"":""Star"", ""JumpDist"":8.625, ""FuelUsed"":0.151982, ""FuelLevel"":31.695932, ""Factions"":[ { ""Name"":""Jaques"", ""FactionState"":""Election"", ""Government"":""Cooperative"", ""Influence"":0.104895, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand1;"", ""Happiness_Localised"":""Elated"", ""MyReputation"":100.000000, ""ActiveStates"":[ { ""State"":""Election"" } ] }, { ""Name"":""Colonia Research Department"", ""FactionState"":""None"", ""Government"":""Cooperative"", ""Influence"":0.078921, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":21.639999, ""RecoveringStates"":[ { ""State"":""Outbreak"", ""Trend"":0 } ] }, { ""Name"":""Pilots' Federation Local Branch"", ""FactionState"":""None"", ""Government"":""Democracy"", ""Influence"":0.000000, ""Allegiance"":""PilotsFederation"", ""Happiness"":"""", ""MyReputation"":100.000000 }, { ""Name"":""Colonia Mining Enterprise"", ""FactionState"":""None"", ""Government"":""Cooperative"", ""Influence"":0.052947, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":100.000000 }, { ""Name"":""Colonia Co-operative"", ""FactionState"":""Election"", ""Government"":""Cooperative"", ""Influence"":0.104895, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":71.470001, ""PendingStates"":[ { ""State"":""Expansion"", ""Trend"":0 } ], ""ActiveStates"":[ { ""State"":""Outbreak"" }, { ""State"":""Election"" } ] }, { ""Name"":""Colonia Agricultural Co-operative"", ""FactionState"":""None"", ""Government"":""Cooperative"", ""Influence"":0.076923, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":6.640000, ""RecoveringStates"":[ { ""State"":""Outbreak"", ""Trend"":0 } ] }, { ""Name"":""GalCop Colonial Defence Commission"", ""FactionState"":""Boom"", ""Government"":""Confederacy"", ""Influence"":0.449550, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":100.000000, ""ActiveStates"":[ { ""State"":""Boom"" } ] }, { ""Name"":""Colonia Tech Combine"", ""FactionState"":""None"", ""Government"":""Cooperative"", ""Influence"":0.090909, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":0.000000, ""RecoveringStates"":[ { ""State"":""Outbreak"", ""Trend"":0 } ] }, { ""Name"":""Milanov's Reavers"", ""FactionState"":""None"", ""Government"":""Anarchy"", ""Influence"":0.040959, ""Allegiance"":""Independent"", ""Happiness"":""$Faction_HappinessBand2;"", ""Happiness_Localised"":""Happy"", ""MyReputation"":0.000000, ""RecoveringStates"":[ { ""State"":""Outbreak"", ""Trend"":0 } ] } ], ""SystemFaction"":{ ""Name"":""GalCop Colonial Defence Commission"", ""FactionState"":""Boom"" }, ""Conflicts"":[ { ""WarType"":""election"", ""Status"":""active"", ""Faction1"":{ ""Name"":""Jaques"", ""Stake"":""Crockett Gateway"", ""WonDays"":1 }, ""Faction2"":{ ""Name"":""Colonia Co-operative"", ""Stake"":"""", ""WonDays"":2 } } ] }";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            JumpedEvent @event = (JumpedEvent)events[0];
+            Assert.IsNotNull(@event);
+            Assert.IsInstanceOfType(@event, typeof(JumpedEvent));
+
+            // Handle the event
+            shipMonitor.PreHandle(@event);
+
+            // Test the result to verify that the distance is calculated relative to the jump coordinates
+            Assert.AreEqual(21996.2981378135M, shipMonitor.GetShip(9999)?.distance);
+        }
     }
 }

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -558,110 +558,107 @@ namespace EddiVoiceAttackResponder
                 Logging.Debug("Setting ship information (" + prefix + ")");
                 try
                 {
-                    vaProxy.SetText(prefix + " manufacturer", ship?.manufacturer);
-                    vaProxy.SetText(prefix + " model", ship?.model);
-                    vaProxy.SetText(prefix + " model (spoken)", ship?.SpokenModel());
+                    vaProxy.SetText(prefix + " manufacturer", ship.manufacturer);
+                    vaProxy.SetText(prefix + " model", ship.model);
+                    vaProxy.SetText(prefix + " model (spoken)", ship.SpokenModel());
 
-                    if (((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor")).GetCurrentShip() != null && EDDI.Instance.Cmdr?.name != null)
+                    if (EDDI.Instance.Cmdr?.name != null)
                     {
-                        vaProxy.SetText(prefix + " callsign", ship == null ? null : ship.manufacturer + " " + EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant());
-                        vaProxy.SetText(prefix + " callsign (spoken)", ship == null ? null : ship.SpokenManufacturer() + " " + Translations.ICAO(EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant()));
+                        vaProxy.SetText(prefix + " callsign", ship.manufacturer + " " + EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant());
+                        vaProxy.SetText(prefix + " callsign (spoken)", ship.SpokenManufacturer() + " " + Translations.ICAO(EDDI.Instance.Cmdr.name.Substring(0, 3).ToUpperInvariant()));
                     }
 
-                    vaProxy.SetText(prefix + " name", ship?.name);
-                    vaProxy.SetText(prefix + " name (spoken)", ship?.phoneticName);
-                    vaProxy.SetText(prefix + " ident", ship?.ident);
-                    vaProxy.SetText(prefix + " ident (spoken)", Translations.ICAO(ship?.ident, false));
-                    vaProxy.SetText(prefix + " role", ship?.Role?.localizedName);
-                    vaProxy.SetText(prefix + " size", ship?.size?.localizedName);
-                    vaProxy.SetDecimal(prefix + " value", ship?.value);
-                    vaProxy.SetText(prefix + " value (spoken)", Translations.Humanize(ship?.value));
-                    vaProxy.SetDecimal(prefix + " hull value", ship?.hullvalue);
-                    vaProxy.SetText(prefix + " hull value (spoken)", Translations.Humanize(ship?.hullvalue));
-                    vaProxy.SetDecimal(prefix + " modules value", ship?.modulesvalue);
-                    vaProxy.SetText(prefix + " modules value (spoken)", Translations.Humanize(ship?.modulesvalue));
-                    vaProxy.SetDecimal(prefix + " rebuy", ship?.rebuy);
-                    vaProxy.SetText(prefix + " rebuy (spoken)", Translations.Humanize(ship?.rebuy));
-                    vaProxy.SetDecimal(prefix + " health", ship?.health);
-                    vaProxy.SetInt(prefix + " cargo capacity", ship?.cargocapacity);
-                    vaProxy.SetBoolean(prefix + " hot", ship?.hot);
+                    vaProxy.SetText(prefix + " name", ship.name);
+                    vaProxy.SetText(prefix + " name (spoken)", ship.phoneticName);
+                    vaProxy.SetText(prefix + " ident", ship.ident);
+                    vaProxy.SetText(prefix + " ident (spoken)", Translations.ICAO(ship.ident, false));
+                    vaProxy.SetText(prefix + " role", ship.Role?.localizedName);
+                    vaProxy.SetText(prefix + " size", ship.size?.localizedName);
+                    vaProxy.SetDecimal(prefix + " value", ship.value);
+                    vaProxy.SetText(prefix + " value (spoken)", Translations.Humanize(ship.value));
+                    vaProxy.SetDecimal(prefix + " hull value", ship.hullvalue);
+                    vaProxy.SetText(prefix + " hull value (spoken)", Translations.Humanize(ship.hullvalue));
+                    vaProxy.SetDecimal(prefix + " modules value", ship.modulesvalue);
+                    vaProxy.SetText(prefix + " modules value (spoken)", Translations.Humanize(ship.modulesvalue));
+                    vaProxy.SetDecimal(prefix + " rebuy", ship.rebuy);
+                    vaProxy.SetText(prefix + " rebuy (spoken)", Translations.Humanize(ship.rebuy));
+                    vaProxy.SetDecimal(prefix + " health", ship.health);
+                    vaProxy.SetInt(prefix + " cargo capacity", ship.cargocapacity);
+                    vaProxy.SetBoolean(prefix + " hot", ship.hot);
 
-                    setShipModuleValues(ship?.bulkheads, prefix + " bulkheads", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.bulkheads, EDDI.Instance.CurrentStation?.outfitting, prefix + " bulkheads", ref vaProxy);
-                    setShipModuleValues(ship?.powerplant, prefix + " power plant", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.powerplant, EDDI.Instance.CurrentStation?.outfitting, prefix + " power plant", ref vaProxy);
-                    setShipModuleValues(ship?.thrusters, prefix + " thrusters", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.thrusters, EDDI.Instance.CurrentStation?.outfitting, prefix + " thrusters", ref vaProxy);
-                    setShipModuleValues(ship?.frameshiftdrive, prefix + " frame shift drive", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.frameshiftdrive, EDDI.Instance.CurrentStation?.outfitting, prefix + " frame shift drive", ref vaProxy);
-                    setShipModuleValues(ship?.lifesupport, prefix + " life support", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.lifesupport, EDDI.Instance.CurrentStation?.outfitting, prefix + " life support", ref vaProxy);
-                    setShipModuleValues(ship?.powerdistributor, prefix + " power distributor", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.powerdistributor, EDDI.Instance.CurrentStation?.outfitting, prefix + " power distributor", ref vaProxy);
-                    setShipModuleValues(ship?.sensors, prefix + " sensors", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.sensors, EDDI.Instance.CurrentStation?.outfitting, prefix + " sensors", ref vaProxy);
-                    setShipModuleValues(ship?.fueltank, prefix + " fuel tank", ref vaProxy);
-                    setShipModuleOutfittingValues(ship?.fueltank, EDDI.Instance.CurrentStation?.outfitting, prefix + " fuel tank", ref vaProxy);
+                    setShipModuleValues(ship.bulkheads, prefix + " bulkheads", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.bulkheads, EDDI.Instance.CurrentStation?.outfitting, prefix + " bulkheads", ref vaProxy);
+                    setShipModuleValues(ship.powerplant, prefix + " power plant", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.powerplant, EDDI.Instance.CurrentStation?.outfitting, prefix + " power plant", ref vaProxy);
+                    setShipModuleValues(ship.thrusters, prefix + " thrusters", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.thrusters, EDDI.Instance.CurrentStation?.outfitting, prefix + " thrusters", ref vaProxy);
+                    setShipModuleValues(ship.frameshiftdrive, prefix + " frame shift drive", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.frameshiftdrive, EDDI.Instance.CurrentStation?.outfitting, prefix + " frame shift drive", ref vaProxy);
+                    setShipModuleValues(ship.lifesupport, prefix + " life support", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.lifesupport, EDDI.Instance.CurrentStation?.outfitting, prefix + " life support", ref vaProxy);
+                    setShipModuleValues(ship.powerdistributor, prefix + " power distributor", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.powerdistributor, EDDI.Instance.CurrentStation?.outfitting, prefix + " power distributor", ref vaProxy);
+                    setShipModuleValues(ship.sensors, prefix + " sensors", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.sensors, EDDI.Instance.CurrentStation?.outfitting, prefix + " sensors", ref vaProxy);
+                    setShipModuleValues(ship.fueltank, prefix + " fuel tank", ref vaProxy);
+                    setShipModuleOutfittingValues(ship.fueltank, EDDI.Instance.CurrentStation?.outfitting, prefix + " fuel tank", ref vaProxy);
 
                     // Special for fuel tank - capacity and total capacity
-                    vaProxy.SetDecimal(prefix + " fuel tank capacity", ship?.fueltankcapacity);
-                    vaProxy.SetDecimal(prefix + " total fuel tank capacity", ship?.fueltanktotalcapacity);
+                    vaProxy.SetDecimal(prefix + " fuel tank capacity", ship.fueltankcapacity);
+                    vaProxy.SetDecimal(prefix + " total fuel tank capacity", ship.fueltanktotalcapacity);
 
                     // Special for max jump range and max fuel per jump
-                    vaProxy.SetDecimal(prefix + " max jump range", ship?.maxjumprange);
-                    vaProxy.SetDecimal(prefix + " max fuel per jump", ship?.maxfuelperjump);
+                    vaProxy.SetDecimal(prefix + " max jump range", ship.maxjumprange);
+                    vaProxy.SetDecimal(prefix + " max fuel per jump", ship.maxfuelperjump);
 
                     // Hardpoints
-                    if (ship != null)
+                    int numTinyHardpoints = 0;
+                    int numSmallHardpoints = 0;
+                    int numMediumHardpoints = 0;
+                    int numLargeHardpoints = 0;
+                    int numHugeHardpoints = 0;
+                    foreach (Hardpoint Hardpoint in ship.hardpoints)
                     {
-                        int numTinyHardpoints = 0;
-                        int numSmallHardpoints = 0;
-                        int numMediumHardpoints = 0;
-                        int numLargeHardpoints = 0;
-                        int numHugeHardpoints = 0;
-                        foreach (Hardpoint Hardpoint in ship.hardpoints)
+                        string baseHardpointName = prefix;
+                        switch (Hardpoint.size)
                         {
-                            string baseHardpointName = prefix;
-                            switch (Hardpoint.size)
-                            {
-                                case 0:
-                                    baseHardpointName = prefix + " tiny hardpoint " + ++numTinyHardpoints;
-                                    break;
-                                case 1:
-                                    baseHardpointName = prefix + " small hardpoint " + ++numSmallHardpoints;
-                                    break;
-                                case 2:
-                                    baseHardpointName = prefix + " medium hardpoint " + ++numMediumHardpoints;
-                                    break;
-                                case 3:
-                                    baseHardpointName = prefix + " large hardpoint " + ++numLargeHardpoints;
-                                    break;
-                                case 4:
-                                    baseHardpointName = prefix + " huge hardpoint " + ++numHugeHardpoints;
-                                    break;
-                            }
-
-                            vaProxy.SetBoolean(baseHardpointName + " occupied", Hardpoint.module != null);
-                            setShipModuleValues(Hardpoint.module, baseHardpointName + " module", ref vaProxy);
-                            setShipModuleOutfittingValues(ship == null ? null : Hardpoint.module, EDDI.Instance.CurrentStation?.outfitting, baseHardpointName + " module", ref vaProxy);
+                            case 0:
+                                baseHardpointName = prefix + " tiny hardpoint " + ++numTinyHardpoints;
+                                break;
+                            case 1:
+                                baseHardpointName = prefix + " small hardpoint " + ++numSmallHardpoints;
+                                break;
+                            case 2:
+                                baseHardpointName = prefix + " medium hardpoint " + ++numMediumHardpoints;
+                                break;
+                            case 3:
+                                baseHardpointName = prefix + " large hardpoint " + ++numLargeHardpoints;
+                                break;
+                            case 4:
+                                baseHardpointName = prefix + " huge hardpoint " + ++numHugeHardpoints;
+                                break;
                         }
-                        vaProxy.SetInt(prefix + " hardpoints", numTinyHardpoints + numSmallHardpoints + numMediumHardpoints + numLargeHardpoints + numHugeHardpoints);
 
-                        // Compartments
-                        int curCompartment = 0;
-                        foreach (Compartment Compartment in ship.compartments)
-                        {
-                            string baseCompartmentName = prefix + " compartment " + ++curCompartment;
-                            vaProxy.SetInt(baseCompartmentName + " size", Compartment.size);
-                            vaProxy.SetBoolean(baseCompartmentName + " occupied", Compartment.module != null);
-                            setShipModuleValues(Compartment.module, baseCompartmentName + " module", ref vaProxy);
-                            setShipModuleOutfittingValues(ship == null ? null : Compartment.module, EDDI.Instance.CurrentStation?.outfitting, baseCompartmentName + " module", ref vaProxy);
-                        }
-                        vaProxy.SetInt(prefix + " compartments", curCompartment);
+                        vaProxy.SetBoolean(baseHardpointName + " occupied", Hardpoint.module != null);
+                        setShipModuleValues(Hardpoint.module, baseHardpointName + " module", ref vaProxy);
+                        setShipModuleOutfittingValues(Hardpoint.module, EDDI.Instance.CurrentStation?.outfitting, baseHardpointName + " module", ref vaProxy);
                     }
+                    vaProxy.SetInt(prefix + " hardpoints", numTinyHardpoints + numSmallHardpoints + numMediumHardpoints + numLargeHardpoints + numHugeHardpoints);
+
+                    // Compartments
+                    int curCompartment = 0;
+                    foreach (Compartment Compartment in ship.compartments)
+                    {
+                        string baseCompartmentName = prefix + " compartment " + ++curCompartment;
+                        vaProxy.SetInt(baseCompartmentName + " size", Compartment.size);
+                        vaProxy.SetBoolean(baseCompartmentName + " occupied", Compartment.module != null);
+                        setShipModuleValues(Compartment.module, baseCompartmentName + " module", ref vaProxy);
+                        setShipModuleOutfittingValues(Compartment.module, EDDI.Instance.CurrentStation?.outfitting, baseCompartmentName + " module", ref vaProxy);
+                    }
+                    vaProxy.SetInt(prefix + " compartments", curCompartment);
 
                     // Fetch the star system in which the ship is stored
-                    if (ship != null && ship.starsystem != null)
+                    if (ship.starsystem != null)
                     {
                         vaProxy.SetText(prefix + " system", ship.starsystem);
                         vaProxy.SetText(prefix + " station", ship.station);

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -576,8 +576,15 @@ namespace EddiVoiceAttackResponder
                     vaProxy.SetText(prefix + " size", ship?.size?.localizedName);
                     vaProxy.SetDecimal(prefix + " value", ship?.value);
                     vaProxy.SetText(prefix + " value (spoken)", Translations.Humanize(ship?.value));
+                    vaProxy.SetDecimal(prefix + " hull value", ship?.hullvalue);
+                    vaProxy.SetText(prefix + " hull value (spoken)", Translations.Humanize(ship?.hullvalue));
+                    vaProxy.SetDecimal(prefix + " modules value", ship?.modulesvalue);
+                    vaProxy.SetText(prefix + " modules value (spoken)", Translations.Humanize(ship?.modulesvalue));
+                    vaProxy.SetDecimal(prefix + " rebuy", ship?.rebuy);
+                    vaProxy.SetText(prefix + " rebuy (spoken)", Translations.Humanize(ship?.rebuy));
                     vaProxy.SetDecimal(prefix + " health", ship?.health);
                     vaProxy.SetInt(prefix + " cargo capacity", ship?.cargocapacity);
+                    vaProxy.SetBoolean(prefix + " hot", ship?.hot);
 
                     setShipModuleValues(ship?.bulkheads, prefix + " bulkheads", ref vaProxy);
                     setShipModuleOutfittingValues(ship?.bulkheads, EDDI.Instance.CurrentStation?.outfitting, prefix + " bulkheads", ref vaProxy);
@@ -638,9 +645,8 @@ namespace EddiVoiceAttackResponder
                             setShipModuleValues(Hardpoint.module, baseHardpointName + " module", ref vaProxy);
                             setShipModuleOutfittingValues(ship == null ? null : Hardpoint.module, EDDI.Instance.CurrentStation?.outfitting, baseHardpointName + " module", ref vaProxy);
                         }
+                        vaProxy.SetInt(prefix + " hardpoints", numTinyHardpoints + numSmallHardpoints + numMediumHardpoints + numLargeHardpoints + numHugeHardpoints);
 
-                        vaProxy.SetInt(prefix + " hardpoints", numSmallHardpoints + numMediumHardpoints + numLargeHardpoints + numHugeHardpoints);
-                        vaProxy.SetInt(prefix + " utility slots", numTinyHardpoints);
                         // Compartments
                         int curCompartment = 0;
                         foreach (Compartment Compartment in ship.compartments)

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -662,23 +662,7 @@ namespace EddiVoiceAttackResponder
                     {
                         vaProxy.SetText(prefix + " system", ship.starsystem);
                         vaProxy.SetText(prefix + " station", ship.station);
-                        StarSystem StoredShipStarSystem = StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(ship.starsystem);
-
-                        // Work out the distance to the system where the ship is stored if we can
-                        // CurrentStarSystem might not have been initialised yet so we check. If not, it may be set on the next pass of the setValues() method.
-                        if (EDDI.Instance.CurrentStarSystem?.x != null & StoredShipStarSystem?.x != null)
-                        {
-                            decimal dx = (EDDI.Instance.CurrentStarSystem.x - StoredShipStarSystem.x) ?? 0M;
-                            decimal dy = (EDDI.Instance.CurrentStarSystem.y - StoredShipStarSystem.y) ?? 0M;
-                            decimal dz = (EDDI.Instance.CurrentStarSystem.z - StoredShipStarSystem.z) ?? 0M;
-                            decimal distance = (decimal)(Math.Sqrt((double)((dx * dx) + (dy * dy) + (dz * dz))));
-                            vaProxy.SetDecimal(prefix + " distance", distance);
-                        }
-                        else
-                        {
-                            // We don't know how far away the ship is
-                            vaProxy.SetDecimal(prefix + " distance", null);
-                        }
+                        vaProxy.SetDecimal(prefix + " distance", ship.distance);
                     }
 
                     setStatus(ref vaProxy, "Operational");

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -87,7 +87,8 @@ EDDI makes a large number of values available to augment your existing scripts. 
   * {BOOL:Status altitude from average radius} true if the altitude is computed relative to the average radius (which is used at higher altitudes) rather than surface directly below the srv
 
 ## Ship Variables
-
+Note: "Tiny" hardpoints are utility slots.
+  * {TXT:Ship manufacturer}: (e.g. "Lakon", "Core Dynamics")
   * {TXT:Ship model}: the model of the ship (e.g. "Cobra Mk", "Fer-de-Lance")
   * {TXT:Ship model (spoken)}: the model of the ship as would be spoken (e.g. "Cobra Mark 4")
   * {TXT:Ship name}: the name of the ship
@@ -100,56 +101,63 @@ EDDI makes a large number of values available to augment your existing scripts. 
   * {TXT:Ship size}: the size of the ship (Small, Medium, or Large)
   * {DEC:Ship value}: the replacement cost of the ship plus modules
   * {TXT:Ship value (spoken)}: the replacement cost of the ship plus modules as would be spoken
+  * {DEC:Ship hull value}: the replacement cost of the ship's hull
+  * {TXT:Ship hull value (spoken)}: the replacement cost of the ship's hull as would be spoken
+  * {DEC:Ship modules value}: the replacement cost of the ship's modules
+  * {TXT:Ship modules value (spoken)}: the replacement cost of the ship's modules as would be spoken
+  * {DEC:Ship rebuy}: the insurance rebuy for the ship in credits
+  * {TXT:Ship rebuy (spoken)}: the insurance rebuy for the ship in credits as would be spoken
   * {INT:Ship cargo capacity}: the maximum cargo capacity of the ship as currently configured
   * {INT:Ship cargo carried}: the cargo currently being carried by the ship
   * {INT:Ship limpets carried}: the number of limpets currently being carried by the ship
-  * {DEC:Ship health}: the percentage health of the ship's hull
+  * {DEC:Ship health}: the last reported percentage health of the ship's hull
+  * {INT:Ship hot}: true if the ship is currently wanted
   * {TXT:Ship bulkheads}: the type of bulkheads fitted to the ship (e.g. "Military Grade Composite")
   * {INT:Ship bulkheads class}: the class of bulkheads fitted to the ship (e.g. 3)
   * {TXT:Ship bulkheads grade}: the grade of bulkheads fitted to the ship (e.g. "A")
-  * {DEC:Ship bulkheads health}: the percentage health of the bulkheads fitted to the ship
+  * {DEC:Ship bulkheads health}: the last reported percentage health of the bulkheads fitted to the ship
   * {DEC:Ship bulkheads cost}: the purchase cost of the bulkheads
   * {DEC:Ship bulkheads value}: the undiscounted cost of the bulkheads
   * {DEC:Ship bulkheads discount}: the percentage discount of the purchased bulkheads against the undiscounted cost
   * {TXT:Ship power plant}: the name of power plant fitted to the ship
   * {INT:Ship power plant class}: the class of bulkheads fitted to the ship (e.g. 3)
   * {TXT:Ship power plant grade}: the grade of bulkheads fitted to the ship (e.g. "A")
-  * {DEC:Ship power plant health}: the percentage health of the power plant fitted to the ship
+  * {DEC:Ship power plant health}: the last reported percentage health of the power plant fitted to the ship
   * {DEC:Ship power plant cost}: the purchase cost of the power plant
   * {DEC:Ship power plant value}: the undiscounted cost of the power plant
   * {DEC:Ship power plant discount}: the percentage discount of the purchased power plant against the undiscounted cost
   * {TXT:Ship thrusters}: the name of thrusters fitted to the ship
   * {INT:Ship thrusters class}: the class of thrusters fitted to the ship (e.g. 3)
   * {TXT:Ship thrusters grade}: the grade of thrusters fitted to the ship (e.g. "A")
-  * {DEC:Ship thrusters health}: the percentage health of the thrusters fitted to the ship
+  * {DEC:Ship thrusters health}: the last reported percentage health of the thrusters fitted to the ship
   * {DEC:Ship thrusters cost}: the purchase cost of the thrusters
   * {DEC:Ship thrusters value}: the undiscounted cost of the thrusters
   * {DEC:Ship thrusters discount}: the percentage discount of the purchased thrusters against the undiscounted cost
   * {TXT:Ship frame shift drive}: the name of frame shift drive fitted to the ship
   * {INT:Ship frame shift drive class}: the class of frame shift drive fitted to the ship (e.g. 3)
   * {TXT:Ship frame shift drive grade}: the grade of frame shift drive fitted to the ship (e.g. "A")
-  * {DEC:Ship frame shift drive health}: the percentage health of the frame shift drive fitted to the ship
+  * {DEC:Ship frame shift drive health}: the last reported percentage health of the frame shift drive fitted to the ship
   * {DEC:Ship frame shift drive cost}: the purchase cost of the frame shift drive
   * {DEC:Ship frame shift drive value}: the undiscounted cost of the frame shift drive
   * {DEC:Ship frame shift drive discount}: the percentage discount of the purchased frame shift drive against the undiscounted cost
   * {TXT:Ship life support}: the name of life support fitted to the ship (e.g. "6D")
   * {INT:Ship life support class}: the class of life support fitted to the ship (e.g. 3)
   * {TXT:Ship life support grade}: the grade of life support fitted to the ship (e.g. "A")
-  * {DEC:Ship life support health}: the percentage health of the life support fitted to the ship
+  * {DEC:Ship life support health}: the last reported percentage health of the life support fitted to the ship
   * {DEC:Ship life support cost}: the purchase cost of the life support
   * {DEC:Ship life support value}: the undiscounted cost of the life support
   * {DEC:Ship life support discount}: the percentage discount of the purchased life support against the undiscounted cost
   * {TXT:Ship power distributor}: the name of power distributor fitted to the ship
   * {INT:Ship power distributor class}: the class of power distributor fitted to the ship (e.g. 3)
   * {TXT:Ship power distributor drive grade}: the grade of power distributor fitted to the ship (e.g. "A")
-  * {DEC:Ship power distributor health}: the percentage health of the power distributor fitted to the ship
+  * {DEC:Ship power distributor health}: the last reported percentage health of the power distributor fitted to the ship
   * {DEC:Ship power distributor cost}: the purchase cost of the power distributor
   * {DEC:Ship power distributor value}: the undiscounted cost of the power distributor
   * {DEC:Ship power distributor discount}: the percentage discount of the purchased power distributor against the undiscounted cost
   * {TXT:Ship sensors}: the name of sensors fitted to the ship
   * {INT:Ship sensors class}: the class of sensors fitted to the ship (e.g. 3)
   * {TXT:Ship sensors drive grade}: the grade of sensors fitted to the ship (e.g. "A")
-  * {DEC:Ship sensors health}: the percentage health of the sensors fitted to the ship
+  * {DEC:Ship sensors health}: the last reported percentage health of the sensors fitted to the ship
   * {DEC:Ship sensors cost}: the purchase cost of the sensors
   * {DEC:Ship sensors value}: the undiscounted cost of the sensors
   * {DEC:Ship sensors discount}: the percentage discount of the purchased sensors against the undiscounted cost
@@ -165,19 +173,26 @@ EDDI makes a large number of values available to augment your existing scripts. 
   * {TXT:Ship tiny/small/medium/large/huge hardpoint *n* module}: the name of the module in this slot
   * {INT:Ship tiny/small/medium/large/huge hardpoint *n* module class}: the class of the module in this slot
   * {TXT:Ship tiny/small/medium/large/huge hardpoint *n* module grade}: the grade of the module in this slot
-  * {DEC:Ship tiny/small/medium/large/huge hardpoint *n* module health}: the percentage health of the module in this slot
+  * {DEC:Ship tiny/small/medium/large/huge hardpoint *n* module health}: the last reported percentage health of the module in this slot
   * {DEC:Ship tiny/small/medium/large/huge hardpoint *n* module cost}: the purchase cost of the module in this slot
   * {DEC:Ship tiny/small/medium/large/huge hardpoint *n* module value}: the undiscounted cost of the module in this slot
   * {DEC:Ship tiny/small/medium/large/huge hardpoint *n* module discount}: the percentage discount of the purchased module against the undiscounted cost
+  * {INT:Ship hardpoints} the total number of filled hardpoints slots (to use when looping through hardpoint data)
   * {INT:Ship Compartment *n* size}: the size of this slot
   * {BOOL:Ship Compartment *n* occupied}: true if there is a module in this slot, otherwise false
   * {TXT:Ship compartment *n* module}: the name of the module in this slot
   * {INT:Ship compartment *n* module class}: the class of the module in this slot
   * {TXT:Ship compartment *n* module grade}: the grade of the module in this slot
-  * {DEC:Ship compartment *n* module health}: the percentage health of the module in this slot
+  * {DEC:Ship compartment *n* module health}: the last reported percentage health of the module in this slot
   * {DEC:Ship compartment *n* module cost}: the purchase cost of the module in this slot
   * {DEC:Ship compartment *n* module value}: the undiscounted cost of the module in this slot
   * {DEC:Ship compartment *n* module station cost}: the purchase cost of the module at this station
+  * {INT:Ship compartments} the total number of filled compartment slots (to use when looping through compartment data)
+
+### Stored ship variables
+  * {TXT:Ship system}: the name of the star system where the ship is stored
+  * {TXT:Ship station}: the name of the station where the ship is stored
+  * {DEC:Ship distance}: the distance to the star system where the ship is stored
 
 ## Current System Variables
 


### PR DESCRIPTION
Resolves #1724.
Update docs for `ship` Cottle variables:
- Health of ship and modules are "last reported" rather than "current"
- Prefer "maxjumprange" over obsolete "maxjump"
- Prefer "maxfuelperjump" over obsolete "maxfuel"
- Prefer "starsystem" over obsolete "system"
Update docs for `ship` VoiceAttack variables to:
- Match variables available to Cottle.
- Add helper variables with hardpoint and compartment counts (for use in VoiceAttack commands which loop through filled modules data).
Replace inefficient calculation of ship distances in the VoiceAttackResponder:
- Replaces inefficient code which deserialized multiple star systems on the VoiceAttack event handler thread to obtain coordinates for stored ships. Ship distances are now either updated during `Location` and `Jumped` events (referencing coordinates set when the ships are stored) or updated from the Frontier API (which is on a separate and non-blocking thread). 
- Distance information is now made equally available to both Cottle and VoiceAttack.