### PR TITLE
Inara Update

### DIFF
--- a/CompanionAppService/CompanionAppAuthenticationException.cs
+++ b/CompanionAppService/CompanionAppAuthenticationException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace EddiCompanionAppService
 {
@@ -9,5 +10,11 @@ namespace EddiCompanionAppService
         public EliteDangerousCompanionAppAuthenticationException() : base() { }
 
         public EliteDangerousCompanionAppAuthenticationException(string message) : base(message) { }
+
+        public EliteDangerousCompanionAppAuthenticationException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected EliteDangerousCompanionAppAuthenticationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
     }
 }

--- a/CompanionAppService/CompanionAppErrorException.cs
+++ b/CompanionAppService/CompanionAppErrorException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace EddiCompanionAppService
 {
@@ -9,5 +10,11 @@ namespace EddiCompanionAppService
         public EliteDangerousCompanionAppErrorException() : base() { }
 
         public EliteDangerousCompanionAppErrorException(string message) : base(message) { }
+
+        public EliteDangerousCompanionAppErrorException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected EliteDangerousCompanionAppErrorException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
     }
 }

--- a/CompanionAppService/CompanionAppException.cs
+++ b/CompanionAppService/CompanionAppException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace EddiCompanionAppService
 {
@@ -9,5 +10,11 @@ namespace EddiCompanionAppService
         public EliteDangerousCompanionAppException() : base() { }
 
         public EliteDangerousCompanionAppException(string message) : base(message) { }
+
+        public EliteDangerousCompanionAppException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected EliteDangerousCompanionAppException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
     }
 }

--- a/CompanionAppService/CompanionIllegalStateException.cs
+++ b/CompanionAppService/CompanionIllegalStateException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace EddiCompanionAppService
 {
@@ -9,5 +10,11 @@ namespace EddiCompanionAppService
         public EliteDangerousCompanionAppIllegalStateException() : base() { }
 
         public EliteDangerousCompanionAppIllegalStateException(string message) : base(message) { }
+
+        public EliteDangerousCompanionAppIllegalStateException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected EliteDangerousCompanionAppIllegalStateException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
     }
 }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -220,11 +220,6 @@ namespace Eddi
                         Logging.Info("EDDI access to the Frontier API is not enabled.");
                     }
                 });
-                Task.Run(() =>
-                {
-                    // Set up the Inara service
-                    EddiInaraService.InaraService.Start(gameIsBeta, EddiIsBeta());
-                });
 
                 // Make sure that our essential tasks have completed before we start
                 Task.WaitAll(essentialAsyncTasks.ToArray());

--- a/EddiInaraService/EddiInaraService.csproj
+++ b/EddiInaraService/EddiInaraService.csproj
@@ -48,6 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InaraAuthenticationException.cs" />
+    <Compile Include="InaraErrorException.cs" />
+    <Compile Include="InaraException.cs" />
     <Compile Include="InaraAPICmdrProfile.cs" />
     <Compile Include="InaraAPIEvent.cs" />
     <Compile Include="InaraCmdr.cs" />

--- a/EddiInaraService/EddiInaraService.csproj
+++ b/EddiInaraService/EddiInaraService.csproj
@@ -56,6 +56,7 @@
     <Compile Include="InaraAPIEvent.cs" />
     <Compile Include="InaraCmdr.cs" />
     <Compile Include="InaraService.cs" />
+    <Compile Include="IInaraService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="InaraConfiguration.cs" />
   </ItemGroup>

--- a/EddiInaraService/EddiInaraService.csproj
+++ b/EddiInaraService/EddiInaraService.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InaraTooManyRequestsException.cs" />
     <Compile Include="InaraAuthenticationException.cs" />
     <Compile Include="InaraErrorException.cs" />
     <Compile Include="InaraException.cs" />

