### PR TITLE
Fix CommodityMarketQuote.cs/FromCapiJson() null reference exception

### DIFF
--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -176,11 +176,14 @@ namespace EddiDataDefinitions
                 };
 
                 List<string> StatusFlags = new List<string>();
-                foreach (string statusFlag in capiJSON["statusFlags"])
+                if (capiJSON["statusFlags"] != null)
                 {
-                    StatusFlags.Add(statusFlag);
+                    foreach (string statusFlag in capiJSON["statusFlags"])
+                    {
+                        StatusFlags.Add(statusFlag);
+                    }
+                    quote.StatusFlags = StatusFlags;
                 }
-                quote.StatusFlags = StatusFlags;
             }
             catch (Exception e)
             {

--- a/Tests/DataDefinitionTests.cs
+++ b/Tests/DataDefinitionTests.cs
@@ -453,5 +453,13 @@ namespace UnitTests
             Assert.IsTrue(system1.DeepEquals(system3));
             Assert.IsFalse(DeserializeJsonResource<StarSystem>(Resources.sqlStarSystem1).Equals(system3));
         }
+
+        [TestMethod]
+        public void TestCommodityMarketQuoteFromCAPIjson()
+        {
+            string line = @" {""id"":128066403,""categoryname"":""NonMarketable"",""name"":""Drones"",""stock"":9999999,""buyPrice"":101,""sellPrice"":101,""demand"":9999999,""legality"":"""",""meanPrice"":101,""demandBracket"":2,""stockBracket"":2,""locName"":""Limpet""} ";
+            var jObject = JObject.Parse(line);
+            var result = CommodityMarketQuote.FromCapiJson(jObject);
+        }
     }
 }


### PR DESCRIPTION
Ref. https://rollbar.com/EDCD/EDDI/items/17843/occurrences/127659784746/
An exception was being thrown because we were trying to enumerate status flags which were not present / null.