### PR TITLE
EDSM credentials

### DIFF
--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -158,7 +158,7 @@ namespace EddiDataProviderService
         // EDSM flight log synchronization (named star systems)
         public List<StarSystem> syncFromStarMapService(List<StarSystem> starSystems)
         {
-            if (edsmService != null && starSystems.Count > 0)
+            if (edsmService != null && edsmService.EdsmCredentialsSet() && starSystems.Count > 0)
             {
                 try
                 {

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -208,12 +208,6 @@ namespace Eddi
                     if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.Authorized)
                     {
                         Logging.Info("EDDI access to the Frontier API is enabled.");
-                        // Pass our commander's Frontier API name to the StarMapService (if it has been set) 
-                        // (the Frontier API name may differ from the EDSM name)
-                        if (Cmdr?.name != null)
-                        {
-                            StarMapService.commanderFrontierApiName = Cmdr.name;
-                        }
                     }
                     else
                     {
@@ -1841,7 +1835,11 @@ namespace Eddi
         private bool eventCommanderLoading(CommanderLoadingEvent theEvent) 
         {
             // Set our commander name and ID
-            Cmdr.name = theEvent.name;
+            if (Cmdr.name != theEvent.name)
+            {
+                Cmdr.name = theEvent.name;
+                ObtainResponder("EDSM Responder").Reload();
+            }
             Cmdr.EDID = theEvent.frontierID;
             return true;
         }
@@ -1872,7 +1870,11 @@ namespace Eddi
             inCQC = false;
 
             // Set our commander name and ID
-            Cmdr.name = theEvent.commander;
+            if (Cmdr.name != theEvent.commander)
+            {
+                Cmdr.name = theEvent.commander;
+                ObtainResponder("EDSM Responder").Reload();
+            }
             Cmdr.EDID = theEvent.frontierID;
 
             // Set game version

--- a/EDSMResponder/EDSMResponder.cs
+++ b/EDSMResponder/EDSMResponder.cs
@@ -66,9 +66,10 @@ namespace EddiEdsmResponder
             if (edsmService != null)
             {
                 // Renew our credentials for the EDSM API
+                StarMapService.inGameCommanderName = EDDI.Instance.Cmdr.name;
                 edsmService.SetEdsmCredentials();
 
-                if (updateThread == null)
+                if (updateThread == null && edsmService.EdsmCredentialsSet())
                 {
                     // Spin off a thread to download & sync flight logs & system comments from EDSM in the background 
                     updateThread = new Thread(() => dataProviderService.syncFromStarMapService(StarMapConfiguration.FromFile()?.lastSync))

--- a/StarMapService/IEdsmService.cs
+++ b/StarMapService/IEdsmService.cs
@@ -9,6 +9,7 @@ namespace EddiStarMapService
         void sendEvent(string eventData);
         void sendStarMapComment(string systemName, string comment);
         void SetEdsmCredentials();
+        bool EdsmCredentialsSet();
         Dictionary<string, string> getStarMapComments();
         List<Body> GetStarMapBodies(string system, long? edsmId = null);
         List<StarMapResponseLogEntry> getStarMapLog(DateTime? since = null, string[] systemNames = null);

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -25,7 +25,7 @@ namespace EddiStarMapService
         // The default timeout for requests to EDSM. Requests can override this by setting `RestRequest.Timeout`. Both are in milliseconds.
         private const int DefaultTimeoutMilliseconds = 10000;
 
-        public static string commanderFrontierApiName { get; set; }
+        public static string inGameCommanderName { get; set; }
 
         private string commanderName { get; set; }
         private string apiKey { get; set; }
@@ -65,7 +65,7 @@ namespace EddiStarMapService
             if (!string.IsNullOrEmpty(starMapCredentials?.apiKey))
             {
                 // Commander name might come from EDSM credentials or from the game and companion app
-                string cmdrName = starMapCredentials.commanderName ?? commanderFrontierApiName;
+                string cmdrName = starMapCredentials.commanderName ?? inGameCommanderName;
                 if (!string.IsNullOrEmpty(cmdrName))
                 {
                     apiKey = starMapCredentials.apiKey?.Trim();
@@ -82,7 +82,7 @@ namespace EddiStarMapService
             }
         }
 
-        private bool EdsmCredentialsSet()
+        public bool EdsmCredentialsSet()
         {
             return !string.IsNullOrEmpty(commanderName) && !string.IsNullOrEmpty(apiKey);
         }


### PR DESCRIPTION
Utilize our events rather than the Frontier API to set the EDSM commander name when it is not set. Do not continually request data from the EDSM service while credentials are unconfigured.
Since the 
Resolves #1720.