--- a/EddiInaraService/IInaraService.cs
+++ b/EddiInaraService/IInaraService.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+
+namespace EddiInaraService
+{
+    public interface IInaraService
+    {
+        // Variables
+        string commanderName { get; }
+        string commanderFrontierID { get; }
+        DateTime lastSync { get; }
+
+        // Background Sync
+        void Start(bool gameIsBeta = false, bool eddiIsBeta = false);
+        void Stop();
+
+        // API Event Queue Management
+        void EnqueueAPIEvent(InaraAPIEvent inaraAPIEvent);
+        void SendQueuedAPIEvents();
+        List<InaraResponse> SendEventBatch(ref List<InaraAPIEvent> events, bool sendEvenForBetaGame = false);
+
+        // Commander Profiles
+        InaraCmdr GetCommanderProfile(string cmdrName);
+        List<InaraCmdr> GetCommanderProfiles(string[] cmdrNames);
+    }
+}

--- a/EddiInaraService/IInaraService.cs
+++ b/EddiInaraService/IInaraService.cs
@@ -17,7 +17,6 @@ namespace EddiInaraService
 
         // API Event Queue Management
         void EnqueueAPIEvent(InaraAPIEvent inaraAPIEvent);
-        void SendQueuedAPIEvents();
         List<InaraResponse> SendEventBatch(ref List<InaraAPIEvent> events, bool sendEvenForBetaGame = false);
 
         // Commander Profiles

--- a/EddiInaraService/InaraAuthenticationException.cs
+++ b/EddiInaraService/InaraAuthenticationException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EddiInaraService  
+{
+    /// <summary>Exceptions thrown due to authentication errors</summary>
+    [Serializable]
+    public class InaraAuthenticationException : InaraException
+    {
+        public InaraAuthenticationException() : base() { }
+
+        public InaraAuthenticationException(string message) : base(message) { }
+
+        public InaraAuthenticationException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected InaraAuthenticationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
+}

--- a/EddiInaraService/InaraConfiguration.cs
+++ b/EddiInaraService/InaraConfiguration.cs
@@ -20,14 +20,16 @@ namespace EddiInaraService
         [JsonProperty("lastSync")]
         public DateTime lastSync { get; set; }
 
-        [JsonProperty("validAPIkey")]
-        public bool validAPIkey { get; set; } = true;
+        [JsonProperty("isAPIkeyValid")]
+        public bool isAPIkeyValid { get; set; } = true;
 
         [JsonIgnore]
         private string dataPath;
 
         [JsonIgnore]
         static readonly object fileLock = new object();
+
+        public static EventHandler ConfigurationUpdated;
 
         /// <summary>
         /// Obtain credentials from a file.  If the file name is not supplied the the default
@@ -96,6 +98,9 @@ namespace EddiInaraService
             {
                 Files.Write(filename, json);
             }
+
+            // Communicate the updated configuration to all subscribed processes
+            ConfigurationUpdated?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/EddiInaraService/InaraConfiguration.cs
+++ b/EddiInaraService/InaraConfiguration.cs
@@ -20,6 +20,9 @@ namespace EddiInaraService
         [JsonProperty("lastSync")]
         public DateTime lastSync { get; set; }
 
+        [JsonProperty("validAPIkey")]
+        public bool validAPIkey { get; set; } = true;
+
         [JsonIgnore]
         private string dataPath;
 

--- a/EddiInaraService/InaraErrorException.cs
+++ b/EddiInaraService/InaraErrorException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EddiInaraService
+{
+    /// <summary>Exceptions thrown due to API errors</summary>
+    [Serializable]
+    public class InaraErrorException : InaraException
+    {
+        public InaraErrorException() : base() { }
+
+        public InaraErrorException(string message) : base(message) { }
+
+        public InaraErrorException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected InaraErrorException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
+}

--- a/EddiInaraService/InaraException.cs
+++ b/EddiInaraService/InaraException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EddiInaraService
+{
+    /// <summary>Base class for exceptions thrown by Inara API</summary>
+    [Serializable]
+    public class InaraException : Exception
+    {
+        public InaraException() : base() { }
+
+        public InaraException(string message) : base(message) { }
+
+        public InaraException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected InaraException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
+}

--- a/EddiInaraService/InaraService.cs
+++ b/EddiInaraService/InaraService.cs
@@ -181,6 +181,14 @@ namespace EddiInaraService
                 {
                     // 400 - Error (you probably did something wrong, there are properties missing, etc. The event was skipped or whole batch cancelled on failed authorization.)
                     Logging.Error("Inara responded with: " + inaraResponse.eventStatusText, JsonConvert.SerializeObject(data));
+                    if (inaraResponse.eventStatusText == "Invalid API key.")
+                    {
+                        throw new InaraAuthenticationException(inaraResponse.eventStatusText);
+                    }
+                    else
+                    {
+                        throw new InaraErrorException(inaraResponse.eventStatusText);
+                    }
                 }
                 else
                 {

--- a/EddiInaraService/InaraService.cs
+++ b/EddiInaraService/InaraService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Utilities;
@@ -43,6 +44,7 @@ namespace EddiInaraService
         }
 
         // Methods
+        [SuppressMessage("ReSharper", "ConvertClosureToMethodGroup")]
         public void Start(bool gameIsBeta = false, bool eddiIsBeta = false)
         {
             // Set up the Inara service credentials
@@ -55,12 +57,12 @@ namespace EddiInaraService
                 || backgroundSync.Status == TaskStatus.RanToCompletion)
             {
                 Logging.Debug("Starting Inara service background sync.");
-                backgroundSync = Task.Run(BackgroundSync);
+                backgroundSync = Task.Run(() => BackgroundSync());
             }
             else if (backgroundSync.Status == TaskStatus.Faulted)
             {
                 Logging.Debug("Restarting Inara service background sync.");
-                backgroundSync = Task.Run(BackgroundSync);
+                backgroundSync = Task.Run(() => BackgroundSync());
             }
         }
 

--- a/EddiInaraService/InaraService.cs
+++ b/EddiInaraService/InaraService.cs
@@ -202,7 +202,7 @@ namespace EddiInaraService
             }
         }
 
