### PR TITLE
Fix speech config inconsistency

### DIFF
--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -1088,8 +1088,8 @@ namespace Eddi
                 DisableSsml = disableSsmlCheckbox.IsChecked.Value,
                 EnableIcao = enableIcaoCheckbox.IsChecked.Value
             };
+            SpeechService.Instance.Configuration = speechConfiguration;
             speechConfiguration.ToFile();
-            SpeechService.Instance.ReloadConfiguration();
         }
 
         // Called from the VoiceAttack plugin if the "Configure EDDI" voice command has

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using Utilities;
+using ComboBox = System.Windows.Controls.ComboBox;
 
 namespace Eddi
 {
@@ -1008,27 +1009,42 @@ namespace Eddi
 
         private void ttsVoiceDropDownUpdated(object sender, SelectionChangedEventArgs e)
         {
-            ttsUpdated();
+            if (sender is ComboBox comboBox && comboBox.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsEffectsLevelUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsDistortionLevelUpdated(object sender, RoutedEventArgs e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsRateUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsVolumeUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsTestVoiceButtonClicked(object sender, RoutedEventArgs e)

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -103,11 +103,6 @@ namespace EddiSpeechService
             }
         }
 
-        public void ReloadConfiguration()
-        {
-            Configuration = SpeechServiceConfiguration.FromFile();
-        }
-
         public void Say(Ship ship, string message, int priority = 3, string voice = null, bool radio = false, string eventType = null, bool invokedFromVA = false)
         {
             if (message == null)


### PR DESCRIPTION
Fixes #1837. 

We were saving to the config file then immediately reading from the config file. Since the write operation is now asynchronous the read operation often actually was completing before the write operation. This created a de-coupling between the displayed UI configuration and the speech service configuration and resulted in the speech service not actually picking up the change in the config file until another change had occurred.

This PR updates the configuration directly, rather than bouncing the update through the file system. It also eliminates several configuration reloads that would otherwise occur while the UI was being loaded.