### PR TITLE
Fix speech config inconsistency

### DIFF
--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -1088,8 +1088,8 @@ namespace Eddi
                 DisableSsml = disableSsmlCheckbox.IsChecked.Value,
                 EnableIcao = enableIcaoCheckbox.IsChecked.Value
             };
+            SpeechService.Instance.Configuration = speechConfiguration;
             speechConfiguration.ToFile();
-            SpeechService.Instance.ReloadConfiguration();
         }
 
         // Called from the VoiceAttack plugin if the "Configure EDDI" voice command has

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using Utilities;
+using ComboBox = System.Windows.Controls.ComboBox;
 
 namespace Eddi
 {
@@ -1008,27 +1009,42 @@ namespace Eddi
 
         private void ttsVoiceDropDownUpdated(object sender, SelectionChangedEventArgs e)
         {
-            ttsUpdated();
+            if (sender is ComboBox comboBox && comboBox.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsEffectsLevelUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsDistortionLevelUpdated(object sender, RoutedEventArgs e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsRateUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsVolumeUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            ttsUpdated();
+            if (sender is Slider slider && slider.IsLoaded)
+            {
+                ttsUpdated();
+            }
         }
 
         private void ttsTestVoiceButtonClicked(object sender, RoutedEventArgs e)

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -1009,7 +1009,7 @@ namespace Eddi
 
         private void ttsVoiceDropDownUpdated(object sender, SelectionChangedEventArgs e)
         {
-            if (sender is ComboBox comboBox && comboBox.IsLoaded)
+            if (sender is FrameworkElement frameworkElement && frameworkElement.IsLoaded)
             {
                 ttsUpdated();
             }
@@ -1017,7 +1017,7 @@ namespace Eddi
 
         private void ttsEffectsLevelUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            if (sender is Slider slider && slider.IsLoaded)
+            if (sender is FrameworkElement frameworkElement && frameworkElement.IsLoaded)
             {
                 ttsUpdated();
             }
@@ -1025,7 +1025,7 @@ namespace Eddi
 
         private void ttsDistortionLevelUpdated(object sender, RoutedEventArgs e)
         {
-            if (sender is Slider slider && slider.IsLoaded)
+            if (sender is FrameworkElement frameworkElement && frameworkElement.IsLoaded)
             {
                 ttsUpdated();
             }
@@ -1033,7 +1033,7 @@ namespace Eddi
 
         private void ttsRateUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            if (sender is Slider slider && slider.IsLoaded)
+            if (sender is FrameworkElement frameworkElement && frameworkElement.IsLoaded)
             {
                 ttsUpdated();
             }
@@ -1041,7 +1041,7 @@ namespace Eddi
 
         private void ttsVolumeUpdated(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
-            if (sender is Slider slider && slider.IsLoaded)
+            if (sender is FrameworkElement frameworkElement && frameworkElement.IsLoaded)
             {
                 ttsUpdated();
             }

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -103,11 +103,6 @@ namespace EddiSpeechService
             }
         }
 
-        public void ReloadConfiguration()
-        {
-            Configuration = SpeechServiceConfiguration.FromFile();
-        }
-
         public void Say(Ship ship, string message, int priority = 3, string voice = null, bool radio = false, string eventType = null, bool invokedFromVA = false)
         {
             if (message == null)

--- a/Utilities/Files.cs
+++ b/Utilities/Files.cs
@@ -4,7 +4,6 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Utilities
 {
@@ -102,7 +101,7 @@ namespace Utilities
         /// </summary>
         /// <param name="fileName"></param>
         /// <param name="content"></param>
-        public static async void Write(string fileName, string content)
+        public static void Write(string fileName, string content)
         {
             if (fileName != null && content != null)
             {
@@ -113,19 +112,16 @@ namespace Utilities
                     return;
                 }
 
-                await Task.Run(() =>
+                int attempts = writeAttempts;
+                while (attempts > 0 && TryWrite(fileName, attempts, content))
                 {
-                    int attempts = writeAttempts;
-                    while (attempts > 0 && TryWrite(fileName, attempts, content))
-                    {
-                        attempts--;
-                        Thread.Sleep(writeIODelayMilliseconds);
-                    }
-                    if (attempts == 0)
-                    {
-                        throw new IOException("IO write failed for " + fileName + ", too many attempts.");
-                    }
-                }).ConfigureAwait(false);
+                    attempts--;
+                    Thread.Sleep(writeIODelayMilliseconds);
+                }
+                if (attempts == 0)
+                {
+                    throw new IOException("IO write failed for " + fileName + ", too many attempts.");
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #1837. 

We were saving to the config file then immediately reading from the config file. Since the write operation is now asynchronous the read operation often actually was completing before the write operation. This created a de-coupling between the displayed UI configuration and the speech service configuration and resulted in the speech service not actually picking up the change in the config file until another change had occurred.

This PR reverts to synchronous writing, looking forward to a future state where we stop bouncing configuration updates through the file system. It also eliminates several configuration reloads that would otherwise occur while the UI was being loaded.