### PR TITLE
Fix Appveyor ambiguous call

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -169,14 +169,19 @@ namespace EddiCore
                     }
                     if (configuration.HomeSystem == configuration.SquadronSystem)
                     {
+                        // Run both actions on the same thread
                         essentialAsyncTasks.Add(Task.Run((Action)ActionUpdateHomeSystemStation + ActionUpdateSquadronSystem));
                     }
                     else
                     {
+                        // Run both actions on distinct threads
                         essentialAsyncTasks.AddRange(new List<Task>()
                         {
-                            Task.Run(ActionUpdateHomeSystemStation),
-                            Task.Run(ActionUpdateSquadronSystem)
+                            // Method groups are considered by AppVeyor to be an ambiguous call.
+                            // ReSharper disable ConvertClosureToMethodGroup
+                            Task.Run(() => ActionUpdateHomeSystemStation()),
+                            Task.Run(() => ActionUpdateSquadronSystem())
+                            // ReSharper restore ConvertClosureToMethodGroup
                         });
                     }
                 }


### PR DESCRIPTION
Code cleanup removed a cast that was necessary to prevent an ambiguous call error when building EDDI.cs.
Fix that here.