### PR TITLE
Implement carrier jump related events for Elite v3.7

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1487,10 +1487,12 @@ namespace Eddi
                     Environment = Constants.ENVIRONMENT_DOCKED;
                     Vehicle = Constants.VEHICLE_SHIP;
 
-                    // Our data source may not include the market id or system address
+                    // Update station properties known from this event
                     station.marketId = theEvent.marketId;
                     station.systemAddress = theEvent.systemAddress;
                     station.Faction = theEvent.controllingstationfaction;
+                    station.Model = theEvent.stationModel;
+                    station.distancefromstar = theEvent.distancefromstar;
 
                     // Kick off the profile refresh if the companion API is available
                     if (CompanionAppService.Instance.CurrentState == CompanionAppService.State.Authorized)

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -994,6 +994,30 @@ namespace Eddi
                     CurrentStellarBody.bodyId = @event.bodyId;
                 }
             }
+            else
+            {
+                // Remove the carrier from its prior location in the origin system so that we can re-save it with a new location
+                StarSystem starSystem = StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(@event.originSystemName);
+                Station carrier = starSystem?.stations.FirstOrDefault(s => s.marketId == @event.carrierId);
+                starSystem?.stations.RemoveAll(s => s.marketId == @event.carrierId);
+                // Save the carrier to the updated star system
+                carrier.systemname = @event.systemname;
+                carrier.systemAddress = @event.systemAddress;
+                if (@event.systemname == CurrentStarSystem?.systemname)
+                {
+                    CurrentStarSystem.stations.Add(carrier);
+                    StarSystemSqLiteRepository.Instance.SaveStarSystem(starSystem);
+                }
+                else
+                {
+                    StarSystem updatedStarSystem = StarSystemSqLiteRepository.Instance.GetOrFetchStarSystem(@event.systemname);
+                    if (updatedStarSystem != null)
+                    {
+                        updatedStarSystem.stations.Add(carrier);
+                        StarSystemSqLiteRepository.Instance.SaveStarSystem(updatedStarSystem);
+                    }
+                }
+            }
             return true;
         }
 

--- a/Events/CarrierCooldownEvent.cs
+++ b/Events/CarrierCooldownEvent.cs
@@ -1,0 +1,69 @@
+﻿using EddiDataDefinitions;
+using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class CarrierCooldownEvent : Event
+    {
+        public const string NAME = "Carrier cooldown";
+        public const string DESCRIPTION = "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown";
+        public static CarrierCooldownEvent SAMPLE = new CarrierCooldownEvent(DateTime.UtcNow, "Aparctias", 358797513434, "Aparctias", 0, BodyType.FromEDName("Star"), "G53-K3Q", StationModel.FromEDName("FleetCarrier"), 3700571136);
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierCooldownEvent()
+        {
+            // System variables
+            VARIABLES.Add("systemname", "The name of the system in which the carrier is located");
+
+            // Body variables
+            VARIABLES.Add("bodyname", "The nearest body to the carrier, if any");
+            VARIABLES.Add("bodytype", "The type of the body nearest to the carrier, if any (Star, Planet. etc.)");
+            VARIABLES.Add("shortname", "The short name of the nearest body, if any");
+
+            // Carrier variables
+            VARIABLES.Add("carriername", "The name of the carrier");
+        }
+
+        // System variables
+
+        public string systemname { get; private set; }
+
+        // Body variables
+
+        public string bodyname { get; private set; }
+
+        public string bodytype => bodyType?.localizedName;
+
+        public string shortname => (systemname == null || bodyname == systemname) ? bodyname : bodyname.Replace(systemname, "").Trim();
+
+        // Carrier variables
+
+        public string carriername { get; private set; }
+
+        // These properties are not intended to be user facing
+        public long? systemAddress { get; private set; }
+        public BodyType bodyType { get; private set; }
+        public long? bodyId { get; private set; }
+        public long? carrierId { get; private set; }
+        public StationModel carrierType { get; private set; }
+
+        public CarrierCooldownEvent(DateTime timestamp, string systemName, long systemAddress, string bodyName, long? bodyId, BodyType bodyType, string carrierName, StationModel carrierType, long? carrierId) : base(timestamp, NAME)
+        {
+            // System
+            this.systemname = systemName;
+            this.systemAddress = systemAddress;
+
+            // Body
+            this.bodyname = bodyName;
+            this.bodyId = bodyId;
+            this.bodyType = bodyType ?? BodyType.None;
+
+            // Carrier
+            this.carrierId = carrierId;
+            this.carriername = carrierName;
+            this.carrierType = carrierType;
+        }
+    }
+}

--- a/Events/CarrierJumpCancelledEvent.cs
+++ b/Events/CarrierJumpCancelledEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class CarrierJumpCancelledEvent : Event
+    {
+        public const string NAME = "Carrier jump cancelled";
+        public const string DESCRIPTION = "Triggered when you cancel a scheduled fleet carrier jump";
+        public const string SAMPLE = "{ \"timestamp\":\"2020-05-11T18:53:47Z\", \"event\":\"CarrierJumpCancelled\", \"CarrierID\":3700357376 }";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierJumpCancelledEvent()
+        { }
+
+        // These properties are not intended to be user facing
+        public long carrierId { get; private set; }
+
+        public CarrierJumpCancelledEvent(DateTime timestamp, long carrierId) : base(timestamp, NAME)
+        {
+            this.carrierId = carrierId;
+        }
+    }
+}