-        public async void SendQueuedAPIEventsAsync()
+        public async Task SendQueuedAPIEventsAsync()
         {
             List<InaraAPIEvent> queue = new List<InaraAPIEvent>();
             while (Instance.queuedAPIEvents.TryDequeue(out InaraAPIEvent pendingEvent))

--- a/EddiInaraService/InaraTooManyRequestsException.cs
+++ b/EddiInaraService/InaraTooManyRequestsException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EddiInaraService  
+{
+    /// <summary>Exceptions thrown due to authentication errors</summary>
+    [Serializable]
+    public class InaraTooManyRequestsException : InaraException
+    {
+        public InaraTooManyRequestsException() : base() { }
+
+        public InaraTooManyRequestsException(string message) : base(message) { }
+
+        public InaraTooManyRequestsException(string message, Exception innerException) : base(message, innerException)
+        { }
+
+        protected InaraTooManyRequestsException(SerializationInfo info, StreamingContext context) : base(info, context)
+        { }
+    }
+}

--- a/InaraResponder/ConfigurationWindow.xaml
+++ b/InaraResponder/ConfigurationWindow.xaml
@@ -23,7 +23,7 @@
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Margin="-5,5" Text="{x:Static resx:InaraResources.p1}"/>
             <Label Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Content="{x:Static resx:InaraResources.api_key_label}"/>
-            <TextBox x:Name="inaraApiKeyTextBox" Grid.Row="1" Grid.Column="1" Margin="0, 5" Height="25" VerticalContentAlignment="Center" TextChanged="inaraApiKeyChanged"/>
+            <TextBox x:Name="inaraApiKeyTextBox" Text="{Binding Path=apiKey, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1" Margin="0, 5" Height="25" VerticalContentAlignment="Center" TextChanged="InaraApiKeyChanged"/>
             <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" TextWrapping="Wrap" Margin="-5,5" Text="{x:Static resx:InaraResources.p2}"/>
         </Grid>
     </DockPanel>

--- a/InaraResponder/ConfigurationWindow.xaml.cs
+++ b/InaraResponder/ConfigurationWindow.xaml.cs
@@ -1,36 +1,130 @@
-﻿using Eddi;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using EddiInaraService;
+using System.Timers;
 using System.Windows.Controls;
 
 namespace EddiInaraResponder
 {
-    /// <summary>
-    /// Interaction logic for ConfigurationWindow.xaml
-    /// </summary>
-    public partial class ConfigurationWindow : UserControl
+    /// <summary> Interaction logic for ConfigurationWindow.xaml </summary>
+    public partial class ConfigurationWindow : UserControl, INotifyPropertyChanged, INotifyDataErrorInfo
     {
+        // Set up a timer... wait 3 seconds before reconfiguring the InaraService for any change in the API key
+        private const int delayMilliseconds = 3000;
+        private readonly Timer inputTimer = new Timer(delayMilliseconds);
+
+        public string apiKey
+        {
+            get => _apiKey;
+            set
+            {
+                OnPropertyChanged();
+                _apiKey = value;
+            }
+        }
+        private string _apiKey;
+
         public ConfigurationWindow()
         {
+            // Subscribe to events that require our attention
+            InaraConfiguration.ConfigurationUpdated += (s, e) => { OnConfigurationUpdated((InaraConfiguration)s); };
+            inputTimer.Elapsed += InputTimer_Elapsed;
+
+            DataContext = this;
             InitializeComponent();
 
             InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
             inaraApiKeyTextBox.Text = inaraConfiguration.apiKey;
+            SetAPIKeyValidity(inaraConfiguration.isAPIkeyValid);
         }
 
-        private void inaraApiKeyChanged(object sender, TextChangedEventArgs e)
+        private void InaraApiKeyChanged(object sender, TextChangedEventArgs e)
         {
-            updateInaraConfiguration();
+            if (sender is TextBox textBox)
+            {
+                if (textBox.IsLoaded && textBox.Name == "inaraApiKeyTextBox")
+                {
+                    SetAPIKeyValidity(true);
+                    inputTimer.Stop();
+                    inputTimer.Start();
+                }
+            }
         }
 
-        private void updateInaraConfiguration()
+        private void InputTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        {
+            inputTimer.Stop();
+            UpdateConfiguration();
+        }
+
+        private void UpdateConfiguration()
         {
             InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
-            if (!string.IsNullOrWhiteSpace(inaraApiKeyTextBox.Text))
-            {
-                inaraConfiguration.apiKey = inaraApiKeyTextBox.Text.Trim();
-            }
+
+            // Reset API key validity when it is edited.
+            inaraConfiguration.isAPIkeyValid = true;
+
+            // Update the changed API key in our configuration
+            inaraConfiguration.apiKey = apiKey;
+
+            // Save and reload
             inaraConfiguration.ToFile();
-            EDDI.Instance.Reload("Inara responder");
+        }
+
+        private void OnConfigurationUpdated(InaraConfiguration inaraConfiguration)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                SetAPIKeyValidity(inaraConfiguration.isAPIkeyValid);
+            });
+
+        }
+
+        private void SetAPIKeyValidity(bool isAPIkeyValid)
+        {
+            if (isAPIkeyValid)
+            {
+                ClearErrors(nameof(apiKey));
+            }
+            else
+            {
+                ReportError(nameof(apiKey), Properties.InaraResources.invalidKeyErr);
+            }
+            inaraApiKeyTextBox.Text = apiKey; // Forces validation to update
+        }
+
+        // Implement INotifyDataErrorInfo for validation
+        public void ReportError(string propertyName, string errorMessage)
+        {
+            if (string.IsNullOrEmpty(propertyName)) { return; }
+            if (!Errors.ContainsKey(propertyName)) { Errors.Add(propertyName, new List<string>()); }
+            Errors[propertyName].Add(errorMessage);
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+        public IEnumerable GetErrors(string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName) || (!HasErrors)) { return null; }
+            if (!Errors.ContainsKey(propertyName)) { Errors.Add(propertyName, new List<string>()); }
+            return Errors[propertyName];
+        }
+        public void ClearErrors(string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName) || (!HasErrors)) { return; }
+            if (Errors.ContainsKey(propertyName)) { Errors.Remove(propertyName); }
+            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+        private readonly Dictionary<string, List<string>> Errors = new Dictionary<string, List<string>>();
+        public bool HasErrors => Errors.Count > 0;
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+        // Implement INotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null) 
+        { 
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)); 
         }
     }
 }

