### PR TITLE
Fix "Reset" button state for edited responder scripts w/ null default values

### DIFF
--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -131,7 +131,7 @@ namespace EddiSpeechResponder
         private void acceptButtonClick(object sender, RoutedEventArgs e)
         {
             // Update the script
-            string newScriptText = scriptView.Text;
+            string newScriptText = string.IsNullOrWhiteSpace(scriptView.Text) ? null : scriptView.Text;
             if (_script != null)
             {
                 Script newScript = new Script(scriptName, 

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -46,7 +46,10 @@ namespace EddiSpeechResponder
         }
 
         [JsonProperty("default")]
-        public bool Default => Value == defaultValue;
+        // Determine whether the script matches the default, treating empty strings and null values as equal
+        public bool Default => string.IsNullOrWhiteSpace(Value) 
+            ? string.IsNullOrWhiteSpace(defaultValue) 
+            : string.Equals(Value, defaultValue);
 
         [JsonIgnore]
         public bool IsResettableOrDeletable


### PR DESCRIPTION
Hitting "Accept" after editing a responder script could activate the "Reset" button even when the script was unchanged / empty because the evaluation of whether the script was default would compare an empty string to a null value ("" == null) and return false while the desired result was true.
This
1. Updates the comparison to the default in the script object so that null values and empty strings are treated as equal.
2. Saves script values as null rather than "" when accepting an empty responder script.