--- a/Events/CarrierJumpEngagedEvent.cs
+++ b/Events/CarrierJumpEngagedEvent.cs
@@ -7,7 +7,7 @@ namespace EddiEvents
     {
         public const string NAME = "Carrier jump engaged";
         public const string DESCRIPTION = "Triggered when your fleet carrier performs a jump";
-        public static CarrierJumpEngagedEvent SAMPLE = new CarrierJumpEngagedEvent(DateTime.UtcNow, "Aparctias", 358797513434, "Aparctias", 0, 3700571136);
+        public static CarrierJumpEngagedEvent SAMPLE = new CarrierJumpEngagedEvent(DateTime.UtcNow, "Aparctias", 358797513434, "Ageno", 18262335038849, "Aparctias", 0, 3700571136);
 
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
@@ -35,8 +35,10 @@ namespace EddiEvents
         public long? systemAddress { get; private set; }
         public long? bodyId { get; private set; }
         public long? carrierId { get; private set; }
+        public string originSystemName { get; private set; }
+        public long? originSystemAddress { get; private set; }
 
-        public CarrierJumpEngagedEvent(DateTime timestamp, string systemName, long systemAddress, string bodyName, long? bodyId, long? carrierId) : base(timestamp, NAME)
+        public CarrierJumpEngagedEvent(DateTime timestamp, string systemName, long systemAddress, string originSystemName, long? originSystemAddress, string bodyName, long? bodyId, long? carrierId) : base(timestamp, NAME)
         {
             // System
             this.systemname = systemName;

--- a/Events/CarrierJumpEngagedEvent.cs
+++ b/Events/CarrierJumpEngagedEvent.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class CarrierJumpEngagedEvent : Event
+    {
+        public const string NAME = "Carrier jump engaged";
+        public const string DESCRIPTION = "Triggered when your fleet carrier performs a jump";
+        public static CarrierJumpEngagedEvent SAMPLE = new CarrierJumpEngagedEvent(DateTime.UtcNow, "Aparctias", 358797513434, "Aparctias", 0, 3700571136);
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierJumpEngagedEvent()
+        {
+            // System variables
+            VARIABLES.Add("systemname", "The name of the destination star system");
+
+            // Body variables
+            VARIABLES.Add("bodyname", "The name of the destination body, if any");
+            VARIABLES.Add("shortname", "The short name of the destination body, if any");
+        }
+
+        // System variables
+
+        public string systemname { get; private set; }
+
+        // Body variables
+
+        public string bodyname { get; private set; }
+
+        public string shortname => (systemname == null || bodyname == systemname) ? bodyname : bodyname.Replace(systemname, "").Trim();
+
+        // These properties are not intended to be user facing
+        public long? systemAddress { get; private set; }
+        public long? bodyId { get; private set; }
+        public long? carrierId { get; private set; }
+
+        public CarrierJumpEngagedEvent(DateTime timestamp, string systemName, long systemAddress, string bodyName, long? bodyId, long? carrierId) : base(timestamp, NAME)
+        {
+            // System
+            this.systemname = systemName;
+            this.systemAddress = systemAddress;
+
+            // Body
+            this.bodyname = bodyName;
+            this.bodyId = bodyId;
+
+            // Carrier
+            this.carrierId = carrierId;
+        }
+    }
+}

--- a/Events/CarrierJumpRequestEvent.cs
+++ b/Events/CarrierJumpRequestEvent.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class CarrierJumpRequestEvent : Event
+    {
+        public const string NAME = "Carrier jump request";
+        public const string DESCRIPTION = "Triggered when you request that your fleet carrier performs a jump";
+        public const string SAMPLE = "{ \"timestamp\":\"2020-05-11T18:56:09Z\", \"event\":\"CarrierJumpRequest\", \"CarrierID\":3700357376, \"SystemName\":\"Hemang\", \"Body\":\"Hemang A 2 a\", \"SystemAddress\":4756709905082, \"BodyID\":7 }";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierJumpRequestEvent()
+        {
+            // System variables
+            VARIABLES.Add("systemname", "The name of the destination star system");
+
+            // Body variables
+            VARIABLES.Add("bodyname", "The name of the destination body, if any");
+            VARIABLES.Add("shortname", "The short name of the destination body, if any");
+        }
+
+        // System variables
+
+        public string systemname { get; private set; }
+
+        // Body variables
+
+        public string bodyname { get; private set; }
+
+        public string shortname => (systemname == null || bodyname == systemname) ? bodyname : bodyname.Replace(systemname, "").Trim();
+
+        // These properties are not intended to be user facing
+        public long? systemAddress { get; private set; }
+        public long? bodyId { get; private set; }
+        public long? carrierId { get; private set; }
+
+        public CarrierJumpRequestEvent(DateTime timestamp, string systemName, long systemAddress, string bodyName, long? bodyId, long? carrierId) : base(timestamp, NAME)
+        {
+            // System
+            this.systemname = systemName;
+            this.systemAddress = systemAddress;
+
+            // Body
+            this.bodyname = bodyName;
+            this.bodyId = bodyId;
+
+            // Carrier
+            this.carrierId = carrierId;
+        }
+    }
+}

