### PR TITLE
Improvements to phonetics

### DIFF
--- a/CrimeMonitor/CrimeMonitor.cs
+++ b/CrimeMonitor/CrimeMonitor.cs
@@ -1025,7 +1025,7 @@ namespace EddiCrimeMonitor
             {
                 // Filter stations within the faction system which meet the station type prioritization,
                 // max distance from the main star, game version, and landing pad size requirements
-                LandingPadSize padSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
+                LandingPadSize padSize = EDDI.Instance?.CurrentShip?.Size ?? LandingPadSize.Large;
                 List<Station> factionStations = !prioritizeOrbitalStations && EDDI.Instance.inHorizons ? factionStarSystem.stations : factionStarSystem.orbitalstations
                     .Where(s => s.stationservices.Count > 0).ToList();
                 factionStations = factionStations.Where(s => s.distancefromstar <= maxStationDistanceFromStarLs).ToList();

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -21,17 +21,23 @@ namespace EddiDataDefinitions
         [JsonIgnore]
         public string manufacturer { get; set; }
 
-        /// <summary>the spoken manufacturer of the ship (Lakon, CoreDynamics etc.)</summary>
+        /// <summary>the spoken manufacturer of the ship (Lakon, CoreDynamics etc.) (rendered using ssml and IPA)</summary>
         [JsonIgnore]
-        public List<Translation> phoneticmanufacturer { get; set; }
+        public string phoneticmanufacturer => SpokenManufacturer();
 
-        /// <summary>the spoken model of the ship (Python, Anaconda, etc.)</summary>
+        /// <summary>the spoken model of the ship (Python, Anaconda, etc.) (rendered using ssml and IPA)</summary>
         [JsonIgnore]
-        public List<Translation> phoneticmodel { get; set; }
+        public string phoneticmodel => SpokenModel();
+        [JsonIgnore]
+        public List<Translation> phoneticModel { get; set; }
 
         /// <summary>the size of this ship</summary>
         [JsonIgnore]
-        public LandingPadSize size { get; set; }
+        public LandingPadSize Size { get; set; }
+
+        /// <summary>the spoken size of this ship</summary>
+        [JsonIgnore]
+        public string size => Size.localizedName;
 
         /// <summary>the size of the military compartment slots</summary>
         [JsonIgnore]
@@ -372,15 +378,14 @@ namespace EddiDataDefinitions
             cargohatch = new Module();
         }
 
