### PR TITLE
Resolve possible divide by zero exception in the Status Monitor

### DIFF
--- a/StatusMonitor/StatusMonitor.cs
+++ b/StatusMonitor/StatusMonitor.cs
@@ -576,12 +576,12 @@ namespace EddiStatusMonitor
             if (currentStatus.vehicle == Constants.VEHICLE_SHIP)
             {
                 Ship ship = EDDI.Instance.CurrentShip;
-                if (ship?.fueltanktotalcapacity != null && fuelRemaining != null)
+                if (ship?.fueltanktotalcapacity > 0)
                 {
                     // Fuel recorded in Status.json includes the fuel carried in the Active Fuel Reservoir
                     decimal percent = (decimal)(fuelRemaining / (ship.fueltanktotalcapacity + ship.activeFuelReservoirCapacity) * 100);
                     fuel_percent = percent > 10 ? Math.Round(percent, 0) : Math.Round(percent, 1);
-                    fuel_seconds = (fuelPerSecond is null || fuelPerSecond == 0) ? null : (int?)((ship.fueltanktotalcapacity + ship.activeFuelReservoirCapacity) / fuelPerSecond);
+                    fuel_seconds = fuelPerSecond > 0 ? (int?)((ship.fueltanktotalcapacity + ship.activeFuelReservoirCapacity) / fuelPerSecond) : null;
                 }
             }
             else if (currentStatus.vehicle == Constants.VEHICLE_SRV)
@@ -589,7 +589,7 @@ namespace EddiStatusMonitor
                 const decimal srvFuelTankCapacity = 0.45M;
                 decimal percent = (decimal)(fuelRemaining / srvFuelTankCapacity * 100);
                 fuel_percent = percent > 10 ? Math.Round(percent, 0) : Math.Round(percent, 1);
-                fuel_seconds = (fuelPerSecond is null || fuelPerSecond == 0) ? null : (int?)(srvFuelTankCapacity / fuelPerSecond);
+                fuel_seconds = fuelPerSecond > 0 ? (int?)(srvFuelTankCapacity / fuelPerSecond) : null;
             }
             return; // At present, fighters do not appear to consume fuel.
         }


### PR DESCRIPTION
Resolves an exception like:
```
2020-05-28T06:24:19 [Warning] StatusMonitor:ParseStatusEntry Failed to parse Status.json line: System.DivideByZeroException: Attempted to divide by zero.
   at System.Decimal.FCallDivide(Decimal& d1, Decimal& d2)
   at System.Decimal.op_Division(Decimal d1, Decimal d2)
   at EddiStatusMonitor.StatusMonitor.FuelPercentAndTime(Nullable`1 fuelRemaining, Nullable`1 fuelPerSecond, Nullable`1& fuel_percent, Nullable`1& fuel_seconds)
   at EddiStatusMonitor.StatusMonitor.SetFuelExtras(Status status)
   at EddiStatusMonitor.StatusMonitor.ParseStatusEntry(String line)
```
that can occur if `ship?.fueltanktotalcapacity` == 0.