--- a/Events/CarrierJumpedEvent.cs
+++ b/Events/CarrierJumpedEvent.cs
@@ -1,0 +1,147 @@
+﻿using EddiDataDefinitions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EddiEvents
+{
+    public class CarrierJumpedEvent : Event
+    {
+        public const string NAME = "Carrier jumped";
+        public const string DESCRIPTION = "Triggered when you are docked at a fleet carrier as it completes a jump";
+        public const string SAMPLE = "{\"timestamp\":\"2020-05-17T14:07:24Z\",\"event\":\"CarrierJump\",\"Docked\":true,\"StationName\":\"G53-K3Q\",\"StationType\":\"FleetCarrier\",\"MarketID\":3700571136,\"StationFaction\":{\"Name\":\"FleetCarrier\"},\"StationGovernment\":\"$government_Carrier;\",\"StationGovernment_Localised\":\"Private Ownership \",\"StationServices\":[\"dock\",\"autodock\",\"blackmarket\",\"commodities\",\"contacts\",\"exploration\",\"crewlounge\",\"rearm\",\"refuel\",\"repair\",\"engineer\",\"flightcontroller\",\"stationoperations\",\"stationMenu\",\"carriermanagement\",\"carrierfuel\",\"voucherredemption\"],\"StationEconomy\":\"$economy_Carrier;\",\"StationEconomy_Localised\":\"Private Enterprise\",\"StationEconomies\":[{\"Name\":\"$economy_Carrier;\",\"Name_Localised\":\"Private Enterprise\",\"Proportion\":1}],\"StarSystem\":\"Aparctias\",\"SystemAddress\":358797513434,\"StarPos\":[25.1875,-56.375,22.90625],\"SystemAllegiance\":\"Independent\",\"SystemEconomy\":\"$economy_Colony;\",\"SystemEconomy_Localised\":\"Colony\",\"SystemSecondEconomy\":\"$economy_Refinery;\",\"SystemSecondEconomy_Localised\":\"Refinery\",\"SystemGovernment\":\"$government_Dictatorship;\",\"SystemGovernment_Localised\":\"Dictatorship\",\"SystemSecurity\":\"$SYSTEM_SECURITY_medium;\",\"SystemSecurity_Localised\":\"Medium Security\",\"Population\":80000,\"Body\":\"Aparctias\",\"BodyID\":0,\"BodyType\":\"Star\",\"Powers\":[\"Yuri Grom\"],\"PowerplayState\":\"Exploited\",\"Factions\":[{\"Name\":\"Union of Aparctias Future\",\"FactionState\":\"None\",\"Government\":\"Democracy\",\"Influence\":0.062,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0},{\"Name\":\"Monarchy of Aparctias\",\"FactionState\":\"None\",\"Government\":\"Feudal\",\"Influence\":0.035,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0},{\"Name\":\"Aparctias Purple Council\",\"FactionState\":\"Boom\",\"Government\":\"Anarchy\",\"Influence\":0.049,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"ActiveStates\":[{\"State\":\"Boom\"}]},{\"Name\":\"Beta-3 Tucani Silver Allied Net\",\"FactionState\":\"None\",\"Government\":\"Corporate\",\"Influence\":0.096,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0.32538},{\"Name\":\"Falcons' Nest\",\"FactionState\":\"None\",\"Government\":\"Confederacy\",\"Influence\":0.078,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"RecoveringStates\":[{\"State\":\"NaturalDisaster\",\"Trend\":0}]},{\"Name\":\"EG Union\",\"FactionState\":\"War\",\"Government\":\"Dictatorship\",\"Influence\":0.34,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"ActiveStates\":[{\"State\":\"Boom\"},{\"State\":\"War\"}]},{\"Name\":\"Paladin Consortium\",\"FactionState\":\"War\",\"Government\":\"Democracy\",\"Influence\":0.34,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"PendingStates\":[{\"State\":\"Boom\",\"Trend\":0},{\"State\":\"CivilLiberty\",\"Trend\":0}],\"ActiveStates\":[{\"State\":\"War\"}]}],\"SystemFaction\":{\"Name\":\"EG Union\",\"FactionState\":\"War\"},\"Conflicts\":[{\"WarType\":\"war\",\"Status\":\"active\",\"Faction1\":{\"Name\":\"EG Union\",\"Stake\":\"Hancock Refinery\",\"WonDays\":1},\"Faction2\":{\"Name\":\"Paladin Consortium\",\"Stake\":\"\",\"WonDays\":0}}]}";
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierJumpedEvent()
+        {
+            // System variables
+            VARIABLES.Add("systemname", "The name of the system into which the carrier has jumped");
+            VARIABLES.Add("x", "The X co-ordinate of the system into which the carrier has jumped");
+            VARIABLES.Add("y", "The Y co-ordinate of the system into which the carrier has jumped");
+            VARIABLES.Add("z", "The Z co-ordinate of the system into which the carrier has jumped");
+            VARIABLES.Add("economy", "The economy of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("economy2", "The secondary economy of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("security", "The security of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("population", "The population of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("systemfaction", "The faction controlling the system into which the carrier has jumped, if any");
+            VARIABLES.Add("systemstate", "The state of the faction controlling the system into which the carrier has jumped, if any");
+            VARIABLES.Add("systemgovernment", "The government of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("systemallegiance", "The allegiance of the system into which the carrier has jumped, if any");
+            VARIABLES.Add("factions", "A list of faction objects describing the factions in the system, if any");
+            VARIABLES.Add("conflicts", "A list of conflict objects describing any conflicts between factions in the system, if any");
+            VARIABLES.Add("power", "(Only when pledged) The powerplay power exerting influence over the star system. If the star system is `Contested`, this will be empty");
+            VARIABLES.Add("powerstate", "(Only when pledged) The state of powerplay efforts within the star system, if any");
+
+            // Body variables
+            VARIABLES.Add("bodyname", "The nearest body to the carrier, if any");
+            VARIABLES.Add("bodytype", "The type of the body nearest to the carrier, if any");
+            VARIABLES.Add("shortname", "The short name of the nearest body, if any");
+
+            // Carrier variables
+            VARIABLES.Add("carriername", "The name of the carrier");
+        }
+
+        // System variables
+
+        public string systemname { get; private set; }
+
+        public decimal x { get; private set; }
+
+        public decimal y { get; private set; }
+
+        public decimal z { get; private set; }
+
+        public string economy => systemEconomy?.localizedName;
+
+        public string economy2 => systemEconomy2?.localizedName;
+
+        public string security => securityLevel?.localizedName;
+
+        public long? population { get; private set; }
+
+        public string systemfaction => controllingsystemfaction?.name;
+
+        public string systemstate => (controllingsystemfaction?.presences.FirstOrDefault(p => p.systemName == systemname)?.FactionState ?? FactionState.None).localizedName;
+
+        public string systemgovernment => (controllingsystemfaction?.Government ?? Government.None).localizedName;
+
+        public string systemallegiance => (controllingsystemfaction?.Allegiance ?? Superpower.None).localizedName;
+
+        public List<Faction> factions { get; private set; }
+
+        public List<Conflict> conflicts { get; private set; }
+
+        // Powerplay properties (only when pledged)
+
+        public string power => Power?.localizedName;
+
+        public string powerstate => powerState?.localizedName;
+
+        // Body variables
+
+        public string bodyname { get; private set; }
+
+        public string bodytype => bodyType?.localizedName;
+
+        public string shortname => (systemname == null || bodyname == systemname) ? bodyname : bodyname.Replace(systemname, "").Trim();
+
+        // Carrier variables
+
+        public string carriername { get; private set; }
+
+        // These properties are not intended to be user facing
+        public bool docked { get; private set; }
+        public long? systemAddress { get; private set; }
+        public long? carrierId { get; private set; }
+        public Economy systemEconomy { get; private set; }
+        public Economy systemEconomy2 { get; private set; }
+        public Faction controllingsystemfaction { get; private set; }
+        public SecurityLevel securityLevel { get; private set; }
+        public BodyType bodyType { get; private set; }
+        public long? bodyId { get; private set; }
+        public Power Power { get; private set; }
+        public PowerplayState powerState { get; private set; }
+        public Faction carrierFaction { get; private set; }
+        public StationModel carrierType { get; private set; }
+        public List<StationService> carrierServices { get; private set; }
+        public List<EconomyShare> carrierEconomies { get; private set; }
+
+        public CarrierJumpedEvent(DateTime timestamp, string systemName, long systemAddress, decimal x, decimal y, decimal z, 
+            string bodyName, long? bodyId, BodyType bodyType, Faction systemFaction, List<Faction> factions, List<Conflict> conflicts, 
+            Economy systemEconomy, Economy systemEconomy2, SecurityLevel systemSecurity, long? systemPopulation, Power powerplayPower, 
+            PowerplayState powerplayState, bool docked, string carrierName, StationModel carrierType, long? carrierId, Faction stationFaction, 
+            List<StationService> stationServices, List<EconomyShare> stationEconomies) : base(timestamp, NAME)
+        {
+            // System
+            this.systemname = systemName;
+            this.systemAddress = systemAddress;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.controllingsystemfaction = systemFaction;
+            this.systemEconomy = (systemEconomy ?? Economy.None);
+            this.systemEconomy2 = (systemEconomy2 ?? Economy.None);
+            this.securityLevel = systemSecurity ?? SecurityLevel.None;
+            this.population = systemPopulation;
+            this.factions = factions ?? new List<Faction>();
+            this.conflicts = conflicts ?? new List<Conflict>();
+            this.Power = powerplayPower;
+            this.powerState = powerplayState ?? PowerplayState.None;
+
+            // Body
+            this.bodyname = bodyName;
+            this.bodyId = bodyId;
+            this.bodyType = bodyType ?? BodyType.None;
+
+            // Carrier
+            this.docked = docked;
+            this.carrierId = carrierId;
+            this.carriername = carrierName;
+            this.carrierType = carrierType ?? StationModel.FromEDName("FleetCarrier");
+            this.carrierFaction = stationFaction;
+            this.carrierServices = stationServices ?? new List<StationService>();
+            this.carrierEconomies = stationEconomies ?? new List<EconomyShare>();
+        }
+    }
+}

--- a/Events/CarrierPadsLockedEvent.cs
+++ b/Events/CarrierPadsLockedEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EddiEvents
+{
+    public class CarrierPadsLockedEvent : Event
+    {
+        public const string NAME = "Carrier pads locked";
+        public const string DESCRIPTION = "Triggered when your fleet carrier locks landing pads prior to jumping";
+        public static CarrierPadsLockedEvent SAMPLE = new CarrierPadsLockedEvent(DateTime.UtcNow, 3700357376);
+
+        public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
+
+        static CarrierPadsLockedEvent()
+        { }
+
+        // These properties are not intended to be user facing
+        public long carrierId { get; private set; }
+
+        public CarrierPadsLockedEvent(DateTime timestamp, long carrierId) : base(timestamp, NAME)
+        {
+            this.carrierId = carrierId;
+        }
+    }
+}

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -65,7 +65,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CarrierJumpCancelledEvent.cs" />
+    <Compile Include="CarrierJumpRequestEvent.cs" />
+    <Compile Include="CarrierPadsLockedEvent.cs" />
+    <Compile Include="CarrierJumpEngagedEvent.cs" />
+    <Compile Include="CarrierCooldownEvent.cs" />
     <Compile Include="CommanderReputationEvent.cs" />
+    <Compile Include="CarrierJumpedEvent.cs" />
     <Compile Include="PowerplayEvent.cs" />
     <Compile Include="CommanderLoadingEvent.cs" />
     <Compile Include="RingMappedEvent.cs" />

--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -44,7 +44,6 @@ namespace EddiEvents
 
         public decimal z { get; private set; }
 
-        /// <summary> Documented by the journal, but apparently never written. We can't rely on this being set. </summary>
         public string star { get; private set; }
 
         public decimal distance { get; private set; }
@@ -74,7 +73,7 @@ namespace EddiEvents
         public string government => (controllingfaction?.Government ?? Government.None).localizedName;
 
         // Powerplay properties (only when pledged)
-        string power => Power.localizedName;
+        public string power => Power.localizedName;
         public string powerstate => powerState.localizedName;
 
         // These properties are not intended to be user facing

--- a/Events/LocationEvent.cs
+++ b/Events/LocationEvent.cs
@@ -28,12 +28,6 @@ namespace EddiEvents
             VARIABLES.Add("marketId", "The market ID of the station at which the commander is docked");
             VARIABLES.Add("stationtype", "The type of the station at which the commander is docked");
 
-            // Pre-3.3.03 faction variables
-            VARIABLES.Add("faction", "The faction controlling the system in which the commander resides");
-            VARIABLES.Add("factionstate", "The state of the faction controlling the system in which the commander resides");
-            VARIABLES.Add("government", "The government of the system in which the commander resides");
-            VARIABLES.Add("allegiance", "The allegiance of the system in which the commander resides");
-
             // Post-3.3.03 faction variables
             VARIABLES.Add("systemfaction", "The faction controlling the system in which the commander resides");
             VARIABLES.Add("systemstate", "The state of the faction controlling the system in which the commander resides");
@@ -41,6 +35,7 @@ namespace EddiEvents
             VARIABLES.Add("stationfaction", "The faction controlling the station, if the commander is docked");
             VARIABLES.Add("stationstate", "The state of the faction controlling the station, if the commander is docked");
             VARIABLES.Add("stationgovernment", "The government of the station, if the commander is docked");
+            VARIABLES.Add("stationallegiance", "The government of the station, if the commander is docked");
 
             VARIABLES.Add("economy", "The economy of the system in which the commander resides");
             VARIABLES.Add("economy2", "The secondary economy of the system in which the commander resides, if any");
@@ -85,12 +80,6 @@ namespace EddiEvents
 
         public decimal? latitude { get; private set; }
 
-        // Pre-3.3.03 faction properties to maintain script/profile backwards compatability
-        public string faction => controllingsystemfaction?.name;
-        public string factionstate => (controllingsystemfaction?.presences.FirstOrDefault(p => p.systemName == systemname)?.FactionState ?? FactionState.None).localizedName;
-        public string government => (controllingsystemfaction?.Government ?? Government.None).localizedName;
-        public string allegiance => (controllingsystemfaction?.Allegiance ?? Superpower.None).localizedName;
-
         // Post-3.3.03 faction properties
         public string systemfaction => controllingsystemfaction?.name;
         public string systemstate => (controllingsystemfaction?.presences.FirstOrDefault(p => p.systemName == systemname)?.FactionState ?? FactionState.None).localizedName;
@@ -99,10 +88,10 @@ namespace EddiEvents
         public string stationfaction => controllingstationfaction?.name;
         public string stationstate => (controllingstationfaction?.presences.FirstOrDefault(p => p.systemName == systemname)?.FactionState ?? FactionState.None).localizedName;
         public string stationgovernment => (controllingstationfaction?.Government ?? Government.None).localizedName;
-        public string stationallegiancet => (controllingstationfaction?.Allegiance ?? Superpower.None).localizedName;
+        public string stationallegiance => (controllingstationfaction?.Allegiance ?? Superpower.None).localizedName;
 
         // Powerplay properties (only when pledged)
-        string power => Power.localizedName;
+        public string power => Power.localizedName;
         public string powerstate => powerState.localizedName;
 
         // Deprecated, maintained for compatibility with user scripts
@@ -110,6 +99,14 @@ namespace EddiEvents
         public string system => systemname;
         [JsonIgnore, Obsolete("Use bodyname instead")]
         public string body => bodyname;
+        [JsonIgnore, Obsolete("Use systemfaction instead")]
+        public string faction => controllingsystemfaction?.name;
+        [JsonIgnore, Obsolete("Use systemstate instead")]
+        public string factionstate => (controllingsystemfaction?.presences.FirstOrDefault(p => p.systemName == systemname)?.FactionState ?? FactionState.None).localizedName;
+        [JsonIgnore, Obsolete("Use systemgovernment instead")]
+        public string government => (controllingsystemfaction?.Government ?? Government.None).localizedName;
+        [JsonIgnore, Obsolete("Use systemallegiance instead")]
+        public string allegiance => (controllingsystemfaction?.Allegiance ?? Superpower.None).localizedName;
 
         // These properties are not intended to be user facing
         public long? systemAddress { get; private set; }

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -3866,7 +3866,9 @@ namespace EddiJournalMonitor
                                         {
                                             int timeMs = (Constants.carrierPreJumpSeconds - varSeconds) * 1000;
                                             await Task.Delay(timeMs);
-                                            EDDI.Instance.enqueueEvent(new CarrierJumpEngagedEvent(timestamp.AddMilliseconds(timeMs), systemName, systemAddress, bodyName, bodyId, carrierId) { fromLoad = fromLogLoad });
+                                            string originStarSystem = EDDI.Instance.CurrentStarSystem?.systemname;
+                                            long? originSystemAddress = EDDI.Instance.CurrentStarSystem?.systemAddress;
+                                            EDDI.Instance.enqueueEvent(new CarrierJumpEngagedEvent(timestamp.AddMilliseconds(timeMs), systemName, systemAddress, originStarSystem, originSystemAddress, bodyName, bodyId, carrierId) { fromLoad = fromLogLoad });
                                         }, carrierJumpCancellationTS.Token).ConfigureAwait(false);
                                     }
                                 }

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.de.json
+++ b/SpeechResponder/eddi.de.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -190,7 +190,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -208,7 +208,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -217,7 +217,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"
@@ -238,7 +238,7 @@
       "script": "Landing pads locked. Final jump preparations initiated.",
       "default": true,
       "name": "Carrier pads locked",