--- a/InaraResponder/EddiInaraResponder.csproj
+++ b/InaraResponder/EddiInaraResponder.csproj
@@ -92,6 +92,10 @@
       <Project>{5294706E-E600-4EA1-B904-66A41561E852}</Project>
       <Name>EddiShipMonitor</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SpeechService\EddiSpeechService.csproj">
+      <Project>{19572a69-c13a-459d-ab72-2b0f034ac27f}</Project>
+      <Name>EddiSpeechService</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Utilities\Utilities.csproj">
       <Project>{cd71dd2a-86ac-44a8-959b-e1c3069966bd}</Project>
       <Name>Utilities</Name>
@@ -108,6 +112,7 @@
     <EmbeddedResource Include="Properties\InaraResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>InaraResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\InaraResources.ru.resx" />
   </ItemGroup>

--- a/InaraResponder/InaraResponder.cs
+++ b/InaraResponder/InaraResponder.cs
@@ -1468,7 +1468,28 @@ namespace EddiInaraResponder
 
         private void SendQueuedAPIEventsAsync()
         {
-            InaraService.Instance.SendQueuedAPIEventsAsync();
+            try
+            {
+                InaraService.Instance.SendQueuedAPIEventsAsync();
+            }
+            catch (InaraException e)
+            {
+                if (e is InaraAuthenticationException)
+                {
+                    InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
+                    inaraConfiguration.validAPIkey = false;
+                    inaraConfiguration.ToFile();
+
+                    // TODO:
+                    // Verbally alert the user that the API key is invalid,
+                    // cease processing journal events until the API key is altered,
+                    // update the UI with a visual indicator that the API key is invalid
+                }
+                else
+                {
+                    // TODO: TBD
+                }
+            }
         }
 
         private void OnApplicationExit(object sender, EventArgs e)

