### PR TITLE
Hotfix/1685 validate personality names and json

### DIFF
--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -291,7 +291,7 @@ namespace EddiSpeechResponder
         private void copyPersonalityClicked(object sender, RoutedEventArgs e)
         {
             EDDI.Instance.SpeechResponderModalWait = true;
-            CopyPersonalityWindow window = new CopyPersonalityWindow(Personality)
+            CopyPersonalityWindow window = new CopyPersonalityWindow(Personalities)
             {
                 Owner = Window.GetWindow(this)
             };

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -35,16 +35,22 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <TextBlock Margin="10" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_name}"></TextBlock>
-            <TextBox Margin="10" Grid.Row="0" Grid.Column="1" Name="PersonalityNameField">
+            <TextBlock Margin="10" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_name}" />
+            <TextBox Margin="10" Grid.Row="0" Grid.Column="1" 
+                     Name="PersonalityNameField" 
+                     Style="{StaticResource textBoxWithValidationToolTip}">
                 <TextBox.Text>
-                    <Binding Path="PersonalityName" Mode="TwoWay" />
+                    <Binding Path="PersonalityName" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged">
+                        <Binding.ValidationRules>
+                            <DataErrorValidationRule />
+                        </Binding.ValidationRules>
+                    </Binding>
                 </TextBox.Text>
             </TextBox>
-            <TextBlock Margin="10" Grid.Row="1" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_description}"></TextBlock>
+            <TextBlock Margin="10" Grid.Row="1" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_description}" />
             <TextBox Margin="10" Grid.Row="1" Grid.Column="1">
                 <TextBox.Text>
-                    <Binding Path="PersonalityDescription" Mode="TwoWay"></Binding>
+                    <Binding Path="PersonalityDescription" Mode="TwoWay" />
                 </TextBox.Text>
             </TextBox>
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="20" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -54,8 +54,15 @@
                 </TextBox.Text>
             </TextBox>
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="20" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">
-                <Button x:Name="acceptButton" IsDefault="True" FontSize="18" Content="{x:Static resx:SpeechResponder.button_ok}" VerticalAlignment="Top" Click="acceptButtonClick" Margin="10" IsEnabled="{Binding Path=AbleToAccept}"/>
-                <Button x:Name="cancelButton" IsCancel="True" FontSize="18" Content="{x:Static resx:SpeechResponder.button_cancel}" VerticalAlignment="Top" Click="cancelButtonClick" Margin="10"/>
+                <Button x:Name="acceptButton" IsDefault="True" FontSize="18" 
+                        Content="{x:Static resx:SpeechResponder.button_ok}" 
+                        VerticalAlignment="Top" Click="acceptButtonClick" 
+                        Margin="10"/>
+                <Button x:Name="cancelButton" IsCancel="True" FontSize="18" 
+                        Content="{x:Static resx:SpeechResponder.button_cancel}" 
+                        VerticalAlignment="Top" 
+                        Click="cancelButtonClick" 
+                        Margin="10"/>
             </UniformGrid>
         </Grid>
     </DockPanel>

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -25,9 +25,17 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock Margin="10" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_name}"></TextBlock>
-            <TextBox Margin="10" Grid.Row="0" Grid.Column="1" Name="PersonalityNameField" Text="{Binding Path=PersonalityName, Mode=TwoWay}"/>
+            <TextBox Margin="10" Grid.Row="0" Grid.Column="1" Name="PersonalityNameField">
+                <TextBox.Text>
+                    <Binding Path="PersonalityName" Mode="TwoWay" />
+                </TextBox.Text>
+            </TextBox>
             <TextBlock Margin="10" Grid.Row="1" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_description}"></TextBlock>
-            <TextBox Margin="10" Grid.Row="1" Grid.Column="1" Text="{Binding Path=PersonalityDescription, Mode=TwoWay}"/>
+            <TextBox Margin="10" Grid.Row="1" Grid.Column="1">
+                <TextBox.Text>
+                    <Binding Path="PersonalityDescription" Mode="TwoWay"></Binding>
+                </TextBox.Text>
+            </TextBox>
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="20" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">
                 <Button x:Name="acceptButton" IsDefault="True" FontSize="18" Content="{x:Static resx:SpeechResponder.button_ok}" VerticalAlignment="Top" Click="acceptButtonClick" Margin="10" IsEnabled="{Binding Path=AbleToAccept}"/>
                 <Button x:Name="cancelButton" IsCancel="True" FontSize="18" Content="{x:Static resx:SpeechResponder.button_cancel}" VerticalAlignment="Top" Click="cancelButtonClick" Margin="10"/>

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -17,8 +17,8 @@
             <Style.Triggers>
                 <Trigger Property="Validation.HasError" Value="true">
                     <Setter Property="ToolTip"