-      "description": "Triggered when your fleet carrier locks landing pads prior to jumping"
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
     },
     "Cleared save": {
       "enabled": true,

--- a/SpeechResponder/eddi.es.json
+++ b/SpeechResponder/eddi.es.json
@@ -186,6 +186,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to jumping"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.fr.json
+++ b/SpeechResponder/eddi.fr.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.hu.json
+++ b/SpeechResponder/eddi.hu.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.it.json
+++ b/SpeechResponder/eddi.it.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.pt-BR.json
+++ b/SpeechResponder/eddi.pt-BR.json
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -249,7 +249,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -258,7 +258,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/SpeechResponder/eddi.pt-BR.json
+++ b/SpeechResponder/eddi.pt-BR.json
@@ -227,6 +227,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -200,6 +200,60 @@
       "name": "Cargo wingupdate",
       "description": "Triggered when a wing-mate collects or delivers cargo for a wing mission"
     },
+    "Carrier cooldown": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Carrier cool down completed.",
+      "default": true,
+      "name": "Carrier cooldown",
+      "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
+    },
+    "Carrier jump cancelled": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump cancelled.",
+      "default": true,
+      "name": "Carrier jump cancelled",
+      "description": "Triggered when you cancel a scheduled fleet carrier jump"
+    },
+    "Carrier jump engaged": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump engaged",
+      "description": "Triggered when your fleet carrier performs a jump"
+    },
+    "Carrier jump request": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "default": true,
+      "name": "Carrier jump request",
+      "description": "Triggered when you request that your fleet carrier performs a jump"
+    },
+    "Carrier jumped": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "{_ Carrier jumped }\r\n{_ Triggered when you are docked at a fleet carrier as it completes a jump }\r\n\r\n{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'complete')}\r\n{SetState('eddi_context_system_name', event.systemname)}\r\n{SetState('eddi_context_system_system', event.systemname)}\r\n{SetState('eddi_context_wanted_list', \"\")}\r\n\r\nFleet carrier {P(event.carriername)} has arrived at the {P(event.systemname)} system\r\n{if event.bodyname && len(event.bodyname) > 0:\r\n    , near the {event.bodytype} {P(event.bodyname)}\r\n}.\r\n{Pause(1000)}\r\n\r\n{_ Update mission data if we have arrived at our mission destination. _}\r\n{if destinationsystem && destinationsystem.name != \"\":\r\n    {RouteDetails(\"update\")}\r\n}\r\n\r\n{_ Report faction states only if it's been more than an hour (3600 seconds) since our last visit. _}\r\n{if SecondsSince(state.eddi_context_system_lastvisit) / 3600 > 1:\r\n    {set state_report to F(\"System state report\")}\r\n}\r\n\r\n{set system_missions to F(\"Mission check system\")}\r\n{set system_crimes to F(\"Crime check system\")}\r\n\r\n{if state_report || system_missions || (system_crimes && find(system_crimes, \"Warning\") < 0):\r\n    {Pause(500)}\r\n    Information:\r\n}\r\n\r\n{if state_report:\r\n    {Pause(500)}\r\n    {state_report}\r\n}\r\n{if system_missions:\r\n    {Pause(500)}\r\n    {system_missions}\r\n}\r\n{if system_crimes:\r\n    {Pause(500)}\r\n    {system_crimes}\r\n}\r\n",
+      "default": true,
+      "name": "Carrier jumped",
+      "description": "Triggered when you are docked at a fleet carrier as it completes a jump"
+    },
+    "Carrier pads locked": {
+      "enabled": true,
+      "priority": 3,
+      "responder": true,
+      "script": "Landing pads locked. Final jump preparations initiated.",
+      "default": true,
+      "name": "Carrier pads locked",
+      "description": "Triggered when your fleet carrier locks landing pads prior to a jump"
+    },
     "Cleared save": {
       "enabled": true,
       "priority": 3,

--- a/SpeechResponder/eddi.ru.json
+++ b/SpeechResponder/eddi.ru.json
@@ -204,7 +204,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Carrier cool down completed.",
+      "script": "Fleet carrier cooldown completed.",
       "default": true,
       "name": "Carrier cooldown",
       "description": "Triggered when you were docked at a fleet carrier during a jump and it completes its cooldown"
@@ -222,7 +222,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump initiated for the {P(event.systemname)} star system.",
+      "script": "{_ Context }\r\n{SetState('eddi_context_last_subject', 'carrier jump')}\r\n{SetState('eddi_context_last_action', 'start')}\r\n{SetState('eddi_context_system_name', event.system)}\r\n{SetState('eddi_context_system_system', event.system)}\r\n{SetState('eddi_context_system_lastvisit', system.lastVisitSeconds)}\r\n\r\n{if environment = \"Docked\":\r\n\r\n    {_ Zero the 'remaining jump' context to only use values following this event _}\r\n    {SetState('eddi_context_remaining_jumps', 0)}\r\n\r\n    {set reportsystem to SystemDetails(event.systemname)}\r\n\r\n    {OneOf(\"Jump in progress\",\"Entering portal\")} to the {P(reportsystem.systemname)} system\r\n        {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n\r\n    {if reportsystem.systemname = homesystem.systemname:\r\n        Welcome home, {F(\"Honorific\")}\r\n    |else:       \r\n        {if lastsystem.allegiance && lastsystem.allegiance != \"None\" && lastsystem.allegiance != \"Independent\" && (!reportsystem.allegiance || reportsystem.allegiance = \"None\" || reportsystem.allegiance = \"Independent\"):\r\n            You {OneOf(\"are leaving\", \"have left\", \"are no longer in\")} {lastsystem.allegiance} space.\r\n        |elif lastsystem.allegiance && lastsystem.allegiance != reportsystem.allegiance && system.allegiance && system.allegiance != \"None\":\r\n            You {OneOf(\"are now in\", \"have entered\", \"are entering\")} {reportsystem.allegiance} space.\r\n            {if cmdr.title != \"Commander\":\r\n                Welcome back {F(\"Honorific\")}.\r\n            }\r\n        }\r\n\r\n        {if reportsystem.visits = 0:\r\n            This is your first visit to this system.\r\n        |elif reportsystem.visits = 1:\r\n            This is your second visit to this system.\r\n        |elif reportsystem.visits = 2:\r\n            {Occasionally(2, \"This is your third visit to this system.\")}\r\n        |elif reportsystem.visits = 3:\r\n            {Occasionally(2, \"This is your fourth visit to this system.\")}\r\n        |else:\r\n            {Occasionally(3, \"You have visited this system {reportsystem.visits} times.\")}\r\n        }\r\n\r\n        {if reportsystem.population && reportsystem.population > 0:\r\n            {if SecondsSince(reportsystem.lastVisitSeconds) > 3600:\r\n                {F(\"System report\")}\r\n            }\r\n        |else:\r\n            {OneOf(\"This system is not populated\",\"There is no human presence here\", \"Humans have yet to colonise this system\")}.\r\n        }\r\n\r\n        {if reportsystem.distancefromhome:\r\n            {set ReportDistanceFromHome() to:\r\n                {return cat(\r\n                \tOneOf(\"You are\", \"Current location is\", \"You are now\"), \" \",\r\n\t                Humanise(reportsystem.distancefromhome), \" lightyears from \",\r\n\t                OneOf(\"home\", \"{P(homesystem.name)}\"), \".\"\r\n\t            )}\r\n            }\r\n            {Occasionally(7, ReportDistanceFromHome())}\r\n        }\r\n\r\n        {if reportsystem.comment:\r\n            You made a {OneOf(\"note\", \"comment\", \"remark\")} {OneOf(\"about\", \"for\", \"on\")} this system.  It {OneOf(\"is as follows\", \"says\", \"reads\", \"is\")} {reportsystem.comment}.\r\n        }\r\n    }\r\n|else:\r\n    Fleet carrier arriving at the {P(event.systemname)} system\r\n    {if len(event.shortname) > 0:\r\n        {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n        near\r\n        {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n        {P(event.shortname)}\r\n    }.\r\n}",
       "default": true,
       "name": "Carrier jump engaged",
       "description": "Triggered when your fleet carrier performs a jump"
@@ -231,7 +231,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system.",
+      "script": "Fleet carrier jump scheduled. Course laid in for the {P(event.systemname)} star system\r\n{if len(event.shortname) > 0:\r\n    {set reportBody to BodyDetails(event.bodyname, event.systemname)} \r\n    , arriving near\r\n    {if len(reportBody.bodytype) > 0: {reportBody.bodytype} |else: body}\r\n    {P(event.shortname)}\r\n}.",
       "default": true,
       "name": "Carrier jump request",
       "description": "Triggered when you request that your fleet carrier performs a jump"

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -1227,5 +1227,44 @@ namespace UnitTests
             EngineerProgressedEvent rankEvent2 = (EngineerProgressedEvent)events[0];
             Assert.AreEqual(2, rankEvent2.Engineer?.rank);
         }