--- a/InaraResponder/InaraResponder.cs
+++ b/InaraResponder/InaraResponder.cs
@@ -58,13 +58,13 @@ namespace EddiInaraResponder
 
         public void Stop()
         {
-            inaraService = null;
+            inaraService.Stop();
         }
 
         public void Reload()
         {
             Stop();
-            inaraService.Start();
+            inaraService.Start(EDDI.Instance.gameIsBeta, EDDI.Instance.EddiIsBeta());
         }
 
         private void OnConfigurationUpdated(InaraConfiguration inaraConfiguration)
@@ -1305,27 +1305,25 @@ namespace EddiInaraResponder
 
         private void handleCommanderStartedEvent(CommanderStartedEvent @event)
         {
-            // Start or restart the Inara service
-            InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
-            inaraConfiguration.commanderName = @event.name;
-            inaraConfiguration.commanderFrontierID = @event.frontierID;
-            inaraConfiguration.ToFile();
-            if (inaraConfiguration.commanderFrontierID != inaraService.commanderFrontierID)
+            // Updating the configuration will restart the Inara service
+            if (inaraService.commanderName != @event.name || inaraService.commanderFrontierID != @event.frontierID)
             {
-                inaraService.Start(EDDI.Instance.gameIsBeta, EDDI.Instance.EddiIsBeta());
+                InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
+                inaraConfiguration.commanderName = @event.name;
+                inaraConfiguration.commanderFrontierID = @event.frontierID;
+                inaraConfiguration.ToFile();
             }
         }
 
         private void handleCommanderLoadingEvent(CommanderLoadingEvent @event)
         {
-            // Start or restart the Inara service
-            InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
-            inaraConfiguration.commanderName = @event.name;
-            inaraConfiguration.commanderFrontierID = @event.frontierID;
-            inaraConfiguration.ToFile();
-            if (inaraConfiguration.commanderFrontierID != inaraService.commanderFrontierID)
+            // Updating the configuration will restart the Inara service
+            if (inaraService.commanderName != @event.name || inaraService.commanderFrontierID != @event.frontierID)
             {
-                inaraService.Start(EDDI.Instance.gameIsBeta, EDDI.Instance.EddiIsBeta());
+                InaraConfiguration inaraConfiguration = InaraConfiguration.FromFile();
+                inaraConfiguration.commanderName = @event.name;
+                inaraConfiguration.commanderFrontierID = @event.frontierID;
+                inaraConfiguration.ToFile();
             }
         }
 

