### PR TITLE
Handle null powerplay data in the `Jumped` event

### DIFF
--- a/Events/JumpedEvent.cs
+++ b/Events/JumpedEvent.cs
@@ -73,8 +73,8 @@ namespace EddiEvents
         public string government => (controllingfaction?.Government ?? Government.None).localizedName;
 
         // Powerplay properties (only when pledged)
-        public string power => Power.localizedName;
-        public string powerstate => powerState.localizedName;
+        public string power => (Power ?? Power.None).localizedName;
+        public string powerstate => (powerState ?? PowerplayState.None).localizedName;
 
         // These properties are not intended to be user facing
         public long systemAddress { get; private set; }


### PR DESCRIPTION
Prevents a NullReferenceException that could occur when `Power` and `powerState` values are null.