### PR TITLE
Fix Inara service exception that can occur when the server does not respond

### DIFF
--- a/EddiInaraService/InaraService.cs
+++ b/EddiInaraService/InaraService.cs
@@ -170,6 +170,7 @@ namespace EddiInaraService
         {
             if (!sendEvenForBetaGame && gameInBeta) { return null; }
 
+            // We always want to return a list from this method (even if it's an empty list) rather than a null value.
             List<InaraResponse> inaraResponses = new List<InaraResponse>();
 
             if (string.IsNullOrEmpty(apiKey))
@@ -227,7 +228,6 @@ namespace EddiInaraService
                         }
                     }
                 }
-                return inaraResponses;
             }
             else
             {
@@ -237,8 +237,8 @@ namespace EddiInaraService
                     // Re-enqueue and send at a later time.
                     EnqueueAPIEvent(inaraAPIEvent);
                 }
-                return null;
             }
+            return inaraResponses;
         }
 
         private bool validateResponse(InaraResponse inaraResponse, ref List<InaraAPIEvent> indexedEvents, bool header = false)


### PR DESCRIPTION
Fixes exceptions like:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at EddiInaraService.InaraService.SendQueuedAPIEvents() in %USERPROFILE%\source\repos\EDDI\EddiInaraService\InaraService.cs:line 302
   at EddiInaraService.InaraService.<BackgroundSync>d__33.MoveNext() in %USERPROFILE%\source\repos\EDDI\EddiInaraService\InaraService.cs:line 89
```
by ensuring that the `SendEventBatch` method always returns a list and never returns a null value.