--- a/InaraResponder/Properties/InaraResources.Designer.cs
+++ b/InaraResponder/Properties/InaraResources.Designer.cs
@@ -70,11 +70,20 @@ namespace EddiInaraResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Send details of your travels to Inara (https://inara.cz). Inara is a third party tool that provides provides information on Pilots Federation members and generates a shareable profile detailing your own status and achievements. .
+        ///   Looks up a localized string similar to Send details of your travels to Inara (https://inara.cz). Inara is a third party tool that provides information on Pilots Federation members and generates a shareable profile detailing your own status and achievements. .
         /// </summary>
         public static string desc {
             get {
                 return ResourceManager.GetString("desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Inara API key appears to be invalid; no data shall be sent..
+        /// </summary>
+        public static string inaraAPIerr {
+            get {
+                return ResourceManager.GetString("inaraAPIerr", resourceCulture);
             }
         }
         

--- a/InaraResponder/Properties/InaraResources.Designer.cs
+++ b/InaraResponder/Properties/InaraResources.Designer.cs
@@ -79,11 +79,11 @@ namespace EddiInaraResponder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Inara API key appears to be invalid; no data shall be sent..
+        ///   Looks up a localized string similar to Please enter a valid Inara API key..
         /// </summary>
-        public static string inaraAPIerr {
+        public static string invalidKeyErr {
             get {
-                return ResourceManager.GetString("inaraAPIerr", resourceCulture);
+                return ResourceManager.GetString("invalidKeyErr", resourceCulture);
             }
         }
         

--- a/InaraResponder/Properties/InaraResources.resx
+++ b/InaraResponder/Properties/InaraResources.resx
@@ -132,7 +132,7 @@
   <data name="p2" xml:space="preserve">
     <value>Once you have entered your API key, EDDI will begin to transmit game session data to Inara.</value>
   </data>
-  <data name="inaraAPIerr" xml:space="preserve">
-    <value>The Inara API key appears to be invalid; no data shall be sent.</value>
+  <data name="invalidKeyErr" xml:space="preserve">
+    <value>Please enter a valid Inara API key.</value>
   </data>
 </root>

--- a/InaraResponder/Properties/InaraResources.resx
+++ b/InaraResponder/Properties/InaraResources.resx
@@ -132,4 +132,7 @@
   <data name="p2" xml:space="preserve">
     <value>Once you have entered your API key, EDDI will begin to transmit game session data to Inara.</value>
   </data>
+  <data name="inaraAPIerr" xml:space="preserve">
+    <value>The Inara API key appears to be invalid; no data shall be sent.</value>
+  </data>
 </root>

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -1152,7 +1152,8 @@ namespace EddiSpeechResponder
                 {
                     if (!string.IsNullOrWhiteSpace(commanderName))
                     {
-                        var result = EddiInaraService.InaraService.Instance.GetCommanderProfile(commanderName);
+                        EddiInaraService.IInaraService inaraService = new EddiInaraService.InaraService();
+                        var result = inaraService.GetCommanderProfile(commanderName);
                         return new ReflectionValue(result ?? new object());
                     }
                 }

--- a/Tests/InaraTests.cs
+++ b/Tests/InaraTests.cs
@@ -9,10 +9,13 @@ namespace IntegrationTests
     [TestClass]
     public class InaraTests : TestBase
     {
+        private IInaraService inaraService;
+
         [TestInitialize]
         public void start()
         {
             MakeSafe();
+            inaraService = new InaraService();
         }
 
         [TestMethod]
@@ -23,7 +26,7 @@ namespace IntegrationTests
                 { new InaraAPIEvent(DateTime.UtcNow, "getCommanderProfile", new Dictionary<string, object>() { { "searchName", "No such name" } })},
                 { new InaraAPIEvent(DateTime.UtcNow, "getCommanderProfile", new Dictionary<string, object>() { { "searchName", "Artie" } })}
             };
-            List<InaraResponse> responses = InaraService.Instance.SendEventBatch(ref inaraAPIEvents, sendEvenForBetaGame: true);
+            List<InaraResponse> responses = inaraService.SendEventBatch(ref inaraAPIEvents, sendEvenForBetaGame: true);
 
             // Check that appropriate response IDs were assigned to each API event
             Assert.AreEqual(0, inaraAPIEvents[0].eventCustomID);
@@ -37,8 +40,7 @@ namespace IntegrationTests
         [TestMethod]
         public void TestGetCmdrProfiles()
         {
-            List<InaraCmdr> inaraCmdrs = InaraService.Instance
-                .GetCommanderProfiles(new string[] { "No such name", "Artie" });
+            List<InaraCmdr> inaraCmdrs = inaraService.GetCommanderProfiles(new string[] { "No such name", "Artie" });
             Assert.AreEqual(1, inaraCmdrs.Count);
             Assert.AreEqual("Artie", inaraCmdrs[0].username);
             Assert.AreEqual(1, inaraCmdrs[0].id);

--- a/VoiceAttackResponder/VoiceAttackPlugin.cs
+++ b/VoiceAttackResponder/VoiceAttackPlugin.cs
@@ -431,10 +431,11 @@ namespace EddiVoiceAttackResponder
             }
             try
             {
-                var profile = EddiInaraService.InaraService.Instance.GetCommanderProfile(commanderName);
-                if (profile != null)
+                EddiInaraService.IInaraService inaraService = new EddiInaraService.InaraService();
+                var result = inaraService.GetCommanderProfile(commanderName);
+                if (result != null)
                 {
-                    OpenOrStoreURI(ref vaProxy, profile.url);
+                    OpenOrStoreURI(ref vaProxy, result.url);
                 }
                 else
                 {


### PR DESCRIPTION
Alerts users when Inara credentials are invalid (both with a spoken and visible response). Ceases sending Inara data until credentials are updated. 
Also...
- Add Inara exception classes and update CompanionApp exception classes with missing .ctors
- Handle Inara server response stating that too many requests have been received (with a one hour cool-down until new requests will be accepted)
- Remove EDDI.cs task to intialize the Inara service when starting EDDI (this is now managed through the Inara responder)
- Defined an interface for the Inara service and removed its instance property
- Moved background synchronization from the Inara responder to the Inara service.
- Threads have been replaced with tasks.
- Refactored. 