### PR TITLE
Speculative fix for CAPI null reference exception

### DIFF
--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -166,7 +166,8 @@ namespace EddiDataDefinitions
                 {
                     fromFDev = true,
                     buyprice = (int)capiJSON["buyPrice"],
-                    avgprice = (int)capiJSON["meanPrice"],
+                    // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
+                    avgprice = (int)capiJSON["meanPrice"] > 0 ? (int)capiJSON["meanPrice"] : commodityDef.avgprice,
                     stock = (int)capiJSON["stock"],
                     stockbracket = intStringOrNull(capiJSON, "stockBracket"),
                     sellprice = (int)capiJSON["sellPrice"],

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -122,108 +122,140 @@ namespace EddiDataDefinitions
 
         public static CommodityMarketQuote FromCapiJson(JObject capiJSON)
         {
-            long eliteId = (long)capiJSON["id"];
-            string edName = (string)capiJSON["name"];
-            string category = (string)capiJSON["category"];
-            int meanPrice = (int)capiJSON["meanPrice"];
-
-            CommodityDefinition commodityDef = CommodityDefinition.CommodityDefinitionFromEliteID(eliteId) ?? CommodityDefinition.FromEDName(edName);
-            if (commodityDef == null || (string)capiJSON["name"] != commodityDef.edname)
+            CommodityMarketQuote quote = null;
+            try 
             {
-                if (commodityDef?.edname != "Drones")
+                long eliteId = (long)capiJSON["id"];
+                string edName = (string)capiJSON["name"];
+                string category = (string)capiJSON["category"];
+                int meanPrice = (int)capiJSON["meanPrice"];
+
+                // `CommodityDefinition.FromEDName()` would create a new commodity if we don't already know about the commodity.
+                // We'll defer using that, in favor of instead creating a more complete definition below.
+                CommodityDefinition commodityDef = CommodityDefinition.CommodityDefinitionFromEliteID(eliteId);
+                if (commodityDef is null)
                 {
-                    // Unknown commodity; report the full object so that we can update the definitions 
-                    Logging.Info("Commodity definition error: " + (string)capiJSON["name"], JsonConvert.SerializeObject(capiJSON));
+                    CommodityCategory commodityCategory = CommodityCategory.FromEDName(category);
+                    if (commodityCategory != CommodityCategory.NonMarketable)
+                    {
+                        // Unknown commodity; report the full object so that we can update the definitions 
+                        Logging.Info("Commodity definition error: " + (string)capiJSON["name"], JsonConvert.SerializeObject(capiJSON));
 
-                    // Create a basic commodity definition from the info available 
-                    commodityDef = new CommodityDefinition(eliteId, -1, edName, CommodityCategory.FromEDName(category), meanPrice, false);
+                        // Create a basic commodity definition from the info available 
+                        commodityDef = new CommodityDefinition(eliteId, -1, edName, commodityCategory, meanPrice, false);
+                    }
                 }
-            }
 
-            dynamic intStringOrNull(JObject jObject, string key)
-            {
-                JToken token = jObject[key];
-                switch (token.Type)
+                dynamic intStringOrNull(JObject jObject, string key)
                 {
-                    case JTokenType.Integer:
-                        return (int)token;
-                    case JTokenType.String:
-                        return (string)token;
-                    case JTokenType.None:
-                        return null;
-                    default:
-                        return token.ToString();
+                    JToken token = jObject[key];
+                    switch (token.Type)
+                    {
+                        case JTokenType.Integer:
+                            return (int)token;
+                        case JTokenType.String:
+                            return (string)token;
+                        case JTokenType.None:
+                            return null;
+                        default:
+                            return token.ToString();
+                    }
                 }
-            }
 
-            CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef)
-            {
-                fromFDev = true,
-                buyprice = (int)capiJSON["buyPrice"],
-                avgprice = (int)capiJSON["meanPrice"],
-                stock = (int)capiJSON["stock"],
-                stockbracket = intStringOrNull(capiJSON, "stockBracket"),
-                sellprice = (int)capiJSON["sellPrice"],
-                demand = (int)capiJSON["demand"],
-                demandbracket = intStringOrNull(capiJSON, "demandBracket")
-            };
+                quote = new CommodityMarketQuote(commodityDef)
+                {
+                    fromFDev = true,
+                    buyprice = (int)capiJSON["buyPrice"],
+                    avgprice = (int)capiJSON["meanPrice"],
+                    stock = (int)capiJSON["stock"],
+                    stockbracket = intStringOrNull(capiJSON, "stockBracket"),
+                    sellprice = (int)capiJSON["sellPrice"],
+                    demand = (int)capiJSON["demand"],
+                    demandbracket = intStringOrNull(capiJSON, "demandBracket")
+                };
 
-            List<string> StatusFlags = new List<string>();
-            foreach (string statusFlag in capiJSON["statusFlags"])
-            {
-                StatusFlags.Add(statusFlag);
+                List<string> StatusFlags = new List<string>();
+                foreach (string statusFlag in capiJSON["statusFlags"])
+                {
+                    StatusFlags.Add(statusFlag);
+                }
+                quote.StatusFlags = StatusFlags;
             }
-            quote.StatusFlags = StatusFlags;
+            catch (Exception e)
+            {
+                Dictionary<string, object> data = new Dictionary<string, object>()
+                {
+                    { "capiJson", JsonConvert.SerializeObject(capiJSON) },
+                    { "Exception", e }
+                };
+                Logging.Error("Failed to handle Frontier API commodity json", data);
+            }
             return quote;
         }
 
         public static CommodityMarketQuote FromMarketInfo(MarketInfo item)
         {
-            long eliteId = item.id;
-            string edName = item.name?.ToLowerInvariant()
-                ?.Replace("$", "")
-                ?.Replace("_name;", "");
-            string category = item.category.ToLowerInvariant()
-                ?.Replace("$market_category", "")
-                ?.Replace("_", "")
-                ?.Replace(";", "");
-
-            CommodityDefinition commodityDef = CommodityDefinition.CommodityDefinitionFromEliteID(eliteId) ?? CommodityDefinition.FromEDName(edName);
-            if (commodityDef == null || edName != commodityDef.edname.ToLowerInvariant())
+            CommodityMarketQuote quote = null;
+            try 
             {
-                if (commodityDef?.edname != "Drones")
+                long eliteId = item.id;
+                string edName = item.name?.ToLowerInvariant()
+                    ?.Replace("$", "")
+                    ?.Replace("_name;", "");
+                string category = item.category.ToLowerInvariant()
+                    ?.Replace("$market_category", "")
+                    ?.Replace("_", "")
+                    ?.Replace(";", "");
+
+                // `CommodityDefinition.FromEDName()` would create a new commodity if we don't already know about the commodity.
+                // We'll defer using that, in favor of instead creating a more complete definition below.
+                CommodityDefinition commodityDef = CommodityDefinition.CommodityDefinitionFromEliteID(eliteId);
+                if (commodityDef is null)
                 {
-                    // Unknown commodity; report the full object so that we can update the definitions 
-                    Logging.Info("Commodity definition error: " + edName);
+                    CommodityCategory commodityCategory = CommodityCategory.FromEDName(category);
+                    if (commodityCategory != CommodityCategory.NonMarketable)
+                    {
+                        // Unknown commodity; report the full object so that we can update the definitions 
+                        Logging.Info("Commodity definition error: " + edName);
 
-                    // Create a basic commodity definition from the info available 
-                    commodityDef = new CommodityDefinition(eliteId, -1, edName, CommodityCategory.FromEDName(category), item.meanprice, false);
+                        // Create a basic commodity definition from the info available 
+                        commodityDef = new CommodityDefinition(eliteId, -1, edName, CommodityCategory.FromEDName(category), item.meanprice, false);
+                    }
                 }
-            }
 
-            CommodityMarketQuote quote = new CommodityMarketQuote(commodityDef)
-            {
-                fromFDev = true,
-                buyprice = item.buyprice,
-                // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
-                avgprice = item.meanprice > 0 ? item.meanprice : commodityDef.avgprice, 
-                stock = item.stock,
-                stockbracket = item.stockbracket,
-                sellprice = item.sellprice,
-                demand = item.demand,
-                demandbracket = item.demandbracket
-            };
+                quote = new CommodityMarketQuote(commodityDef)
+                {
+                    fromFDev = true,
+                    buyprice = item.buyprice,
+                    // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
+                    avgprice = item.meanprice > 0 ? item.meanprice : commodityDef.avgprice, 
+                    stock = item.stock,
+                    stockbracket = item.stockbracket,
+                    sellprice = item.sellprice,
+                    demand = item.demand,
+                    demandbracket = item.demandbracket
+                };
 
-            List<string> StatusFlags = new List<string>();
-            if (item.producer)
-            {
-                StatusFlags.Add("Producer");
+                List<string> StatusFlags = new List<string>();
+                if (item.producer)
+                {
+                    StatusFlags.Add("Producer");
+                }
+                if (item.consumer)
+                {
+                    StatusFlags.Add("Consumer");
+                }
+                quote.StatusFlags = StatusFlags;
             }
-            if (item.consumer)
+            catch (Exception e)
             {
-                StatusFlags.Add("Consumer");
+                Dictionary<string, object> data = new Dictionary<string, object>()
+                {
+                    { "item", JsonConvert.SerializeObject(item) },
+                    { "Exception", e }
+                };
+                Logging.Error("Failed to handle market.json commodity item", data);
             }
-            quote.StatusFlags = StatusFlags;
             return quote;
         }
     }

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -167,7 +167,7 @@ namespace EddiDataDefinitions
                     fromFDev = true,
                     buyprice = (int)capiJSON["buyPrice"],
                     // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
-                    avgprice = (int)capiJSON["meanPrice"] > 0 ? (int)capiJSON["meanPrice"] : commodityDef.avgprice,
+                    avgprice = (int)capiJSON["meanPrice"] > 0 ? (int)capiJSON["meanPrice"] : commodityDef?.avgprice ?? 0,
                     stock = (int)capiJSON["stock"],
                     stockbracket = intStringOrNull(capiJSON, "stockBracket"),
                     sellprice = (int)capiJSON["sellPrice"],
@@ -229,7 +229,7 @@ namespace EddiDataDefinitions
                     fromFDev = true,
                     buyprice = item.buyprice,
                     // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
-                    avgprice = item.meanprice > 0 ? item.meanprice : commodityDef.avgprice, 
+                    avgprice = item.meanprice > 0 ? item.meanprice : commodityDef?.avgprice ?? 0, 
                     stock = item.stock,
                     stockbracket = item.stockbracket,
                     sellprice = item.sellprice,


### PR DESCRIPTION
Ref. example https://rollbar.com/EDCD/EDDI/items/17660/occurrences/127021360161/

Also extends fleet carrier fix for zero commodity average prices to include CAPI data (in addition to market.json data).