-                            Value="{Binding RelativeSource={x:Static RelativeSource.Self},
-                        Path=(Validation.Errors)/ErrorContent}"/>
+                            Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)/ErrorContent}" 
+                            />
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -56,7 +56,8 @@
             <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="20" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">
                 <Button x:Name="acceptButton" IsDefault="True" FontSize="18" 
                         Content="{x:Static resx:SpeechResponder.button_ok}" 
-                        VerticalAlignment="Top" Click="acceptButtonClick" 
+                        VerticalAlignment="Top" 
+                        Click="acceptButtonClick" 
                         Margin="10"/>
                 <Button x:Name="cancelButton" IsCancel="True" FontSize="18" 
                         Content="{x:Static resx:SpeechResponder.button_cancel}" 

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -12,6 +12,17 @@
         WindowStyle="ToolWindow"
         Height="200" Width="300"
         >
+    <Window.Resources>
+        <Style x:Key="textBoxWithValidationToolTip" TargetType="{x:Type TextBox}">
+            <Style.Triggers>
+                <Trigger Property="Validation.HasError" Value="true">
+                    <Setter Property="ToolTip"
+                            Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+                        Path=(Validation.Errors)/ErrorContent}"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
     <DockPanel LastChildFill="True" Background="#FFE5E5E5">
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace EddiSpeechResponder
             get => personalityDescription;
             set
             {
-                personalityDescription = value; 
+                personalityDescription = value;
                 OnPropertyChanged(PersonalityDescription);
             }
         }

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Forms.VisualStyles;
 
 namespace EddiSpeechResponder
 {
@@ -75,6 +73,7 @@ namespace EddiSpeechResponder
         }
 
 #region DataErrorInfo
+        // C#'s lack of string-based enums is annoying here. We have to resort to string literals, which are vulnerable to typos.
         public string Error
         {
             get
@@ -86,11 +85,11 @@ namespace EddiSpeechResponder
             }
         }
 
-        public string this[string columnName]
+        public string this[string fieldName]
         {
             get
             {
-                switch (columnName)
+                switch (fieldName)
                 {
                     case "PersonalityName":
                         return ValidatePersonalityName();

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -73,14 +73,11 @@ namespace EddiSpeechResponder
         }
 
 #region DataErrorInfo
-        // C#'s lack of string-based enums is annoying here. We have to resort to string literals, which are vulnerable to typos.
         public string Error
         {
             get
             {
-                string result = this["PersonalityName"];
-                if (!string.IsNullOrEmpty(result)) { return result; }
-
+                string result = this[nameof(PersonalityName)];
                 return result;
             }
         }
@@ -91,7 +88,7 @@ namespace EddiSpeechResponder
             {
                 switch (fieldName)
                 {
-                    case "PersonalityName":
+                    case nameof(PersonalityName):
                         return ValidatePersonalityName();
 
                     default:

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -26,8 +26,8 @@ namespace EddiSpeechResponder
                 OnPropertyChanged(PersonalityName);
             }
         }
-        private string personalityDescription;
 
+        private string personalityDescription;
         public string PersonalityDescription
         {
             get => personalityDescription;
@@ -58,6 +58,8 @@ namespace EddiSpeechResponder
             {
                 existingNames.Add(personality.Name.ToLower());
             }
+
+            acceptButton.IsEnabled = CanAccept();
         }
 
         private void acceptButtonClick(object sender, RoutedEventArgs e)

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms.VisualStyles;
 
 namespace EddiSpeechResponder
 {
@@ -37,10 +38,16 @@ namespace EddiSpeechResponder
             }
         }
 
+        bool CanAccept()
+        {
+            return string.IsNullOrWhiteSpace(Error);
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
         private void OnPropertyChanged(string name)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+            acceptButton.IsEnabled = CanAccept();
         }
 
         public CopyPersonalityWindow(IEnumerable<Personality> personalities)
@@ -55,7 +62,7 @@ namespace EddiSpeechResponder
 
         private void acceptButtonClick(object sender, RoutedEventArgs e)
         {
-            DialogResult = !Validation.GetHasError(this.PersonalityNameField);
+            DialogResult = !Validation.GetHasError(PersonalityNameField);
             Close();
         }
 
@@ -66,7 +73,16 @@ namespace EddiSpeechResponder
         }
 
 #region DataErrorInfo