+
+        [TestMethod]
+        public void TestCarrierJumpedEvent()
+        {
+            string line = "{\"timestamp\":\"2020-05-17T14:07:24Z\",\"event\":\"CarrierJump\",\"Docked\":true,\"StationName\":\"G53-K3Q\",\"StationType\":\"FleetCarrier\",\"MarketID\":3700571136,\"StationFaction\":{\"Name\":\"FleetCarrier\"},\"StationGovernment\":\"$government_Carrier;\",\"StationGovernment_Localised\":\"Private Ownership \",\"StationServices\":[\"dock\",\"autodock\",\"blackmarket\",\"commodities\",\"contacts\",\"exploration\",\"crewlounge\",\"rearm\",\"refuel\",\"repair\",\"engineer\",\"flightcontroller\",\"stationoperations\",\"stationMenu\",\"carriermanagement\",\"carrierfuel\",\"voucherredemption\"],\"StationEconomy\":\"$economy_Carrier;\",\"StationEconomy_Localised\":\"Private Enterprise\",\"StationEconomies\":[{\"Name\":\"$economy_Carrier;\",\"Name_Localised\":\"Private Enterprise\",\"Proportion\":1}],\"StarSystem\":\"Aparctias\",\"SystemAddress\":358797513434,\"StarPos\":[25.1875,-56.375,22.90625],\"SystemAllegiance\":\"Independent\",\"SystemEconomy\":\"$economy_Colony;\",\"SystemEconomy_Localised\":\"Colony\",\"SystemSecondEconomy\":\"$economy_Refinery;\",\"SystemSecondEconomy_Localised\":\"Refinery\",\"SystemGovernment\":\"$government_Dictatorship;\",\"SystemGovernment_Localised\":\"Dictatorship\",\"SystemSecurity\":\"$SYSTEM_SECURITY_medium;\",\"SystemSecurity_Localised\":\"Medium Security\",\"Population\":80000,\"Body\":\"Aparctias\",\"BodyID\":0,\"BodyType\":\"Star\",\"Powers\":[\"Yuri Grom\"],\"PowerplayState\":\"Exploited\",\"Factions\":[{\"Name\":\"Union of Aparctias Future\",\"FactionState\":\"None\",\"Government\":\"Democracy\",\"Influence\":0.062,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0},{\"Name\":\"Monarchy of Aparctias\",\"FactionState\":\"None\",\"Government\":\"Feudal\",\"Influence\":0.035,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0},{\"Name\":\"Aparctias Purple Council\",\"FactionState\":\"Boom\",\"Government\":\"Anarchy\",\"Influence\":0.049,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"ActiveStates\":[{\"State\":\"Boom\"}]},{\"Name\":\"Beta-3 Tucani Silver Allied Net\",\"FactionState\":\"None\",\"Government\":\"Corporate\",\"Influence\":0.096,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0.32538},{\"Name\":\"Falcons' Nest\",\"FactionState\":\"None\",\"Government\":\"Confederacy\",\"Influence\":0.078,\"Allegiance\":\"Federation\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"RecoveringStates\":[{\"State\":\"NaturalDisaster\",\"Trend\":0}]},{\"Name\":\"EG Union\",\"FactionState\":\"War\",\"Government\":\"Dictatorship\",\"Influence\":0.34,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"ActiveStates\":[{\"State\":\"Boom\"},{\"State\":\"War\"}]},{\"Name\":\"Paladin Consortium\",\"FactionState\":\"War\",\"Government\":\"Democracy\",\"Influence\":0.34,\"Allegiance\":\"Independent\",\"Happiness\":\"$Faction_HappinessBand2;\",\"Happiness_Localised\":\"Happy\",\"MyReputation\":0,\"PendingStates\":[{\"State\":\"Boom\",\"Trend\":0},{\"State\":\"CivilLiberty\",\"Trend\":0}],\"ActiveStates\":[{\"State\":\"War\"}]}],\"SystemFaction\":{\"Name\":\"EG Union\",\"FactionState\":\"War\"},\"Conflicts\":[{\"WarType\":\"war\",\"Status\":\"active\",\"Faction1\":{\"Name\":\"EG Union\",\"Stake\":\"Hancock Refinery\",\"WonDays\":1},\"Faction2\":{\"Name\":\"Paladin Consortium\",\"Stake\":\"\",\"WonDays\":0}}]}";
+            List<Event> events = JournalMonitor.ParseJournalEntry(line);
+            CarrierJumpedEvent @event = (CarrierJumpedEvent)events[0];
+            Assert.IsTrue(@event.docked);
+            Assert.AreEqual("G53-K3Q", @event.carriername);
+            Assert.AreEqual("Fleet Carrier", @event.carrierType.invariantName);
+            Assert.AreEqual(3700571136, @event.carrierId);
+            Assert.AreEqual("FleetCarrier", @event.carrierFaction.name);
+            Assert.AreEqual("Private Ownership", @event.carrierFaction.Government.invariantName);
+            Assert.AreEqual(17, @event.carrierServices.Count);
+            Assert.AreEqual(1, @event.carrierEconomies.Count);
+            Assert.AreEqual("Private Enterprise", @event.carrierEconomies[0].economy.invariantName);
+            Assert.AreEqual("Aparctias", @event.systemname);
+			Assert.AreEqual(358797513434, @event.systemAddress);
+            Assert.AreEqual(25.1875M, @event.x);
+            Assert.AreEqual(-56.375M, @event.y);
+	        Assert.AreEqual(22.90625M, @event.z);
+            Assert.AreEqual("Independent", @event.controllingsystemfaction.Allegiance.invariantName);
+            Assert.AreEqual("Colony", @event.systemEconomy.invariantName);
+            Assert.AreEqual("Refinery", @event.systemEconomy2.invariantName);
+            Assert.AreEqual("Dictatorship", @event.controllingsystemfaction.Government.invariantName);
+            Assert.AreEqual("Medium", @event.securityLevel.invariantName);
+            Assert.AreEqual(80000, @event.population);
+            Assert.AreEqual("Aparctias", @event.bodyname);
+            Assert.AreEqual(0, @event.bodyId);
+            Assert.AreEqual("Star", @event.bodyType.invariantName);
+            Assert.AreEqual("Yuri Grom", @event.Power.invariantName);
+            Assert.AreEqual("Exploited", @event.powerState.invariantName);
+            Assert.AreEqual(7, @event.factions.Count);
+            Assert.AreEqual("EG Union", @event.controllingsystemfaction.name);
+            Assert.AreEqual("War", @event.controllingsystemfaction.presences.FirstOrDefault(p => p.systemName == "Aparctias")?.FactionState.invariantName);
+            Assert.AreEqual(1, @event.conflicts.Count);
+            Assert.AreEqual("EG Union", @event.conflicts[0].faction1);
+            Assert.AreEqual("Paladin Consortium", @event.conflicts[0].faction2);
+        }
     }
 }

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -67,6 +67,11 @@ namespace Utilities
         {
             {1, 4.00M}, {2, 6.00M}, {3, 7.75M}, {4, 9.25M}, {5, 10.50M}
         };
