### PR TITLE
Update `Ship repaired` event for Elite v3.7.

### DIFF
--- a/ShipMonitor/ShipRepairedEvent.cs
+++ b/ShipMonitor/ShipRepairedEvent.cs
@@ -1,6 +1,8 @@
 ﻿using EddiEvents;
 using System;
 using System.Collections.Generic;
+using EddiDataDefinitions;
+using System.Linq;
 
 namespace EddiShipMonitor
 {
@@ -12,18 +14,64 @@ namespace EddiShipMonitor
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
         static ShipRepairedEvent()
         {
-            VARIABLES.Add("item", "The item repaired, if repairing a specific item");
+            VARIABLES.Add("item", "Either 'All', 'Ship Integrity', 'Hull', 'Paint', the name of the item repaired (if repairing one item), or nothing (if repairing multiple items)");
+            VARIABLES.Add("items", "The items repaired (if repairing multiple items)");
+            VARIABLES.Add("module", "a module object representing the item repaired");
+            VARIABLES.Add("modules", "module objects representing the items repaired (if repairing multiple items)");
             VARIABLES.Add("price", "The price of the repair");
         }
 
         public string item { get; private set; }
 
+        public List<string> items { get; private set; } = new List<string>();
+
+        public Module module { get; private set; }
+
+        public List<Module> modules { get; private set; } = new List<Module>();
+
         public long price { get; private set; }
 
-        public ShipRepairedEvent(DateTime timestamp, string item, long price) : base(timestamp, NAME)
+        public ShipRepairedEvent(DateTime timestamp, string item, Module module, long price) : base(timestamp, NAME)
         {
-            this.item = item;
+            this.item = localizedModule(module) ?? item;
+            this.module = module;
             this.price = price;
+        }
+
+        public ShipRepairedEvent(DateTime timestamp, List<string> items, List<Module> modules, long price) : base(timestamp, NAME)
+        {
+            this.items = modules.Select(localizedModule).ToList();
+            this.modules = modules;
+            this.price = price;
+        }
+
+        private static string localizedModule(Module moduleToLocalize)
+        {
+            if (moduleToLocalize == null) return null;
+
+            if (moduleToLocalize.mount != null)
+            {
+                // This is a weapon so provide a bit more information
+                string mount = "";
+                switch (moduleToLocalize.mount)
+                {
+                    // FIXME this breaks localisation
+                    case Module.ModuleMount.Fixed:
+                        mount = "fixed";
+                        break;
+                    case Module.ModuleMount.Gimballed:
+                        mount = "gimballed";
+                        break;
+                    case Module.ModuleMount.Turreted:
+                        mount = "turreted";
+                        break;
+                }
+                return $"{moduleToLocalize.@class}{moduleToLocalize.grade} {mount} {moduleToLocalize.localizedName}";
+            }
+            else
+            {
+                return moduleToLocalize.localizedName;
+            }
         }
     }
 }

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -1824,7 +1824,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{ShipName()} repaired.",
+      "script": "{if len(event.items) > 0:\r\n    {List(event.items)} repaired.\r\n|else:\r\n    {if event.item = \"Paint\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        paint \r\n        {OneOf(\"restored.\", \"renewed.\")}\r\n    |elif event.item = \"Ship Integrity\" || event.item = \"Wear\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        {Occasionally(2, '{OneOf(\\\"regular\\\", \\\"standard\\\")}')} \r\n        maintenance completed.\r\n    |elif find(event.item, \"Cockpit\") > -1:\r\n        Canopy repaired.\r\n    |else:\r\n        {ShipName()} repaired.\r\n    }\r\n}",
       "default": true,
       "name": "Ship repaired",
       "description": "Triggered when you repair your ship"

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -1824,7 +1824,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{ShipName()} repaired.",
+      "script": "{if len(event.items) > 0:\r\n    {List(event.items)} repaired.\r\n|else:\r\n    {if event.item = \"Paint\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        paint \r\n        {OneOf(\"restored.\", \"renewed.\")}\r\n    |elif event.item = \"Ship Integrity\" || event.item = \"Wear\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        {Occasionally(2, '{OneOf(\\\"regular\\\", \\\"standard\\\")}')} \r\n        maintenance completed.\r\n    |elif find(event.item, \"Cockpit\") > -1:\r\n        Canopy repaired.\r\n    |else:\r\n        {ShipName()} repaired.\r\n    }\r\n}",
       "default": true,
       "name": "Ship repaired",
       "description": "Triggered when you repair your ship"

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -1824,7 +1824,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{ShipName()} repaired.",
+      "script": "{if len(event.items) > 0:\r\n    {List(event.items)} repaired.\r\n|else:\r\n    {if event.item = \"Paint\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        paint \r\n        {OneOf(\"restored.\", \"renewed.\")}\r\n    |elif event.item = \"Ship Integrity\" || event.item = \"Wear\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        {Occasionally(2, '{OneOf(\\\"regular\\\", \\\"standard\\\")}')} \r\n        maintenance completed.\r\n    |elif find(event.item, \"Cockpit\") > -1:\r\n        Canopy repaired.\r\n    |else:\r\n        {ShipName()} repaired.\r\n    }\r\n}",
       "default": true,
       "name": "Ship repaired",
       "description": "Triggered when you repair your ship"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1823,7 +1823,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{ShipName()} repaired.",
