### PR TITLE
Support the Elite v3.7 `CarrierJump` event in the EDDN responder

### DIFF
--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -41,6 +41,7 @@ namespace EDDNResponder
         // These events must be ignored to prevent enriching events with incorrect location data
         private static readonly string[] ignoredEvents =
         {
+            "CarrierJumpRequest", // CarrierJumpRequest events describing the system the carrier is jumping too rather than the system we are in
             "FSDTarget", // FSDTarget events describing the system we are targeting rather than the system we are in
             "StartJump"  // Scan events can register after StartJump and before we actually leave the originating system
         };

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -26,7 +26,8 @@ namespace EDDNResponder
         private static readonly string[] fullLocationEvents =
         {
             "FSDJump",
-            "Location"
+            "Location",
+            "CarrierJump"
         };
 
         // We support sending these events to EDDN. These events contain partial location data... location data will need to be enriched. 


### PR DESCRIPTION
The `CarrierJump` event has been added to EDDN schemas (https://github.com/EDSM-NET/EDDN/commit/f03a0857cf4a2b95903d332697b07cc055c6cee7) and we can add support for it simply and immediately.

Change is compatible w/ Elite v3.6.