### PR TITLE
Handle null or empty ship objects in the Inara Responder

### DIFF
--- a/InaraResponder/InaraResponder.cs
+++ b/InaraResponder/InaraResponder.cs
@@ -317,14 +317,17 @@ namespace EddiInaraResponder
 
         private void handleCarrierJumpedEvent(CarrierJumpedEvent @event) 
         {
-            Ship currentShip = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship Monitor")).GetCurrentShip();
-
-            inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelCarrierJump", new Dictionary<string, object>()
+            var eventData = new Dictionary<string, object>()
             {
                 { "starsystemName", @event.systemname },
-                { "shipType", currentShip.model },
-                { "shipGameID", currentShip.LocalId }
-            }));
+            };
+            Ship currentShip = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship Monitor")).GetCurrentShip();
+            if (!string.IsNullOrEmpty(currentShip?.model))
+            {
+                eventData.Add("shipType", currentShip.model);
+                eventData.Add("shipGameID", currentShip.LocalId);
+            }
+            inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelCarrierJump", eventData));
             // Note: There is a "jumpDistance" input property for this event,
             // but the current recommendation from the API documentation is to omit it.
         }
@@ -500,15 +503,19 @@ namespace EddiInaraResponder
             // Don't add this at the session start after Location, per guidance from Inara. 
             if (@event.station != firstDockedLocation)
             {
-                Ship currentShip = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship Monitor")).GetCurrentShip();
-                inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelDock", new Dictionary<string, object>()
+                var eventData = new Dictionary<string, object>()
                 {
                     { "starsystemName", @event.system },
                     { "stationName", @event.station },
-                    { "marketID", @event.marketId },
-                    { "shipType", currentShip.EDName },
-                    { "shipGameID", currentShip.LocalId }
-                }));
+                    { "marketID", @event.marketId }
+                };
+                Ship currentShip = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship Monitor")).GetCurrentShip();
+                if (!string.IsNullOrEmpty(currentShip?.model))
+                {
+                    eventData.Add("shipType", currentShip.model);
+                    eventData.Add("shipGameID", currentShip.LocalId);
+                }
+                inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelDock", eventData));
             }
             firstDockedLocation = null;
         }
@@ -1068,14 +1075,18 @@ namespace EddiInaraResponder
             {
                 inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "setCommanderReputationMinorFaction", minorFactionRepData));
             }
+            var eventData = new Dictionary<string, object>()
+                {
+                    { "starsystemName", @event.system },
+                    { "jumpDistance", @event.distance }
+                };
             Ship currentShip = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship Monitor")).GetCurrentShip();
-            inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelFSDJump", new Dictionary<string, object>()
+            if (!string.IsNullOrEmpty(currentShip?.model))
             {
-                { "starsystemName", @event.system },
-                { "jumpDistance", @event.distance },
-                { "shipType", currentShip.EDName },
-                { "shipGameID", currentShip.LocalId }
-            }));
+                eventData.Add("shipType", currentShip.model);
+                eventData.Add("shipGameID", currentShip.LocalId);
+            }
+            inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "addCommanderTravelFSDJump", eventData));
         }
 
         private static List<Dictionary<string, object>> minorFactionReputations(List<Faction> factions)


### PR DESCRIPTION
Ref. https://rollbar.com/EDCD/EDDI/items/17848/, https://rollbar.com/EDCD/EDDI/items/17845/
Either the ShipMonitor.CurrentShip() method is returning null (because currentShipId is not assigned) or it is returning a new ship with no assigned properties. Neither case is acceptable to the Inara responder.