### PR TITLE
More gracefully handle EDSM server unavailable and other network interruptions.

### DIFF
--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -292,10 +292,13 @@ namespace EddiDataDefinitions
             if (factionPresence.FactionState == null)
             {
                 // Convert legacy data
-                string factionState = (string)additionalJsonData?["state"];
-                if (factionState != null)
+                if (additionalJsonData.ContainsKey("state"))
                 {
-                    factionPresence.FactionState = FactionState.FromEDName(factionState) ?? FactionState.None;
+                    string factionState = (string)additionalJsonData?["state"];
+                    if (factionState != null)
+                    {
+                        factionPresence.FactionState = FactionState.FromEDName(factionState) ?? FactionState.None;
+                    }
                 }
             }
             else

--- a/DataProviderService/StarSystemSqLiteRepository.cs
+++ b/DataProviderService/StarSystemSqLiteRepository.cs
@@ -196,7 +196,7 @@ namespace EddiDataProviderService
         public StarSystem GetStarSystem(string name, bool refreshIfOutdated = true)
         {
             if (String.IsNullOrEmpty(name)) { return null; }
-            return GetStarSystems(new[] { name }, refreshIfOutdated).FirstOrDefault();
+            return GetStarSystems(new[] { name }, refreshIfOutdated)?.FirstOrDefault();
         }
 
         public List<StarSystem> GetStarSystems(string[] names, bool refreshIfOutdated = true)

--- a/EDDI/StarSystemComboBox.cs
+++ b/EDDI/StarSystemComboBox.cs
@@ -15,7 +15,8 @@ namespace Eddi
         private List<string> SystemsBeginningWith(string systemName)
         {
             IEdsmService edsmService = new StarMapService();
-            return edsmService.GetStarMapSystemsPartial(systemName, false, false).Select(s => s.systemname).ToList();
+            return edsmService.GetStarMapSystemsPartial(systemName, false, false)?.Select(s => s.systemname).ToList()
+                ?? new List<string>();
         }
 
         internal void TextDidChange(object sender, TextChangedEventArgs e, string oldValue, Action changeHandler)

--- a/StarMapService/EdsmSystemData.cs
+++ b/StarMapService/EdsmSystemData.cs
@@ -38,8 +38,9 @@ namespace EddiStarMapService
                 if (token is JArray responses)
                 {
                     List<StarSystem> starSystems = new List<StarSystem>();
-                    foreach (JObject response in responses)
+                    foreach (var jToken in responses)
                     {
+                        var response = (JObject)jToken;
                         if (response != null)
                         {
                             starSystems.Add(ParseStarMapSystem(response));
@@ -75,8 +76,9 @@ namespace EddiStarMapService
                 if (token is JArray responses)
                 {
                     List<StarSystem> starSystems = new List<StarSystem>();
-                    foreach (JObject response in responses)
+                    foreach (var jToken in responses)
                     {
+                        var response = (JObject) jToken;
                         if (response != null)
                         {
                             starSystems.Add(ParseStarMapSystem(response));

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -438,7 +438,7 @@ namespace UnitTests
             List<StarSystem> starSystems = fakeEdsmService.GetStarMapSystems(systemNames, true, false);
 
             // Assert
-            Assert.AreEqual(3, starSystems.Count);
+            Assert.AreEqual(3, starSystems?.Count);
         }
 
         [TestMethod]


### PR DESCRIPTION
Unplanned null values can cause EDDI to crash in some circumstances (including if EDSM is not available while customizing the commander's home star system). This PR improves handling of those null values.