### PR TITLE
Prevent IO exceptions

### DIFF
--- a/CargoMonitor/CargoMonitorConfiguration.cs
+++ b/CargoMonitor/CargoMonitorConfiguration.cs
@@ -19,9 +19,6 @@ namespace EddiCargoMonitor
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         public CargoMonitorConfiguration()
         {
             cargo = new ObservableCollection<Cargo>();
@@ -109,10 +106,7 @@ namespace EddiCargoMonitor
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
             Logging.Debug("Configuration to file: " + json);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/CompanionAppService/CommanderConfiguration.cs
+++ b/CompanionAppService/CommanderConfiguration.cs
@@ -14,10 +14,7 @@ namespace EddiCompanionAppService
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
+        
         /// <summary>
         /// Obtain commander config from a file. If  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\commander.json is used
@@ -69,10 +66,7 @@ namespace EddiCompanionAppService
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/CompanionAppService/CompanionAppCredentials.cs
+++ b/CompanionAppService/CompanionAppCredentials.cs
@@ -22,9 +22,7 @@ namespace EddiCompanionAppService
 
         [JsonIgnore]
         private string dataPath = defaultPath;
-
-        static readonly object fileLock = new object();
-
+        
         /// <summary>
         /// Obtain credentials from a file. If filepath is not supplied then defaultPath is used.
         /// </summary>
@@ -79,10 +77,7 @@ namespace EddiCompanionAppService
             filename = filename ?? dataPath ?? defaultPath;
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/CrimeMonitor/CrimeMonitorConfiguration.cs
+++ b/CrimeMonitor/CrimeMonitorConfiguration.cs
@@ -24,10 +24,7 @@ namespace EddiCrimeMonitor
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
+        
         public CrimeMonitorConfiguration()
         {
             criminalrecord = new ObservableCollection<FactionRecord>();
@@ -113,10 +110,7 @@ namespace EddiCrimeMonitor
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
             Logging.Debug("Configuration to file: " + json);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/EDDI/EDDIConfiguration.cs
+++ b/EDDI/EDDIConfiguration.cs
@@ -173,10 +173,7 @@ namespace EddiCore
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
+        
         public EDDIConfiguration()
         {
             Debug = false;
@@ -248,10 +245,7 @@ namespace EddiCore
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/EDDI/EliteConfiguration.cs
+++ b/EDDI/EliteConfiguration.cs
@@ -17,9 +17,6 @@ namespace EddiCore
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         public EliteConfiguration()
         {
             Beta = false;
@@ -75,10 +72,7 @@ namespace EddiCore
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -154,9 +154,7 @@ namespace Eddi
         }
 
         private bool runBetaCheck = false;
-
-        private static readonly object logLock = new object();
-
+        
         public MainWindow()
         {
             InitializeComponent();
@@ -1185,10 +1183,7 @@ namespace Eddi
         {
             if (File.Exists(fromLogPath))
             {
-                lock (logLock)
-                {
-                    File.WriteAllText(toTruncatedLogPath, File.ReadAllText(fromLogPath));
-                }
+                Files.Write(toTruncatedLogPath, Files.Read(fromLogPath));
 
                 // Truncate log files more than the specified size MB in size
                 const long maxLogSizeBytes = 5 * 1024 * 1024; // 5 MB (before zipping)

--- a/EDDPMonitor/EddpConfiguration.cs
+++ b/EDDPMonitor/EddpConfiguration.cs
@@ -19,9 +19,6 @@ namespace EddiEddpMonitor
             watches = new List<Watch>();
         }
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         /// <summary>
         /// Obtain configuration from a file.  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\eddpmonitor.json is used
@@ -85,10 +82,7 @@ namespace EddiEddpMonitor
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/EddiInaraService/InaraConfiguration.cs
+++ b/EddiInaraService/InaraConfiguration.cs
@@ -25,9 +25,6 @@ namespace EddiInaraService
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
         
         /// <summary>
         /// Obtain credentials from a file.  If the file name is not supplied the the default
@@ -92,10 +89,7 @@ namespace EddiInaraService
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/GalnetMonitor/GalnetConfiguration.cs
+++ b/GalnetMonitor/GalnetConfiguration.cs
@@ -17,9 +17,6 @@ namespace GalnetMonitor
 
         public bool galnetAlwaysOn { get; set; } = false;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         /// <summary>
         /// Obtain configuration from a file.  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\galnetmonitor.json is used
@@ -75,10 +72,7 @@ namespace GalnetMonitor
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/MaterialMonitor/MaterialMonitorConfiguration.cs
+++ b/MaterialMonitor/MaterialMonitorConfiguration.cs
@@ -17,9 +17,6 @@ namespace EddiMaterialMonitor
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         public MaterialMonitorConfiguration()
         {
             materials = new ObservableCollection<MaterialAmount>();
@@ -86,10 +83,7 @@ namespace EddiMaterialMonitor
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/MissionMonitor/MissionMonitorConfiguration.cs
+++ b/MissionMonitor/MissionMonitorConfiguration.cs
@@ -22,9 +22,6 @@ namespace EddiMissionMonitor
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         public MissionMonitorConfiguration()
         {
             missions = new ObservableCollection<Mission>();
@@ -112,10 +109,7 @@ namespace EddiMissionMonitor
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
             Logging.Debug("Configuration to file: " + json);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/ShipMonitor/ShipMonitorConfiguration.cs
+++ b/ShipMonitor/ShipMonitorConfiguration.cs
@@ -19,10 +19,7 @@ namespace EddiShipMonitor
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
+        
         public ShipMonitorConfiguration()
         {
             shipyard = new ObservableCollection<Ship>();
@@ -119,10 +116,7 @@ namespace EddiShipMonitor
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -33,9 +33,6 @@ namespace EddiSpeechResponder
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         private static readonly string DEFAULT_PATH = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).FullName + @"\" + Properties.SpeechResponder.default_personality_script_filename;
         private static readonly string DEFAULT_USER_PATH = Constants.DATA_DIR + @"\personalities\" + Properties.SpeechResponder.default_personality_script_filename;
 
@@ -163,10 +160,7 @@ namespace EddiSpeechResponder
             if (filename != DEFAULT_PATH)
             {
                 string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-                lock (fileLock)
-                {
-                    Files.Write(filename, json);
-                }
+                Files.Write(filename, json);
             }
         }
 

--- a/SpeechResponder/SpeechResponderConfiguration.cs
+++ b/SpeechResponder/SpeechResponderConfiguration.cs
@@ -19,10 +19,7 @@ namespace EddiSpeechResponder
 
         [JsonIgnore]
         private string dataPath;
-
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
+        
         /// <summary>
         /// Obtain configuration from a file.  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\speechresponder.json is used
@@ -82,10 +79,7 @@ namespace EddiSpeechResponder
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/SpeechService/SpeechServiceConfiguration.cs
+++ b/SpeechService/SpeechServiceConfiguration.cs
@@ -34,9 +34,6 @@ namespace EddiSpeechService
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         /// <summary>
         /// Obtain speech config from a file. If  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\speech.json is used
@@ -99,10 +96,7 @@ namespace EddiSpeechService
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/StarMapService/StarMapConfiguration.cs
+++ b/StarMapService/StarMapConfiguration.cs
@@ -20,9 +20,6 @@ namespace EddiStarMapService
         [JsonIgnore]
         private string dataPath;
 
-        [JsonIgnore]
-        static readonly object fileLock = new object();
-
         /// <summary>
         /// Obtain credentials from a file.  If the file name is not supplied the the default
         /// path of Constants.Data_DIR\edsm.json is used
@@ -88,10 +85,7 @@ namespace EddiStarMapService
             }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            lock (fileLock)
-            {
-                Files.Write(filename, json);
-            }
+            Files.Write(filename, json);
         }
     }
 }

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -21,11 +21,9 @@ namespace Utilities
         /// <summary> If true, skips writing to permanent storage </summary>
         public static bool unitTesting { get; set; } = false;
 
-        /// <summary>
-        /// Read a file, handling exceptions
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
+        /// <summary>Attempt to read a file, handling exceptions, and bailing if too many attempts fail</summary>
+        /// <param name="fileName">the file to read</param>
+        /// <returns>the contents of the file</returns>
         public static string Read(string fileName)
         {
             string result = null;

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -276,60 +275,5 @@ namespace Utilities
             //file is not locked
             return false;
         }
-    }
-
-    // Code from https://www.codeproject.com/Tips/1190802/File-Locking-in-a-Multi-Threaded-Environment
-    // The code maintains a concurrent dictionary of lock objects and keeps track of how many calls are in the queue for
-    // accessing each filename. If the count goes down to 0, the key is removed from the dictionary as a cleanup mechanism.
-    class LockManager
-    {
-        private static readonly ConcurrentDictionary<string, lobj> _locks =
-                new ConcurrentDictionary<string, lobj>();
-
-        public static void GetLock(string filename, Action action)
-        {
-            lock (GetLock(filename))
-            {
-                try 
-                {
-                    action();
-                }
-                finally
-                {
-                    Unlock(filename);
-                }
-            }
-        }
-
-        private static lobj GetLock(string filename)
-        {
-            if (_locks.TryGetValue(filename.ToLower(), out var o))
-            {
-                o.count++;
-                return o;
-            }
-            else
-            {
-                o = new lobj();
-                _locks.TryAdd(filename.ToLower(), o);
-                o.count++;
-                return o;
-            }
-        }
-
-        private static void Unlock(string filename)
-        {
-            if (_locks.TryGetValue(filename.ToLower(), out var o))
-            {
-                o.count--;
-                if (o.count != 0) { return; }
-                _locks.TryRemove(filename.ToLower(), out lobj _);
-            }
-        }
-    }
-
-    class lobj
-    {
-        public int count = 0;
     }
 }

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -290,8 +290,14 @@ namespace Utilities
         {
             lock (GetLock(filename))
             {
-                action();
-                Unlock(filename);
+                try 
+                {
+                    action();
+                }
+                finally
+                {
+                    Unlock(filename);
+                }
             }
         }
 

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -10,6 +10,11 @@ namespace Utilities
 {
     public class Files
     {
+        private const int readAttempts = 10;
+        private const int readIODelayMs = 25;
+        private const int writeAttempts = 20;
+        private const int writeIODelayMs = 25;
+        
         /// <summary> Ignore missing config files on first launch? </summary>
         public static bool ignoreMissing { get; set; } = false;
 
@@ -24,16 +29,14 @@ namespace Utilities
         public static string Read(string fileName)
         {
             string result = null;
-            int attempts = 10;
-            int ioDelayMs = 25;
+            int attempts = readAttempts;
             if (fileName != null)
             {
                 while (attempts > 0 && TryRead(fileName, attempts, out result))
                 {
                     attempts--;
-                    Thread.Sleep(ioDelayMs);
+                    Thread.Sleep(readIODelayMs);
                 }
-
                 if (attempts == 0)
                 {
                     throw new IOException("IO read failed for " + fileName + ", too many attempts.");
@@ -114,13 +117,11 @@ namespace Utilities
 
                 await Task.Run(() =>
                 {
-                    int attempts = 20;
-                    int ioDelayMs = 25;
-
+                    int attempts = writeAttempts;
                     while (attempts > 0 && TryWrite(fileName, attempts, content))
                     {
                         attempts--;
-                        Thread.Sleep(ioDelayMs);
+                        Thread.Sleep(writeIODelayMs);
                     }
                     if (attempts == 0)
                     {

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -11,10 +11,10 @@ namespace Utilities
     public class Files
     {
         private const int readAttempts = 10;
-        private const int readIODelayMs = 25;
+        private const int readIODelayMilliseconds = 25;
         private const int writeAttempts = 20;
-        private const int writeIODelayMs = 25;
-        
+        private const int writeIODelayMilliseconds = 25;
+
         /// <summary> Ignore missing config files on first launch? </summary>
         public static bool ignoreMissing { get; set; } = false;
 
@@ -33,11 +33,11 @@ namespace Utilities
                 while (attempts > 0 && TryRead(fileName, attempts, out result))
                 {
                     attempts--;
-                    Thread.Sleep(readIODelayMs);
+                    Thread.Sleep(readIODelayMilliseconds);
                 }
                 if (attempts == 0)
                 {
-                    throw new IOException("IO read failed for " + fileName + ", too many attempts.");
+                    throw new IOException($"IO read failed for {fileName}, too many attempts.");
                 }
             }
             return result;
@@ -119,7 +119,7 @@ namespace Utilities
                     while (attempts > 0 && TryWrite(fileName, attempts, content))
                     {
                         attempts--;
-                        Thread.Sleep(writeIODelayMs);
+                        Thread.Sleep(writeIODelayMilliseconds);
                     }
                     if (attempts == 0)
                     {

--- a/Utilities/LockManager.cs
+++ b/Utilities/LockManager.cs
@@ -7,10 +7,9 @@ namespace Utilities
     // Code from https://www.codeproject.com/Tips/1190802/File-Locking-in-a-Multi-Threaded-Environment
     // The code maintains a concurrent dictionary of lock objects and keeps track of how many calls are in the queue for
     // accessing each filename. If the count goes down to 0, the key is removed from the dictionary as a cleanup mechanism.
-    public class LockManager
+    public static class LockManager
     {
-        private static readonly ConcurrentDictionary<string, lobj> _locks =
-                new ConcurrentDictionary<string, lobj>();
+        private static readonly ConcurrentDictionary<string, lockCount> _locks = new ConcurrentDictionary<string, lockCount>();
 
         public static void GetLock(string lockName, Action action)
         {
@@ -27,34 +26,34 @@ namespace Utilities
             }
         }
 
-        private static lobj GetLock(string lockName)
+        private static lockCount GetLock(string lockName)
         {
-            if (_locks.TryGetValue(lockName.ToLower(), out var o))
+            if (_locks.TryGetValue(lockName.ToLower(), out lockCount lc))
             {
-                o.count++;
-                return o;
+                lc.count++;
+                return lc;
             }
             else
             {
-                o = new lobj();
-                _locks.TryAdd(lockName.ToLower(), o);
-                o.count++;
-                return o;
+                lc = new lockCount();
+                _locks.TryAdd(lockName.ToLower(), lc);
+                lc.count++;
+                return lc;
             }
         }
 
         private static void Unlock(string lockName)
         {
-            if (_locks.TryGetValue(lockName.ToLower(), out var o))
+            if (_locks.TryGetValue(lockName.ToLower(), out lockCount lc))
             {
-                o.count--;
-                if (o.count != 0) { return; }
-                _locks.TryRemove(lockName.ToLower(), out lobj _);
+                lc.count--;
+                if (lc.count != 0) { return; }
+                _locks.TryRemove(lockName.ToLower(), out lockCount _);
             }
         }
     }
 
-    class lobj
+    internal class lockCount
     {
         public int count = 0;
     }

--- a/Utilities/LockManager.cs
+++ b/Utilities/LockManager.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Utilities
+{
+
+    // Code from https://www.codeproject.com/Tips/1190802/File-Locking-in-a-Multi-Threaded-Environment
+    // The code maintains a concurrent dictionary of lock objects and keeps track of how many calls are in the queue for
+    // accessing each filename. If the count goes down to 0, the key is removed from the dictionary as a cleanup mechanism.
+    public class LockManager
+    {
+        private static readonly ConcurrentDictionary<string, lobj> _locks =
+                new ConcurrentDictionary<string, lobj>();
+
+        public static void GetLock(string lockName, Action action)
+        {
+            lock (GetLock(lockName))
+            {
+                try
+                {
+                    action();
+                }
+                finally
+                {
+                    Unlock(lockName);
+                }
+            }
+        }
+
+        private static lobj GetLock(string lockName)
+        {
+            if (_locks.TryGetValue(lockName.ToLower(), out var o))
+            {
+                o.count++;
+                return o;
+            }
+            else
+            {
+                o = new lobj();
+                _locks.TryAdd(lockName.ToLower(), o);
+                o.count++;
+                return o;
+            }
+        }
+
+        private static void Unlock(string lockName)
+        {
+            if (_locks.TryGetValue(lockName.ToLower(), out var o))
+            {
+                o.count--;
+                if (o.count != 0) { return; }
+                _locks.TryRemove(lockName.ToLower(), out lobj _);
+            }
+        }
+    }
+
+    class lobj
+    {
+        public int count = 0;
+    }
+}

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -90,6 +90,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LockManager.cs" />
     <Compile Include="Processes.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="IPA.cs" />


### PR DESCRIPTION
This PR is designed to prevent issues like:
- https://rollbar.com/EDCD/EDDI/items/17558/
- https://rollbar.com/EDCD/EDDI/items/16979/
- https://rollbar.com/EDCD/EDDI/items/17609/
- https://rollbar.com/EDCD/EDDI/items/17607/
- https://rollbar.com/EDCD/EDDI/items/17583/

It moves file locking from each individual config file into the `Files` class and if an IO exception occurs it waits and retries several times before completely failing.

May resolve #1780.
Replaces #1808.