+      "script": "{if len(event.items) > 0:\r\n    {List(event.items)} repaired.\r\n|else:\r\n    {if event.item = \"Paint\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        paint \r\n        {OneOf(\"restored.\", \"renewed.\")}\r\n    |elif event.item = \"Ship Integrity\" || event.item = \"Wear\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        {Occasionally(2, '{OneOf(\\\"regular\\\", \\\"standard\\\")}')} \r\n        maintenance completed.\r\n    |elif find(event.item, \"Cockpit\") > -1:\r\n        Canopy repaired.\r\n    |else:\r\n        {ShipName()} repaired.\r\n    }\r\n}",
       "default": true,
       "name": "Ship repaired",
       "description": "Triggered when you repair your ship"

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -1824,7 +1824,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{ShipName()} repaired.",
+      "script": "{if len(event.items) > 0:\r\n    {List(event.items)} repaired.\r\n|else:\r\n    {if event.item = \"Paint\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        paint \r\n        {OneOf(\"restored.\", \"renewed.\")}\r\n    |elif event.item = \"Ship Integrity\" || event.item = \"Wear\":\r\n        {Occasionally(2, \"{ShipName()}'s\")} \r\n        {Occasionally(2, '{OneOf(\\\"regular\\\", \\\"standard\\\")}')} \r\n        maintenance completed.\r\n    |elif find(event.item, \"Cockpit\") > -1:\r\n        Canopy repaired.\r\n    |else:\r\n        {ShipName()} repaired.\r\n    }\r\n}",
       "default": true,
       "name": "Ship repaired",
       "description": "Triggered when you repair your ship"

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -1227,5 +1227,41 @@ namespace UnitTests
             EngineerProgressedEvent rankEvent2 = (EngineerProgressedEvent)events[0];
             Assert.AreEqual(2, rankEvent2.Engineer?.rank);
         }
+
+        [TestMethod]
+        public void TestShipRepairedEvent()
+        {
+			string line = "{ \"timestamp\":\"2016-09-25T12:31:38Z\", \"event\":\"Repair\", \"Item\":\"Wear\", \"Cost\":2824 }";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            ShipRepairedEvent @event = (ShipRepairedEvent)events[0];
+            Assert.AreEqual("Ship Integrity", @event.item);
+            Assert.IsNull(@event.module);
+            Assert.AreEqual(0, @event.modules.Count);
+            Assert.AreEqual(2824, @event.price);
+        }
+
+        [TestMethod]
+        public void TestShipRepairedEvent2()
+        {
+            string line = "{ \"timestamp\":\"2020-03-31T13:39:42Z\", \"event\":\"Repair\", \"Items\":[ \"$hpt_dumbfiremissilerack_fixed_large_name;\", \"$hpt_beamlaser_gimbal_medium_name;\", \"$hpt_railgun_fixed_medium_name;\", \"$hpt_beamlaser_gimbal_medium_name;\", \"$hpt_dumbfiremissilerack_fixed_large_name;\" ], \"Cost\":34590 }";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            ShipRepairedEvent @event = (ShipRepairedEvent)events[0];
+            Assert.IsInstanceOfType(@event.items, typeof(List<string>));
+            Assert.AreEqual(5, @event.items.Count);
+            Assert.AreEqual(34590, @event.price);
+            Assert.IsNull(@event.item);
+        }
+
+        [TestMethod]
+        public void TestShipRepairedEvent3()
+        {
+            string line = "{ \"timestamp\":\"2020-05-13T08:45:03Z\", \"event\":\"RepairAll\", \"Cost\":104817 }";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            ShipRepairedEvent @event = (ShipRepairedEvent)events[0];
+            Assert.AreEqual("All", @event.item);
+            Assert.IsNull(@event.module);
+            Assert.AreEqual(0, @event.modules.Count);
+            Assert.AreEqual(104817, @event.price);
+        }
     }
 }


### PR DESCRIPTION
- Support parsing a list of repaired modules (as reported when repairing modules at a fleet carrier)
- Make localized module name construction optional by exposing the underlying module objects
- Add appropriate unit tests
- Update `Ship repaired ` script for revised event.