-        public Ship(long EDID, string EDName, string Manufacturer, List<Translation> PhoneticManufacturer, string Model, List<Translation> PhoneticModel, string Size, int? MilitarySize, decimal reservoirFuelTankSize)
+        public Ship(long EDID, string EDName, string Manufacturer, string Model, List<Translation> PhoneticModel, string Size, int? MilitarySize, decimal reservoirFuelTankSize)
         {
             this.EDID = EDID;
             this.EDName = EDName;
             manufacturer = Manufacturer;
-            phoneticmanufacturer = PhoneticManufacturer;
             model = Model;
-            phoneticmodel = PhoneticModel;
-            size = LandingPadSize.FromEDName(Size);
+            phoneticModel = PhoneticModel;
+            this.Size = LandingPadSize.FromEDName(Size);
             militarysize = MilitarySize;
             health = 100M;
             hardpoints = new List<Hardpoint>();
@@ -406,8 +411,8 @@ namespace EddiDataDefinitions
 
         public string SpokenName(string defaultname = null)
         {
-            string model = (defaultname ?? SpokenModel()) ?? Properties.Ship._ship;
-            string result = Properties.Ship.your + " " + model;
+            string ship = (defaultname ?? phoneticmodel) ?? Properties.Ship._ship;
+            string result = Properties.Ship.your + " " + ship;
             if (!string.IsNullOrWhiteSpace(phoneticName))
             {
                 result = "<phoneme alphabet=\"ipa\" ph=\"" + phoneticName + "\">" + name + "</phoneme>";
@@ -422,14 +427,14 @@ namespace EddiDataDefinitions
         public string SpokenModel()
         {
             string result;
-            if (phoneticmodel == null)
+            if (phoneticModel == null)
             {
                 result = model;
             }
             else
             {
                 result = "";
-                foreach (Translation item in phoneticmodel)
+                foreach (Translation item in phoneticModel)
                 {
                     result += "<phoneme alphabet=\"ipa\" ph=\"" + item.to + "\">" + item.from + "</phoneme> ";
                 }
@@ -437,23 +442,7 @@ namespace EddiDataDefinitions
             return result;
         }
 
-        public string SpokenManufacturer()
-        {
-            string result;
-            if (phoneticmanufacturer == null)
-            {
-                result = manufacturer;
-            }
-            else
-            {
-                result = "";
-                foreach (Translation item in phoneticmanufacturer)
-                {
-                    result += "<phoneme alphabet=\"ipa\" ph=\"" + item.to + "\">" + item.from + "</phoneme> ";
-                }
-            }
-            return result;
-        }
+        public string SpokenManufacturer() => ShipDefinitions.SpokenManufacturer(manufacturer) ?? manufacturer;
 
         /// <summary> Calculates the distance from the specified coordinates to the ship's recorded x, y, and z coordinates </summary>
         public decimal? Distance(decimal? fromX, decimal? fromY, decimal? fromZ)
@@ -538,9 +527,8 @@ namespace EddiDataDefinitions
                 EDID = template.EDID;
                 EDName = template.EDName;
                 manufacturer = template.manufacturer;
-                phoneticmanufacturer = template.phoneticmanufacturer;
-                phoneticmodel = template.phoneticmodel;
-                size = template.size;
+                phoneticModel = template.phoneticModel;
+                Size = template.Size;
                 militarysize = template.militarysize;
                 activeFuelReservoirCapacity = template.activeFuelReservoirCapacity;
                 if (Role == null)

--- a/DataDefinitions/ShipDefinitions.cs
+++ b/DataDefinitions/ShipDefinitions.cs
@@ -6,52 +6,61 @@ namespace EddiDataDefinitions
 {
     public class ShipDefinitions
     {
-        private static Dictionary<long, Ship> ShipsByEliteID = new Dictionary<long, Ship>()
+        private static readonly Dictionary<long, Ship> ShipsByEliteID = new Dictionary<long, Ship>()
         {
-            { 128049267, new Ship(128049267, "Adder", "Zorgon Peterson", null, "Adder", null, "Small", null, 0.36M) },
-            { 128049363, new Ship(128049363, "Anaconda", "Faulcon DeLacy", null, "Anaconda", null, "Large", 5, 1.07M) },
-            { 128049303, new Ship(128049303, "Asp", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Asp Explorer", null, "Medium", null, 0.63M) },
-            { 128672276, new Ship(128672276, "Asp_Scout", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Asp Scout", null, "Medium", null, 0.47M) },
-            { 128049345, new Ship(128049345, "BelugaLiner", "Saud Kruger", new List<Translation> {new Translation("Saud", "saʊd"), new Translation("Kruger", "ˈkruːɡə") }, "Beluga", new List<Translation> {new Translation("beluga", "bɪˈluːɡə") }, "Large", null, 0.81M) },
-            { 128049279, new Ship(128049279, "CobraMkIII", "Faulcon DeLacy", null, "Cobra Mk. III", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, "Small", null, 0.49M) },
-            { 128672262, new Ship(128672262, "CobraMkIV", "Faulcon DeLacy", null, "Cobra Mk. IV", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, "Small", null, 0.51M) },
-            { 128671831, new Ship(128671831, "DiamondbackXL", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Diamondback Explorer", null, "Small", null, 0.52M) },
-            { 128671217, new Ship(128671217, "Diamondback", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Diamondback Scout", null, "Small", null, 0.49M) },
-            { 128049291, new Ship(128049291, "Dolphin", "Saud Kruger", new List<Translation> {new Translation("Saud", "saʊd"), new Translation("Kruger", "ˈkruːɡə") }, "Dolphin", null, "Small", null, 0.50M) },
-            { 128049255, new Ship(128049255, "Eagle", "Core Dynamics", null, "Eagle", null, "Small", null, 0.34M) },
-            { 128672145, new Ship(128672145, "Federation_Dropship_MkII", "Core Dynamics", null, "Federal Assault Ship", null, "Medium", 4, 0.72M) },
-            { 128049369, new Ship(128049369, "Federation_Corvette", "Core Dynamics", null, "Federal Corvette", null, "Large", 5, 1.13M) },
-            { 128049321, new Ship(128049321, "Federation_Dropship", "Core Dynamics", null, "Federal Dropship", null, "Medium", 4, 0.83M) },
-            { 128672152, new Ship(128672152, "Federation_Gunship", "Core Dynamics", null, "Federal Gunship", null, "Medium", 4, 0.82M) },
-            { 128049351, new Ship(128049351, "FerDeLance", "Zorgon Peterson", null, "Fer-de-Lance", new List<Translation> {new Translation("fer-de-lance", "ˌfɛədəˈlɑːns") }, "Medium", null, 0.67M) },
-            { 128049315, new Ship(128049315, "Empire_Trader", "Gutamaya", new List<Translation> {new Translation("Gutamaya", "guːtəˈmaɪə") }, "Imperial Clipper", null, "Large", 5, 0.74M) },
-            { 128671223, new Ship(128671223, "Empire_Courier", "Gutamaya", new List<Translation> {new Translation("Gutamaya", "guːtəˈmaɪə") }, "Imperial Courier", null, "Small", null, 0.41M) },
-            { 128049375, new Ship(128049375, "Cutter", "Gutamaya", new List<Translation> {new Translation("Gutamaya", "guːtəˈmaɪə") }, "Imperial Cutter", null, "Large", 5, 1.16M) },
-            { 128672138, new Ship(128672138, "Empire_Eagle", "Gutamaya", new List<Translation> {new Translation("Gutamaya", "guːtəˈmaɪə") }, "Imperial Eagle", null, "Small", 2, 0.37M) },
-            { 128049261, new Ship(128049261, "Hauler", "Zorgon Peterson", null, "Hauler", null, "Small", null, 0.25M) },
-            { 128672269, new Ship(128672269, "Independant_Trader", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Keelback", null, "Medium", null, 0.39M) },
-            { 128049327, new Ship(128049327, "Orca", "Saud Kruger", new List<Translation> {new Translation("Saud", "saʊd"), new Translation("Kruger", "ˈkruːɡə") }, "Orca", null, "Large", null, 0.79M) },
-            { 128049339, new Ship(128049339, "Python", "Faulcon DeLacy", null, "Python", null, "Medium", null, 0.83M)},
-            { 128049249, new Ship(128049249, "Sidewinder", "Faulcon DeLacy", null, "Sidewinder", null, "Small", null, 0.3M) },
-            { 128049285, new Ship(128049285, "Type6", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Type-6 Transporter", null, "Medium", null, 0.39M) },
-            { 128049297, new Ship(128049297, "Type7", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Type-7 Transporter", null, "Large", null, 0.52M) },
-            { 128049333, new Ship(128049333, "Type9", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Type-9 Heavy", null, "Large", null, 0.77M) },
-            { 128049273, new Ship(128049273, "Viper", "Faulcon DeLacy", null, "Viper Mk. III", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, "Small", 3, 0.41M) },
-            { 128672255, new Ship(128672255, "Viper_MkIV", "Faulcon DeLacy", null, "Viper Mk. IV", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, "Small", 3, 0.46M) },
-            { 128049309, new Ship(128049309, "Vulture", "Core Dynamics", null, "Vulture", new List<Translation> { new Translation("vulture", "ˈvʌltʃə") }, "Small", 5, 0.57M) },
-            { 128785619, new Ship(128785619, "Type9_Military", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Type-10 Defender", null, "Large", 5, 0.77M) },
-            { 128816574, new Ship(128816574, "TypeX", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Alliance Chieftain", null, "Medium", 4, 0.77M) },
-            { 128816581, new Ship(128816581, "TypeX_2", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Alliance Crusader", null, "Medium", 4, 0.77M) },
-            { 128816588, new Ship(128816588, "TypeX_3", "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn") }, "Alliance Challenger", null, "Medium", 4, 0.77M) },
-            { 128816567, new Ship(128816567, "Krait_MkII", "Faulcon DeLacy", null, "Krait Mk. II", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Mark", "mɑːk"), new Translation("2", "ˈtuː") }, "Medium", null, 0.63M) },
-            { 128839281, new Ship(128839281, "Krait_Light", "Faulcon DeLacy", null, "Krait Phantom", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Phantom", "ˈfæntəm") }, "Medium", null, 0.63M) },
-            { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", null, "Mamba", null, "Medium", null, 0.5M) },
+            { 128049267, new Ship(128049267, "Adder", "Zorgon Peterson", "Adder", null, "Small", null, 0.36M) },
+            { 128049363, new Ship(128049363, "Anaconda", "Faulcon DeLacy", "Anaconda", null, "Large", 5, 1.07M) },
+            { 128049303, new Ship(128049303, "Asp", "Lakon Spaceways", "Asp Explorer", null, "Medium", null, 0.63M) },
+            { 128672276, new Ship(128672276, "Asp_Scout", "Lakon Spaceways", "Asp Scout", null, "Medium", null, 0.47M) },
+            { 128049345, new Ship(128049345, "BelugaLiner", "Saud Kruger", "Beluga", new List<Translation> {new Translation("beluga", "bɪˈluːɡə") }, "Large", null, 0.81M) },
+            { 128049279, new Ship(128049279, "CobraMkIII", "Faulcon DeLacy", "Cobra Mk. III", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, "Small", null, 0.49M) },
+            { 128672262, new Ship(128672262, "CobraMkIV", "Faulcon DeLacy", "Cobra Mk. IV", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, "Small", null, 0.51M) },
+            { 128671831, new Ship(128671831, "DiamondbackXL", "Lakon Spaceways", "Diamondback Explorer", null, "Small", null, 0.52M) },
+            { 128671217, new Ship(128671217, "Diamondback", "Lakon Spaceways", "Diamondback Scout", null, "Small", null, 0.49M) },
+            { 128049291, new Ship(128049291, "Dolphin", "Saud Kruger", "Dolphin", null, "Small", null, 0.50M) },
+            { 128049255, new Ship(128049255, "Eagle", "Core Dynamics", "Eagle", null, "Small", null, 0.34M) },
+            { 128672145, new Ship(128672145, "Federation_Dropship_MkII", "Core Dynamics", "Federal Assault Ship", null, "Medium", 4, 0.72M) },
+            { 128049369, new Ship(128049369, "Federation_Corvette", "Core Dynamics", "Federal Corvette", null, "Large", 5, 1.13M) },
+            { 128049321, new Ship(128049321, "Federation_Dropship", "Core Dynamics", "Federal Dropship", null, "Medium", 4, 0.83M) },
+            { 128672152, new Ship(128672152, "Federation_Gunship", "Core Dynamics", "Federal Gunship", null, "Medium", 4, 0.82M) },
+            { 128049351, new Ship(128049351, "FerDeLance", "Zorgon Peterson", "Fer-de-Lance", new List<Translation> {new Translation("fer-de-lance", "ˌfɛədəˈlɑːns") }, "Medium", null, 0.67M) },
+            { 128049315, new Ship(128049315, "Empire_Trader", "Gutamaya", "Imperial Clipper", null, "Large", 5, 0.74M) },
+            { 128671223, new Ship(128671223, "Empire_Courier", "Gutamaya", "Imperial Courier", null, "Small", null, 0.41M) },
+            { 128049375, new Ship(128049375, "Cutter", "Gutamaya", "Imperial Cutter", null, "Large", 5, 1.16M) },
+            { 128672138, new Ship(128672138, "Empire_Eagle", "Gutamaya", "Imperial Eagle", null, "Small", 2, 0.37M) },
+            { 128049261, new Ship(128049261, "Hauler", "Zorgon Peterson", "Hauler", null, "Small", null, 0.25M) },
+            { 128672269, new Ship(128672269, "Independant_Trader", "Lakon Spaceways", "Keelback", null, "Medium", null, 0.39M) },
+            { 128049327, new Ship(128049327, "Orca", "Saud Kruger", "Orca", null, "Large", null, 0.79M) },
+            { 128049339, new Ship(128049339, "Python", "Faulcon DeLacy", "Python", null, "Medium", null, 0.83M)},
+            { 128049249, new Ship(128049249, "Sidewinder", "Faulcon DeLacy", "Sidewinder", null, "Small", null, 0.3M) },
+            { 128049285, new Ship(128049285, "Type6", "Lakon Spaceways", "Type-6 Transporter", null, "Medium", null, 0.39M) },
+            { 128049297, new Ship(128049297, "Type7", "Lakon Spaceways", "Type-7 Transporter", null, "Large", null, 0.52M) },
+            { 128049333, new Ship(128049333, "Type9", "Lakon Spaceways", "Type-9 Heavy", null, "Large", null, 0.77M) },
+            { 128049273, new Ship(128049273, "Viper", "Faulcon DeLacy", "Viper Mk. III", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, "Small", 3, 0.41M) },
+            { 128672255, new Ship(128672255, "Viper_MkIV", "Faulcon DeLacy", "Viper Mk. IV", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, "Small", 3, 0.46M) },
+            { 128049309, new Ship(128049309, "Vulture", "Core Dynamics", "Vulture", new List<Translation> { new Translation("vulture", "ˈvʌltʃə") }, "Small", 5, 0.57M) },
+            { 128785619, new Ship(128785619, "Type9_Military", "Lakon Spaceways", "Type-10 Defender", null, "Large", 5, 0.77M) },
+            { 128816574, new Ship(128816574, "TypeX", "Lakon Spaceways", "Alliance Chieftain", null, "Medium", 4, 0.77M) },
+            { 128816581, new Ship(128816581, "TypeX_2", "Lakon Spaceways", "Alliance Crusader", null, "Medium", 4, 0.77M) },
+            { 128816588, new Ship(128816588, "TypeX_3", "Lakon Spaceways", "Alliance Challenger", null, "Medium", 4, 0.77M) },
+            { 128816567, new Ship(128816567, "Krait_MkII", "Faulcon DeLacy", "Krait Mk. II", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Mark", "mɑːk"), new Translation("2", "ˈtuː") }, "Medium", null, 0.63M) },
+            { 128839281, new Ship(128839281, "Krait_Light", "Faulcon DeLacy", "Krait Phantom", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Phantom", "ˈfæntəm") }, "Medium", null, 0.63M) },
+            { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", "Mamba", null, "Medium", null, 0.5M) },
         };
 
         public static readonly SortedSet<string> ShipModels = new SortedSet<string>(ShipsByEliteID.Select(kp => kp.Value.model));
 
-        private static Dictionary<string, Ship> ShipsByModel = ShipsByEliteID.ToDictionary(kp => kp.Value.model.ToLowerInvariant(), kp => kp.Value);
-        private static Dictionary<string, Ship> ShipsByEDModel = ShipsByEliteID.ToDictionary(kp => kp.Value.EDName.ToLowerInvariant().Replace(" ", "").Replace(".", "").Replace("_", ""), kp => kp.Value);
+        private static readonly Dictionary<string, Ship> ShipsByModel = ShipsByEliteID.ToDictionary(kp => kp.Value.model.ToLowerInvariant(), kp => kp.Value);
+        private static readonly Dictionary<string, Ship> ShipsByEDModel = ShipsByEliteID.ToDictionary(kp => kp.Value.EDName.ToLowerInvariant().Replace(" ", "").Replace(".", "").Replace("_", ""), kp => kp.Value);
+        public static readonly Dictionary<string, List<Translation>> ManufacturerPhoneticNames = new Dictionary<string, List<Translation>>()
+        {
+            { "Core Dynamics", null },
+            { "Faulcon DeLacy", null },
+            { "Gutamaya", new List<Translation> {new Translation("Gutamaya", "guːtəˈmaɪə") }},
+            { "Lakon Spaceways", new List<Translation> {new Translation("Lakon", "leɪkɒn"), new Translation("Spaceways", "speɪsweɪz") }},
+            { "Saud Kruger", new List<Translation> {new Translation("Saud", "saʊd"), new Translation("Kruger", "ˈkruːɡə") }},
+            { "Zorgon Peterson", null }
+        };
 
         /// <summary>Obtain details of a ship given its Elite ID</summary>
         public static Ship FromEliteID(long id)
@@ -62,10 +71,9 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
-                Ship.phoneticmanufacturer = Template.phoneticmanufacturer;
                 Ship.model = Template.model;
-                Ship.phoneticmodel = Template.phoneticmodel;
-                Ship.size = Template.size;
+                Ship.phoneticModel = Template.phoneticModel;
+                Ship.Size = Template.Size;
                 Ship.militarysize = Template.militarysize;
                 Ship.activeFuelReservoirCapacity = Template.activeFuelReservoirCapacity;
             }
@@ -89,10 +97,9 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
-                Ship.phoneticmanufacturer = Template.phoneticmanufacturer;
                 Ship.model = Template.model;
-                Ship.phoneticmodel = Template.phoneticmodel;
-                Ship.size = Template.size;
+                Ship.phoneticModel = Template.phoneticModel;
+                Ship.Size = Template.Size;
                 Ship.militarysize = Template.militarysize;
                 Ship.activeFuelReservoirCapacity = Template.activeFuelReservoirCapacity;
             }
@@ -122,10 +129,9 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
-                Ship.phoneticmanufacturer = Template.phoneticmanufacturer;
                 Ship.model = Template.model;
-                Ship.phoneticmodel = Template.phoneticmodel;
-                Ship.size = Template.size;
+                Ship.phoneticModel = Template.phoneticModel;
+                Ship.Size = Template.Size;
                 Ship.militarysize = Template.militarysize;
                 Ship.activeFuelReservoirCapacity = Template.activeFuelReservoirCapacity;
             }
@@ -179,5 +185,21 @@ namespace EddiDataDefinitions
             { "Krait Phantom", "Krait_Light" },
             { "Mamba", "Mamba" },
         };
+
+        public static string SpokenManufacturer(string manufacturer)
+        {
+            var phoneticmanufacturer = ManufacturerPhoneticNames.FirstOrDefault(m => m.Key == manufacturer).Value;
+            if (phoneticmanufacturer != null)
+            {
+                var result = "";
+                foreach (Translation item in phoneticmanufacturer)
+                {
+                    result += "<phoneme alphabet=\"ipa\" ph=\"" + item.to + "\">" + item.from + "</phoneme> ";
+                }
+                return result;
+            }
+            // Model isn't in the dictionary
+            return null;
+        }
     }
 }

--- a/NavigationService/NavigationService.cs
+++ b/NavigationService/NavigationService.cs
@@ -420,7 +420,7 @@ namespace EddiNavigationService
             StarSystem currentSystem = EDDI.Instance?.CurrentStarSystem;
             if (currentSystem != null)
             {
-                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
+                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.Size ?? LandingPadSize.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
 
                 StarSystem ServiceStarSystem = GetServiceSystem(serviceType, maxStationDistance, prioritizeOrbitalStations);
@@ -466,7 +466,7 @@ namespace EddiNavigationService
             if (currentSystem != null)
             {
                 // Get the filter parameters
-                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.size ?? LandingPadSize.Large;
+                LandingPadSize shipSize = EDDI.Instance?.CurrentShip?.Size ?? LandingPadSize.Large;
                 ServiceFilter.TryGetValue(serviceType, out dynamic filter);
                 int cubeLy = filter.cubeLy;
 

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -390,7 +390,7 @@ namespace EddiShipMonitor
                 updatedAt = @event.timestamp;
 
                 // Save swapped ship size for minor faction station update
-                LandingPadSize swappedShipSize = GetCurrentShip()?.size;
+                LandingPadSize swappedShipSize = GetCurrentShip()?.Size;
 
                 // Set ship hull and module health with a profile refresh before we write the stored ship.
                 EDDI.Instance?.refreshProfile();
@@ -421,7 +421,7 @@ namespace EddiShipMonitor
                 if (!@event.fromLoad) { writeShips(); }
 
                 // Update stations in minor faction records
-                if (swappedShipSize != LandingPadSize.Large && swappedShipSize != GetCurrentShip()?.size)
+                if (swappedShipSize != LandingPadSize.Large && swappedShipSize != GetCurrentShip()?.Size)
                 {
                     ((CrimeMonitor)EDDI.Instance.ObtainMonitor("Crime monitor"))?.UpdateStations();
                 }

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -299,52 +299,7 @@ namespace EddiSpeechResponder
             store["P"] = new NativeFunction((values) =>
             {
                 string val = values[0].AsString;
-                string translation = val;
-                if (translation == val)
-                {
-                    translation = Translations.StellarClass(val);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.PlanetClass(val);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.Body(val, useICAO);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.StarSystem(val, useICAO);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.Station(val);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.Faction(val);
-                }
-                if (translation == val)
-                {
-                    translation = Translations.Power(val);
-                }
-                if (translation == val)
-                {
-                    Ship ship = ShipDefinitions.FromModel(val);
-                    if (ship != null && ship.EDID > 0)
-                    {
-                        translation = ship.SpokenModel();
-                    }
-                }
-                if (translation == val)
-                {
-                    Ship ship = ShipDefinitions.FromEDModel(val);
-                    if (ship != null && ship.EDID > 0)
-                    {
-                        translation = ship.SpokenModel();
-                    }
-                }
-                return translation;
+                return Translations.GetTranslation(val, useICAO);
             }, 1);
 
             // Boolean constants
@@ -615,17 +570,17 @@ namespace EddiSpeechResponder
                     {
                         // Obtain the first three characters
                         string chars = new Regex("[^a-zA-Z0-9]").Replace(EDDI.Instance.Cmdr.name, "").ToUpperInvariant().Substring(0, 3);
-                        result = ship.SpokenManufacturer() + " " + Translations.ICAO(chars);
+                        result = ship.phoneticmanufacturer + " " + Translations.ICAO(chars);
                     }
                     else
                     {
-                        if (ship.SpokenManufacturer() == null)
+                        if (string.IsNullOrEmpty(ship.phoneticmanufacturer))
                         {
                             result = "unidentified ship";
                         }
                         else
                         {
-                            result = "unidentified " + ship.SpokenManufacturer() + " " + ship.SpokenModel();
+                            result = "unidentified " + ship.phoneticmanufacturer + " " + ship.phoneticmodel;
                         }
                     }
                 }

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -313,6 +313,8 @@ Any values might be missing, depending on EDDI's configuration.
     - `cargocapacity` the total tonnage cargo capacity
     - `name` the name of the ship
     - `phoneticname` the name of the ship, using any phonetic pronunciation that has been set and is supported by the current voice 
+    - `phoneticmodel` the model of the ship, using any phonetic pronunciation that has been set and is supported by the current voice 
+    - `phoneticmanufacturer` the manufacturer of the ship, using any phonetic pronunciation that has been set and is supported by the current voice 
     - `ident` the identifier of the ship
     - `role` the role of the ship 
     - `health` the last reported health of the hull, from 0 to 100

--- a/SpeechService/SpeechFX.cs
+++ b/SpeechService/SpeechFX.cs
@@ -88,15 +88,15 @@ namespace EddiSpeechService
             int echoDelay = 50; // Default
             if (ship != null)
             {
-                if (ship.size == LandingPadSize.Small)
+                if (ship.Size == LandingPadSize.Small)
                 {
                     echoDelay = 50;
                 }
-                else if (ship.size == LandingPadSize.Medium)
+                else if (ship.Size == LandingPadSize.Medium)
                 {
                     echoDelay = 100;
                 }
-                else if (ship.size == LandingPadSize.Large)
+                else if (ship.Size == LandingPadSize.Large)
                 {
                     echoDelay = 200;
                 }

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -3,12 +3,64 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Utilities;
 
 namespace EddiSpeechService
 {
     /// <summary>Translations for Elite items for text-to-speech</summary>
     public class Translations
     {
+        public static string GetTranslation(string val, bool useICAO = false)
+        {
+            // Translations from fixed dictionaries
+            string translation = val;
+            if (translation == val)
+            {
+                translation = Power(val);
+            }
+            if (translation == val)
+            {
+                translation = StellarClass(val);
+            }
+            if (translation == val)
+            {
+                translation = PlanetClass(val);
+            }
+            if (translation == val)
+            {
+                Ship ship = ShipDefinitions.FromModel(val);
+                if (ship != null && ship.EDID > 0)
+                {
+                    translation = ship.SpokenModel();
+                }
+            }
+            if (translation == val)
+            {
+                string phoneticManufacturer = ShipDefinitions.SpokenManufacturer(val);
+                if (phoneticManufacturer != null)
+                {
+                    translation = phoneticManufacturer;
+                }
+            }
+            if (translation == val)
+            {
+                translation = Body(val, useICAO);
+            }
+            if (translation == val)
+            {
+                translation = StarSystem(val, useICAO);
+            }
+            if (translation == val)
+            {
+                translation = Station(val);
+            }
+            if (translation == val)
+            {
+                translation = Faction(val);
+            }
+            return translation.Trim();
+        }
+
         /// <summary>Fix up power names</summary>
         public static string Power(string power)
         {
@@ -251,7 +303,7 @@ namespace EddiSpeechService
         }
 
         /// <summary>Fix up body names</summary>
-        public static string Body(string body, bool useICAO = false)
+        private static string Body(string body, bool useICAO = false)
         {
             if (body == null)
             {
@@ -359,9 +411,9 @@ namespace EddiSpeechService
             }
 
             // Common star catalogues
-            if (starSystem.StartsWith("HIP "))
+            if (starSystem.StartsWith("HIP"))
             {
-                starSystem = starSystem.Replace("HIP ", "Hip ");
+                starSystem = starSystem.Replace("HIP", "Hip");
             }
             else if (starSystem.StartsWith("L ")
                 || starSystem.StartsWith("LFT ")
@@ -427,7 +479,7 @@ namespace EddiSpeechService
             else if (starSystem.StartsWith("2MASS ")
                 || starSystem.StartsWith("AC ")
                 || starSystem.StartsWith("AG") // Note no space
-                || starSystem.StartsWith("BD")
+                || starSystem.StartsWith("BD") // Note no space
                 || starSystem.StartsWith("CFBDSIR ")
                 || starSystem.StartsWith("CXOONC ")
                 || starSystem.StartsWith("CXOU ")
@@ -481,7 +533,7 @@ namespace EddiSpeechService
         }
 
         /// <summary>Fix up station related pronunciations </summary>
-        public static string Station(string station)
+        private static string Station(string station)
         {
             // Specific fixing of station model pronunciations
             if (STATION_MODEL_FIXES.ContainsKey(station))

--- a/Tests/NavigationServiceTests.cs
+++ b/Tests/NavigationServiceTests.cs
@@ -47,7 +47,7 @@ namespace IntegrationTests
             PrivateObject eddiInstance = new PrivateObject(Eddi.EDDI.Instance);
             PrivateObject navInstance = new PrivateObject(NavigationService.Instance);
             eddiInstance.SetFieldOrProperty("CurrentStarSystem", new StarSystem() { systemname = "Sol", systemAddress = 10477373803, x = 0, y = 0, z = 0 });
-            eddiInstance.SetFieldOrProperty("CurrentShip", new Ship() { size = LandingPadSize.Medium });
+            eddiInstance.SetFieldOrProperty("CurrentShip", new Ship() { Size = LandingPadSize.Medium });
 
             // Interstellar Factors Contact
             NavigationService.Instance.GetServiceRoute("facilitator", 10000);

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -32,11 +32,11 @@ namespace UnitTests
         [TestMethod]
         public void TestTemplateFunctional()
         {
-            var document = new SimpleDocument(@"You are entering the {System(system)} system.");
+            var document = new SimpleDocument(@"You are entering the {P(system)} system.");
             var store = new BuiltinStore();
-            store["System"] = new NativeFunction((values) =>
+            store["P"] = new NativeFunction((values) =>
             {
-                return Translations.StarSystem(values[0].AsString);
+                return Translations.GetTranslation(values[0].AsString);
             }, 1);
             store["system"] = "Alrai";
             var result = document.Render(store);

--- a/Tests/SpeechTests.cs
+++ b/Tests/SpeechTests.cs
@@ -62,7 +62,7 @@ namespace SpeechTests
         public void TestSagAStar()
         {
             string SagI = "Sagittarius A*";
-            string translated = Translations.StarSystem(SagI);
+            string translated = Translations.GetTranslation(SagI);
             SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049309), translated);
         }
 
@@ -88,7 +88,7 @@ namespace SpeechTests
         public void TestSsml4()
         {
             Logging.Verbose = true;
-            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049309), @"<break time=""100ms""/>We're on our way to " + Translations.StarSystem("i Bootis") + ".");
+            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049309), @"<break time=""100ms""/>We're on our way to " + Translations.GetTranslation("i Bootis") + ".");
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfecrtly correct    
@@ -129,7 +129,7 @@ namespace SpeechTests
         [TestMethod, TestCategory("Speech")]
         public void TestSsml()
         {
-            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049363), "You are travelling to the " + Translations.StarSystem("Hotas") + " system.");
+            SpeechService.Instance.Say(ShipDefinitions.FromEliteID(128049363), "You are travelling to the " + Translations.GetTranslation("Hotas") + " system.");
         }
 
         [TestMethod, TestCategory("Speech")]

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -272,8 +272,8 @@ namespace UnitTests
         [TestMethod]
         public void TestSectorTranslations()
         {
-            Assert.AreEqual("Swoiwns N Y dash B a 95 dash 0", Translations.StarSystem("Swoiwns NY-B a95-0"));
-            Assert.AreEqual("P P M 5 2 8 7", Translations.StarSystem("PPM 5287"));
+            Assert.AreEqual("Swoiwns N Y dash B a 95 dash 0", Translations.GetTranslation("Swoiwns NY-B a95-0"));
+            Assert.AreEqual("P P M 5 2 8 7", Translations.GetTranslation("PPM 5287"));
         }
 
         [TestMethod]
@@ -392,7 +392,7 @@ namespace UnitTests
         [TestMethod]
         public void TestTranslationVesper()
         {
-            Assert.AreEqual(Translations.StarSystem("VESPER-M4"), "Vesper M 4");
+            Assert.AreEqual(Translations.GetTranslation("VESPER-M4"), "Vesper M 4");
         }
 
         [TestMethod]

--- a/Tests/TranslationTests.cs
+++ b/Tests/TranslationTests.cs
@@ -1,5 +1,6 @@
 ﻿using EddiSpeechService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tests.Properties;
 
 namespace UnitTests
 {
@@ -48,150 +49,197 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestTranslateCallsigns()
+        {
+            Assert.AreEqual("<phoneme alphabet=\"ipa\" ph=\"ɡɒlf\">golf</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈælfə\">alpha</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈeksˈrei\">x-ray</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈwʌn\">one</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈzɪərəʊ\">zero</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈnaɪnər\">niner</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈfoʊ.ər\">fawer</phoneme>", Translations.ICAO("GAX-1094"));
+        }
+
+        [TestMethod]
         public void TestTranslateBody1()
         {
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <say-as interpret-as=""characters"">A</say-as> 1", Translations.Body("Shinrarta Dezhra A 1"));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.Body("Shinrarta Dezhra A 1", true));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <say-as interpret-as=""characters"">A</say-as> 1", Translations.GetTranslation("Shinrarta Dezhra A 1"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.GetTranslation("Shinrarta Dezhra A 1", true));
         }
 
         [TestMethod]
         public void TestTranslateBody2()
         {
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> A B 1", Translations.Body("Shinrarta Dezhra AB 1"));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.Body("Shinrarta Dezhra AB 1", true));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> A B 1", Translations.GetTranslation("Shinrarta Dezhra AB 1"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.GetTranslation("Shinrarta Dezhra AB 1", true));
         }
 
         [TestMethod]
         public void TestTranslateBody3()
         {
-            Assert.AreEqual(@"Coll 1 0 7 Sector A I dash H b 40 dash 6 <say-as interpret-as=""characters"">A</say-as> <say-as interpret-as=""characters"">B</say-as> 3", Translations.Body("Col 107 Sector AI-H b40-6 A B 3"));
-            Assert.AreEqual(@"Coll <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> Sector <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈindiˑɑ"">india</phoneme> dash <phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme>", Translations.Body("Col 107 Sector AI-H b40-6 AB 3", true));
+            Assert.AreEqual(@"Coll 1 0 7 Sector A I dash H b 40 dash 6 <say-as interpret-as=""characters"">A</say-as> <say-as interpret-as=""characters"">B</say-as> 3", Translations.GetTranslation("Col 107 Sector AI-H b40-6 A B 3"));
+            Assert.AreEqual(@"Coll <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> Sector <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈindiˑɑ"">india</phoneme> dash <phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme>", Translations.GetTranslation("Col 107 Sector AI-H b40-6 AB 3", true));
         }
 
         [TestMethod]
         public void TestTranslateBody4()
         {
-            Assert.AreEqual(@"H R 7 7 5 6 A B C D E 6 <say-as interpret-as=""characters"">b</say-as>", Translations.Body("HR 7756 ABCDE 6 b"));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeko"">echo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme>", Translations.Body("HR 7756 ABCDE 6 b", true));
+            Assert.AreEqual(@"H R 7 7 5 6 A B C D E 6 <say-as interpret-as=""characters"">b</say-as>", Translations.GetTranslation("HR 7756 ABCDE 6 b"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeko"">echo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme>", Translations.GetTranslation("HR 7756 ABCDE 6 b", true));
         }
 
         [TestMethod]
         public void TestTranslateBody5()
         {
-            Assert.AreEqual(@"Hip 6 3 8 3 5 A B C D 1 <say-as interpret-as=""characters"">c</say-as> <say-as interpret-as=""characters"">a</say-as>", Translations.Body("HIP 63835 ABCD 1 c a"));
-            Assert.AreEqual(@"Hip <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme>", Translations.Body("HIP 63835 ABCD 1 c a", true));
+            Assert.AreEqual(@"Hip 6 3 8 3 5 A B C D 1 <say-as interpret-as=""characters"">c</say-as> <say-as interpret-as=""characters"">a</say-as>", Translations.GetTranslation("HIP 63835 ABCD 1 c a"));
+            Assert.AreEqual(@"Hip <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme>", Translations.GetTranslation("HIP 63835 ABCD 1 c a", true));
         }
 
         [TestMethod]
         public void TestTranslateBody6()
         {
-            Assert.AreEqual(@"Boewnst T Q dash K d 9 dash 7 4 0 <say-as interpret-as=""characters"">A</say-as> <say-as interpret-as=""characters"">A</say-as> Belt", Translations.Body("Boewnst TQ-K d9-740 A A Belt"));
-            Assert.AreEqual(@"Boewnst <phoneme alphabet=""ipa"" ph=""ˈtænɡo"">tango</phoneme> <phoneme alphabet=""ipa"" ph=""keˈbek"">quebec</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈkiːlo"">kilo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt", Translations.Body("Boewnst TQ-K d9-740 A A Belt", true));
+            Assert.AreEqual(@"Boewnst T Q dash K d 9 dash 7 4 0 <say-as interpret-as=""characters"">A</say-as> <say-as interpret-as=""characters"">A</say-as> Belt", Translations.GetTranslation("Boewnst TQ-K d9-740 A A Belt"));
+            Assert.AreEqual(@"Boewnst <phoneme alphabet=""ipa"" ph=""ˈtænɡo"">tango</phoneme> <phoneme alphabet=""ipa"" ph=""keˈbek"">quebec</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈkiːlo"">kilo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt", Translations.GetTranslation("Boewnst TQ-K d9-740 A A Belt", true));
         }
 
         [TestMethod]
         public void TestTranslateBody7()
         {
-            Assert.AreEqual(@"Calea <say-as interpret-as=""characters"">B</say-as> <say-as interpret-as=""characters"">A</say-as> Belt Cluster 1", Translations.Body("Calea B A Belt Cluster 1"));
-            Assert.AreEqual(@"Calea <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt Cluster <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.Body("Calea B A Belt Cluster 1", true));
+            Assert.AreEqual(@"Calea <say-as interpret-as=""characters"">B</say-as> <say-as interpret-as=""characters"">A</say-as> Belt Cluster 1", Translations.GetTranslation("Calea B A Belt Cluster 1"));
+            Assert.AreEqual(@"Calea <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt Cluster <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.GetTranslation("Calea B A Belt Cluster 1", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem1()
         {
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme>", Translations.StarSystem("Shinrarta Dezhra", false));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme>", Translations.StarSystem("Shinrarta Dezhra", true));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme>", Translations.GetTranslation("Shinrarta Dezhra"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdezɦrə"">Dezhra</phoneme>", Translations.GetTranslation("Shinrarta Dezhra", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem2()
         {
-            Assert.AreEqual(@"Hip 1 2 3 4 5", Translations.StarSystem("HIP 12345", false));
-            Assert.AreEqual(@"Hip <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme>", Translations.StarSystem("HIP 12345", true));
+            Assert.AreEqual(@"Hip 1 2 3 4 5", Translations.GetTranslation("HIP 12345"));
+            Assert.AreEqual(@"Hip <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme>", Translations.GetTranslation("HIP 12345", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem3()
         {
-            Assert.AreEqual(@"Skull and Crossbones Sector A W dash M b 7 dash 0 4", Translations.StarSystem("Skull and Crossbones Neb. Sector AW-M b7-0 4", false));
-            Assert.AreEqual(@"Skull and Crossbones Sector <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwiski"">whiskey</phoneme> dash <phoneme alphabet=""ipa"" ph=""maɪk"">mike</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme>", Translations.StarSystem("Skull and Crossbones Neb. Sector AW-M b7-0 4", true));
+            Assert.AreEqual(@"Skull and Crossbones Sector A W dash M b 7 dash 0 4", Translations.GetTranslation("Skull and Crossbones Neb. Sector AW-M b7-0 4"));
+            Assert.AreEqual(@"Skull and Crossbones Sector <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwiski"">whiskey</phoneme> dash <phoneme alphabet=""ipa"" ph=""maɪk"">mike</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme>", Translations.GetTranslation("Skull and Crossbones Neb. Sector AW-M b7-0 4", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem4()
         {
-            Assert.AreEqual(@"2 mass J 2 1 5 4 1 8 7 7 plus 4 7 1 2 0 9 6", Translations.StarSystem("2MASS J21541877+4712096", false));
-            Assert.AreEqual(@"2 mass <phoneme alphabet=""ipa"" ph=""ˈdʒuːliˑˈet"">juliet</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme><phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> plus <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme>", Translations.StarSystem("2MASS J21541877+4712096", true));
+            Assert.AreEqual(@"2 mass J 2 1 5 4 1 8 7 7 plus 4 7 1 2 0 9 6", Translations.GetTranslation("2MASS J21541877+4712096"));
+            Assert.AreEqual(@"2 mass <phoneme alphabet=""ipa"" ph=""ˈdʒuːliˑˈet"">juliet</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme><phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> plus <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme>", Translations.GetTranslation("2MASS J21541877+4712096", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem5()
         {
-            Assert.AreEqual(@"V 1 3 9 7 Orionis", Translations.StarSystem("V1397 Orionis", false));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈvɪktə"">victor</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme><phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> Orionis", Translations.StarSystem("V1397 Orionis", true));
+            Assert.AreEqual(@"V 1 3 9 7 Orionis", Translations.GetTranslation("V1397 Orionis"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈvɪktə"">victor</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme><phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> Orionis", Translations.GetTranslation("V1397 Orionis", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem6()
         {
-            Assert.AreEqual(@"X T E P S R J 1 8 1 0 minus 1 9 7", Translations.StarSystem("XTE PSR J1810-197", false));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈeksˈrei"">x-ray</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtænɡo"">tango</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeko"">echo</phoneme> <phoneme alphabet=""ipa"" ph=""pəˈpɑ"">papa</phoneme> <phoneme alphabet=""ipa"" ph=""siˈerə"">sierra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdʒuːliˑˈet"">juliet</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme><phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> minus <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme>", Translations.StarSystem("XTE PSR J1810-197", true));
+            Assert.AreEqual(@"X T E P S R J 1 8 1 0 minus 1 9 7", Translations.GetTranslation("XTE PSR J1810-197"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈeksˈrei"">x-ray</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtænɡo"">tango</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeko"">echo</phoneme> <phoneme alphabet=""ipa"" ph=""pəˈpɑ"">papa</phoneme> <phoneme alphabet=""ipa"" ph=""siˈerə"">sierra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdʒuːliˑˈet"">juliet</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme><phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> minus <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme>", Translations.GetTranslation("XTE PSR J1810-197", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem7()
         {
-            Assert.AreEqual(@"Gliese 3 9 8 point 2", Translations.StarSystem("Gliese 398.2", false));
-            Assert.AreEqual(@"Gliese <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> point 2", Translations.StarSystem("Gliese 398.2", true));
+            Assert.AreEqual(@"Gliese 3 9 8 point 2", Translations.GetTranslation("Gliese 398.2"));
+            Assert.AreEqual(@"Gliese <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> <phoneme alphabet=""ipa"" ph=""ˈnaɪnər"">niner</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> point 2", Translations.GetTranslation("Gliese 398.2", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem8()
         {
-            Assert.AreEqual(@"Coll 2 8 5 Sector Q H dash U c 3 dash 22", Translations.StarSystem("Col 285 Sector QH-U c3-22", false));
-            Assert.AreEqual(@"Coll <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> Sector <phoneme alphabet=""ipa"" ph=""keˈbek"">quebec</phoneme> <phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈjuːnifɔːm"">uniform</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme>", Translations.StarSystem("Col 285 Sector QH-U c3-22", true));
+            Assert.AreEqual(@"Coll 2 8 5 Sector Q H dash U c 3 dash 22", Translations.GetTranslation("Col 285 Sector QH-U c3-22"));
+            Assert.AreEqual(@"Coll <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> Sector <phoneme alphabet=""ipa"" ph=""keˈbek"">quebec</phoneme> <phoneme alphabet=""ipa"" ph=""hoːˈtel"">hotel</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈjuːnifɔːm"">uniform</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtriː"">tree</phoneme> dash <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme>", Translations.GetTranslation("Col 285 Sector QH-U c3-22", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem9()
         {
-            Assert.AreEqual(@"Hip 72", Translations.StarSystem("HIP 72", false));
-            Assert.AreEqual(@"Hip 72", Translations.StarSystem("HIP 72", true));
+            Assert.AreEqual(@"Hip 72", Translations.GetTranslation("HIP 72"));
+            Assert.AreEqual(@"Hip <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme>", Translations.GetTranslation("HIP 72", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem10()
         {
-            Assert.AreEqual(@"C F B D S I R 1 4 5 8 plus 10 B", Translations.StarSystem("CFBDSIR 1458+10 B", false));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfɒkstrɒt"">foxtrot</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""siˈerə"">sierra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈindiˑɑ"">india</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> plus 10 <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme>", Translations.StarSystem("CFBDSIR 1458+10 B", true));
+            Assert.AreEqual(@"C F B D S I R 1 4 5 8 plus 10 <say-as interpret-as=""characters"">B</say-as>", Translations.GetTranslation("CFBDSIR 1458+10 B"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈtʃɑːli"">charlie</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfɒkstrɒt"">foxtrot</phoneme> <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> <phoneme alphabet=""ipa"" ph=""siˈerə"">sierra</phoneme> <phoneme alphabet=""ipa"" ph=""ˈindiˑɑ"">india</phoneme> <phoneme alphabet=""ipa"" ph=""ˈroːmiˑo"">romeo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfoʊ.ər"">fawer</phoneme> <phoneme alphabet=""ipa"" ph=""ˈfaɪf"">fife</phoneme> <phoneme alphabet=""ipa"" ph=""ˈeɪt"">eight</phoneme> plus 10 <phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme>", Translations.GetTranslation("CFBDSIR 1458+10 B", true));
         }
 
         [TestMethod]
         public void TestTranslateStarSystem11()
         {
-            Assert.AreEqual(@"B D plus 18 7 1 1", Translations.StarSystem("BD+18 711", false));
-            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> plus 18 <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.StarSystem("BD+18 711", true));
+            Assert.AreEqual(@"B D plus 18 7 1 1", Translations.GetTranslation("BD+18 711"));
+            Assert.AreEqual(@"<phoneme alphabet=""ipa"" ph=""ˈbrɑːˈvo"">bravo</phoneme> <phoneme alphabet=""ipa"" ph=""ˈdɛltə"">delta</phoneme> plus 18 <phoneme alphabet=""ipa"" ph=""ˈsɛvɛn"">seven</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme> <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.GetTranslation("BD+18 711", true));
+        }
+
+        [TestMethod]
+        public void TestTranslateStarSystems()
+        {
+            Assert.AreEqual("L H S 1 2 3 4 5", Translations.GetTranslation("LHS 12345"));
+            Assert.AreEqual("H R 1 2 3 4 5", Translations.GetTranslation("HR 12345"));
+            Assert.AreEqual("C X O U J 0 6 1 7 0 5 point 3 plus 2 2 2 1 2 7", Translations.GetTranslation("CXOU J061705.3+222127"));
+            Assert.AreEqual("S D S S J 1 4 1 6 plus 1 3 4 8", Translations.GetTranslation("SDSS J1416+1348"));
+            Assert.AreEqual("U G C S J 1 2 2 0 3 1 point 5 6 plus 2 4 3 6 1 4 point 8", Translations.GetTranslation("UGCS J122031.56+243614.8"));
+            Assert.AreEqual("X T E J 1 7 4 8 minus 2 8 8", Translations.GetTranslation("XTE J1748-288"));
+            Assert.AreEqual("", Translations.GetTranslation(""));
+        }
+
+        [TestMethod]
+        public void TestTranslateStarSystemsStability()
+        {
+            string[] starSystems = Resources.starsystems.Split(new[] { '\r', '\n' });
+
+            foreach (string starSystem in starSystems)
+            {
+                Translations.GetTranslation(starSystem);
+            }
         }
 
         [TestMethod]
         public void TestTranslateStation()
         {
-            Assert.AreEqual("Or-bis Starport", Translations.Station("Orbis Starport"));
-            Assert.AreEqual("Mega-ship", Translations.Station("Megaship"));
+            Assert.AreEqual("Or-bis Starport", Translations.GetTranslation("Orbis Starport"));
+            Assert.AreEqual("Mega-ship", Translations.GetTranslation("Megaship"));
         }
 
         [TestMethod]
         public void TestTranslateRing()
         {
-            Assert.AreEqual(@"Oponner 6 <say-as interpret-as=""characters"">A</say-as> Ring", Translations.Body("Oponner 6 A Ring", false));
-            Assert.AreEqual(@"Oponner <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Ring", Translations.Body("Oponner 6 A Ring", true));
+            Assert.AreEqual(@"Oponner 6 <say-as interpret-as=""characters"">A</say-as> Ring", Translations.GetTranslation("Oponner 6 A Ring"));
+            Assert.AreEqual(@"Oponner <phoneme alphabet=""ipa"" ph=""ˈsɪks"">six</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Ring", Translations.GetTranslation("Oponner 6 A Ring", true));
         }
 
         [TestMethod]
         public void TestTranslateBelt()
         {
-            Assert.AreEqual(@"Wolf 2 0 2 <say-as interpret-as=""characters"">A</say-as> Belt Cluster 1", Translations.Body("Wolf 202 A Belt Cluster 1", false));
-            Assert.AreEqual(@"Wolf <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt Cluster <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.Body("Wolf 202 A Belt Cluster 1", true));
+            Assert.AreEqual(@"Wolf 2 0 2 <say-as interpret-as=""characters"">A</say-as> Belt Cluster 1", Translations.GetTranslation("Wolf 202 A Belt Cluster 1"));
+            Assert.AreEqual(@"Wolf <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈzɪərəʊ"">zero</phoneme> <phoneme alphabet=""ipa"" ph=""ˈtuː"">two</phoneme> <phoneme alphabet=""ipa"" ph=""ˈælfə"">alpha</phoneme> Belt Cluster <phoneme alphabet=""ipa"" ph=""ˈwʌn"">one</phoneme>", Translations.GetTranslation("Wolf 202 A Belt Cluster 1", true));
+        }
+
+        [TestMethod]
+        public void TestSpokenShipModel()
+        {
+            var fromEDName = Translations.GetTranslation("CobraMkIII");
+            var fromName = Translations.GetTranslation("Cobra Mk. III");
+            string expected = "<phoneme alphabet=\"ipa\" ph=\"ˈkəʊbrə\">cobra</phoneme> " + "<phoneme alphabet=\"ipa\" ph=\"mɑːk\">Mark</phoneme> " + "<phoneme alphabet=\"ipa\" ph=\"θriː\">3</phoneme>";
+            Assert.AreEqual(expected, fromEDName);
+            Assert.AreEqual(expected, fromName);
+        }
+
+        [TestMethod]
+        public void TestSpokenShipManufacturer()
+        {
+            var fromName = Translations.GetTranslation("Lakon Spaceways");
+            string expected = "<phoneme alphabet=\"ipa\" ph=\"leɪkɒn\">Lakon</phoneme> " + "<phoneme alphabet=\"ipa\" ph=\"speɪsweɪz\">Spaceways</phoneme>";
+            Assert.AreEqual(expected, fromName);
         }
     }
 }

--- a/Tests/VoiceAttackPluginTests.cs
+++ b/Tests/VoiceAttackPluginTests.cs
@@ -74,35 +74,6 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void TestTranslateStarSystems()
-        {
-            Assert.AreEqual("L H S 1 2 3 4 5", Translations.StarSystem("LHS 12345"));
-            Assert.AreEqual("H R 1 2 3 4 5", Translations.StarSystem("HR 12345"));
-            Assert.AreEqual("C X O U J 0 6 1 7 0 5 point 3 plus 2 2 2 1 2 7", Translations.StarSystem("CXOU J061705.3+222127"));
-            Assert.AreEqual("S D S S J 1 4 1 6 plus 1 3 4 8", Translations.StarSystem("SDSS J1416+1348"));
-            Assert.AreEqual("U G C S J 1 2 2 0 3 1 point 5 6 plus 2 4 3 6 1 4 point 8", Translations.StarSystem("UGCS J122031.56+243614.8"));
-            Assert.AreEqual("X T E J 1 7 4 8 minus 2 8 8", Translations.StarSystem("XTE J1748-288"));
-            Assert.AreEqual("", Translations.StarSystem(""));
-        }
-
-        [TestMethod]
-        public void TestTranslateStarSystemsStability()
-        {
-            string[] starSystems = Resources.starsystems.Split(new[] { '\r', '\n' });
-
-            foreach (string starSystem in starSystems)
-            {
-                Translations.StarSystem(starSystem);
-            }
-        }
-
-        [TestMethod]
-        public void TestTranslateCallsigns()
-        {
-            Assert.AreEqual("<phoneme alphabet=\"ipa\" ph=\"ɡɒlf\">golf</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈælfə\">alpha</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈeksˈrei\">x-ray</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈwʌn\">one</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈzɪərəʊ\">zero</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈnaɪnər\">niner</phoneme> <phoneme alphabet=\"ipa\" ph=\"ˈfoʊ.ər\">fawer</phoneme>", Translations.ICAO("GAX-1094"));
-        }
-
-        [TestMethod]
         public void TestSqlRepositoryPresent()
         {
             StarSystemRepository starSystemRepository = StarSystemSqLiteRepository.Instance;

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -573,7 +573,7 @@ namespace EddiVoiceAttackResponder
                     vaProxy.SetText(prefix + " ident", ship.ident);
                     vaProxy.SetText(prefix + " ident (spoken)", Translations.ICAO(ship.ident, false));
                     vaProxy.SetText(prefix + " role", ship.Role?.localizedName);
-                    vaProxy.SetText(prefix + " size", ship.size?.localizedName);
+                    vaProxy.SetText(prefix + " size", ship.Size?.localizedName);
                     vaProxy.SetDecimal(prefix + " value", ship.value);
                     vaProxy.SetText(prefix + " value (spoken)", Translations.Humanize(ship.value));
                     vaProxy.SetDecimal(prefix + " hull value", ship.hullvalue);


### PR DESCRIPTION
Refactor the {P()} function and move to Translations.cs under new method `GetTranslation()`. Add ship manufacturers to translations. Revise phonetic unit tests to better model real-world use by routing through `GetTranslation()`. Prevents regressions like rendering "Cobra Mk. III" as "Cobra Mk. I I I" rather than applying the proper IPA.

For the ship definition:
- revise lowercase "size" to return localized size (revising to match published docs)
- add phoneticmodel (similar to current phoneticname)
- add phoneticmanufacturer (similar to current phoneticname)