-        public string Error => null;
+        public string Error
+        {
+            get
+            {
+                string result = this["PersonalityName"];
+                if (!string.IsNullOrEmpty(result)) { return result; }
+
+                return result;
+            }
+        }
 
         public string this[string columnName]
         {
@@ -76,15 +92,16 @@ namespace EddiSpeechResponder
                 {
                     case "PersonalityName":
                         return ValidatePersonalityName();
+
                     default:
-                        return "";
+                        return string.Empty;
                 }
             }
         }
 
         string ValidatePersonalityName()
         {
-            string trimmedName = personalityName?.Trim()?.ToLower();
+            string trimmedName = personalityName?.Trim().ToLower();
 
             if (string.IsNullOrEmpty(trimmedName))
             {

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -1,52 +1,104 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace EddiSpeechResponder
 {
+    using resx = Properties.SpeechResponder;
+
     /// <summary>
     /// Interaction logic for CopyPersonalityWindow.xaml
     /// </summary>
-    public partial class CopyPersonalityWindow : Window, INotifyPropertyChanged
+    public partial class CopyPersonalityWindow : Window, INotifyPropertyChanged, IDataErrorInfo
     {
-        private Personality personality;
+        private readonly HashSet<string> existingNames = new HashSet<string>();
 
         private string personalityName;
         public string PersonalityName
         {
-            get { return personalityName; }
-            set { personalityName = value; OnPropertyChanged("PersonalityName"); }
+            get => personalityName;
+            set
+            {
+                personalityName = value;
+                OnPropertyChanged(PersonalityName);
+            }
         }
         private string personalityDescription;
+
         public string PersonalityDescription
         {
-            get { return personalityDescription; }
-            set { personalityDescription = value; OnPropertyChanged("PersonalityDescription"); }
+            get => personalityDescription;
+            set
+            {
+                personalityDescription = value; 
+                OnPropertyChanged(PersonalityDescription);
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged(string name)
+        private void OnPropertyChanged(string name)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
-        public CopyPersonalityWindow(Personality personality)
+        public CopyPersonalityWindow(IEnumerable<Personality> personalities)
         {
             InitializeComponent();
             DataContext = this;
-
-            this.personality = personality;
+            foreach (var personality in personalities)
+            {
+                existingNames.Add(personality.Name.ToLower());
+            }
         }
 
         private void acceptButtonClick(object sender, RoutedEventArgs e)
         {
-            DialogResult = (PersonalityName != null && PersonalityName.Trim() != "");
-            this.Close();
+            DialogResult = !Validation.GetHasError(this.PersonalityNameField);
+            Close();
         }
 
         private void cancelButtonClick(object sender, RoutedEventArgs e)
         {
             DialogResult = false;
-            this.Close();
+            Close();
         }
+
+#region DataErrorInfo
+        public string Error => null;
+
+        public string this[string columnName]
+        {
+            get
+            {
+                switch (columnName)
+                {
+                    case "PersonalityName":
+                        return ValidatePersonalityName();
+                    default:
+                        return "";
+                }
+            }
+        }
+
+        string ValidatePersonalityName()
+        {
+            string trimmedName = personalityName?.Trim()?.ToLower();
+
+            if (string.IsNullOrEmpty(trimmedName))
+            {
+                return resx.validation_tooltip_name_empty;
+            }
+
+            if (existingNames.Contains(trimmedName))
+            {
+                return resx.validation_tooltip_name_taken;
+            }
+
+            return string.Empty;
+        }
+#endregion
+
     }
 }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -123,7 +123,16 @@ namespace EddiSpeechResponder
                 }
                 catch (Exception e)
                 {
-                    Logging.Warn("Failed to access personality at " + filename + ": " + e.Message);
+                    // malformed JSON for some reason: rename so that the user can examine and fix it.
+                    string newFileName = filename + ".malformed";
+                    if (File.Exists(newFileName))
+                    {
+                        // no point keeping a history: only the latest is likely to be useful. Pro users will be using version control anyway.
+                        File.Delete(newFileName);
+                    }
+                    File.Move(filename, newFileName);
+
+                    Logging.Error($"Could not parse \"{filename}\": moved to \"{newFileName}\". Error was \"{e.Message}\"");
                 }
             }
 

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -394,6 +394,24 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please supply a name.
+        /// </summary>
+        public static string validation_tooltip_name_empty {
+            get {
+                return ResourceManager.GetString("validation_tooltip_name_empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to That name is taken; please supply another.
+        /// </summary>
+        public static string validation_tooltip_name_taken {
+            get {
+                return ResourceManager.GetString("validation_tooltip_name_taken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to View.
         /// </summary>
         public static string view_script {

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -236,4 +236,10 @@
   <data name="messagebox_recoveredScript" xml:space="preserve">
     <value>EDDI has recovered a script that was being edited when the program closed unexpectedly. Do you want to re-open it?</value>
   </data>
+  <data name="validation_tooltip_name_empty" xml:space="preserve">
+    <value>Please supply a name</value>
+  </data>
+  <data name="validation_tooltip_name_taken" xml:space="preserve">
+    <value>That name is taken; please supply another</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #1685.
Supersedes #1686.

Implements validation against runtime criteria by implementing `IDataErrorInfo`.

Implements customisation of validation error display via a `Style` resource.

Implements a way to handle OK button enabling based upon validation.