### PR TITLE
Fix `TrafficDetails()` null reference exception

### DIFF
--- a/StarMapService/EdsmTrafficData.cs
+++ b/StarMapService/EdsmTrafficData.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Collections.Generic;
+using Utilities;
 
 namespace EddiStarMapService
 {
@@ -11,13 +12,17 @@ namespace EddiStarMapService
         {
             Traffic traffic = GetStarMapTraffic(systemName, edsmId);
             Traffic deaths = GetStarMapDeaths(systemName, edsmId);
-            Traffic hostility = new Traffic(
-                decimal.Divide((long)deaths.total, (long)traffic.total) * 100,
-                decimal.Divide((long)deaths.week, (long)traffic.week) * 100,
-                decimal.Divide((long)deaths.day, (long)traffic.day) * 100
-            );
 
-            return hostility;
+            if (traffic != null && deaths != null)
+            {
+                Traffic hostility = new Traffic(
+                    decimal.Divide((long)deaths.total, (long)traffic.total) * 100,
+                    decimal.Divide((long)deaths.week, (long)traffic.week) * 100,
+                    decimal.Divide((long)deaths.day, (long)traffic.day) * 100
+                );
+                return hostility;
+            }
+            return new Traffic();
         }
 
         public Traffic GetStarMapTraffic(string systemName, long? edsmId = null)
@@ -37,11 +42,12 @@ namespace EddiStarMapService
                     return ParseStarMapTraffic(response);
                 }
             }
-            return null;
+            return new Traffic();
         }
 
         public Traffic ParseStarMapTraffic(JObject response)
         {
+            if (response.IsNullOrEmpty()) { return new Traffic(); }
             Traffic traffic = ((JObject)response["traffic"]).ToObject<Traffic>();
             return traffic;
         }
@@ -63,11 +69,12 @@ namespace EddiStarMapService
                     return ParseStarMapDeaths(response);
                 }
             }
-            return null;
+            return new Traffic();
         }
 
         public Traffic ParseStarMapDeaths(JObject response)
         {
+            if (response.IsNullOrEmpty()) { return new Traffic(); }
             Traffic deaths = ((JObject)response["deaths"]).ToObject<Traffic>();
             return deaths;
         }

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -529,5 +529,21 @@ namespace UnitTests
             Assert.AreEqual(31, deaths.week);
             Assert.AreEqual(4, deaths.day);
         }
+
+        [TestMethod]
+        public void TestTrafficUnknown()
+        {
+            // Setup
+            JObject response = new JObject();
+
+            // Act
+            Traffic traffic = fakeEdsmService.ParseStarMapTraffic(response);
+            
+            // Assert
+            Assert.IsNotNull(traffic);
+            Assert.AreEqual(0, traffic.total);
+            Assert.AreEqual(0, traffic.week);
+            Assert.AreEqual(0, traffic.day);
+        }
     }
 }

--- a/Utilities/ExtensionMethods.cs
+++ b/Utilities/ExtensionMethods.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace Utilities
 {
@@ -14,6 +16,15 @@ namespace Utilities
             var anotherJson = JsonConvert.SerializeObject(another);
 
             return objJson == anotherJson;
+        }
+
+        public static bool IsNullOrEmpty(this JToken token)
+        {
+            return (token == null) ||
+                   (token.Type == JTokenType.Array && !token.HasValues) ||
+                   (token.Type == JTokenType.Object && !token.HasValues) ||
+                   (token.Type == JTokenType.String && token.ToString() == String.Empty) ||
+                   (token.Type == JTokenType.Null);
         }
     }
 }


### PR DESCRIPTION
Fix null reference exception on attempting to obtain traffic data from a star system which does not exit.
Ref. https://rollbar.com/EDCD/EDDI/items/17849/occurrences/127675545451/