+
+        // Fleet Carrier Constants
+        public const int carrierPreJumpSeconds = 900; // 15 minutes (900s) to spool up before jumping
+        public const int carrierPostJumpSeconds = 300; // 5 minutes (300s) cool down
+        public const int carrierLandingPadLockdownSeconds = 200; // Landing pads are locked down 200 seconds prior to jumping
     }
 
     public class ConstantConverters

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -69,9 +69,9 @@ namespace Utilities
         };
 
         // Fleet Carrier Constants
-        public const int carrierPreJumpSeconds = 900; // 15 minutes (900s) to spool up before jumping
-        public const int carrierPostJumpSeconds = 300; // 5 minutes (300s) cool down
-        public const int carrierLandingPadLockdownSeconds = 200; // Landing pads are locked down 200 seconds prior to jumping
+        public const int carrierPreJumpSeconds = 960; // 16 minutes to spool up before jumping (minus the absolute value of the difference from 10 seconds after the minute)
+        public const int carrierPostJumpSeconds = 300; // 5 minutes cool down
+        public const int carrierLandingPadLockdownSeconds = 180; // Landing pads are locked down 3 minutes prior to jumping
     }
 
     public class ConstantConverters


### PR DESCRIPTION
From the journal manual, v28:
✔️ 11.1 CarrierJumpedEvent
✔️ 11.4 CarrierJumpRequestEvent
✔️ 11.16 CarrierJumpCancelledEvent

Include synthetic, timer based events for:
- CarrierPadsLockedEvent
- CarrierJumpEngagedEvent
- CarrierCooldownEvent

Please play attention to state tracking when testing and verify that it is robust.
Event scripts are subject to change, please provide feedback.