### PR TITLE
Fix invalid IPA for the `Electra` star system

### DIFF
--- a/SpeechService/Properties/Phonetics.Designer.cs
+++ b/SpeechService/Properties/Phonetics.Designer.cs
@@ -19,7 +19,7 @@ namespace EddiSpeechService.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Phonetics {
@@ -547,7 +547,7 @@ namespace EddiSpeechService.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ᵻˈlɛktrə.
+        ///   Looks up a localized string similar to iˈlɛktrə.
         /// </summary>
         public static string electra {
             get {

--- a/SpeechService/Properties/Phonetics.resx
+++ b/SpeechService/Properties/Phonetics.resx
@@ -334,7 +334,7 @@
     <comment>Optional phonetic pronunciation for edmund</comment>
   </data>
   <data name="electra" xml:space="preserve">
-    <value>ᵻˈlɛktrə</value>
+    <value>iˈlɛktrə</value>
     <comment>Optional phonetic pronunciation for electra</comment>
   </data>
   <data name="eranin" xml:space="preserve">

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -351,5 +351,13 @@ namespace SpeechTests
                 speechresponder.Handle(@event);
             }
         }
+
+
+        [TestMethod, TestCategory("Speech")]
+        public void TestSpeechPhonemes()
+        {
+            var line = @"<phoneme alphabet=""ipa"" ph=""iˈlɛktrə"">Electra</phoneme>";
+            SpeechService.Instance.Speak(line, null, 0, 40, 0, 0, 0);
+        }
     }
 }


### PR DESCRIPTION
Corrects an exception like
```
SpeechService:speak Speech failed:  System.FormatException: 'phoneme' attribute in 'item' not valid.
   at System.Speech.Internal.Synthesis.VoiceSynthesis.Speak(Prompt prompt)
   at System.Speech.Synthesis.SpeechSynthesizer.Speak(Prompt prompt)
   at System.Speech.Synthesis.SpeechSynthesizer.SpeakSsml(String textToSpeak)
   at EddiSpeechService.SpeechService.<>c__DisplayClass40_0.<speak>b__0() in %USERPROFILE%\source\repos\EDDI\SpeechService\SpeechService.cs:line 380
```