### PR TITLE
Speech responder - Improved exception reporting

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1252,7 +1252,14 @@ namespace EddiCore
                         }
                         catch (Exception ex)
                         {
-                            Logging.Error(responder.ResponderName() + " failed to handle event " + JsonConvert.SerializeObject(@event), ex);
+                            Dictionary<string, object> data = new Dictionary<string, object>
+                            {
+                                { "event", JsonConvert.SerializeObject(@event) },
+                                { "exception", ex.Message },
+                                { "stacktrace", ex.StackTrace }
+                            };
+
+                            Logging.Error(responder.ResponderName() + " failed to handle event " + @event.type, data);
                         }
                     });
                     responderTasks.Add(responderTask);

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -155,6 +155,17 @@ namespace EddiSpeechResponder
                 Logging.Warn($"Failed to resolve {scriptName} at line {e.Line}. {e}");
                 return $"There is a problem with {scriptName} at line {e.Line}. {errorTranslation(e.Message)}";
             }
+            catch (Exception e)
+            {
+                Dictionary<string, object> data = new Dictionary<string, object>
+                {
+                    { "exception", e },
+                    { "script", script },
+                    { "store", JsonConvert.SerializeObject(store) }
+                };
+                Logging.Error(e.Message, data);
+                return $"{e.Message}";
+            }
         }
 
         private string errorTranslation(string msg)


### PR DESCRIPTION
- [Cottle related exceptions in the Speech Responder (other than parse exceptions) are being thrown all the way to EDDI.cs before they are being caught](https://rollbar.com/EDCD/all/items).
  - System.Reflection.TargetInvocationException
  - System.ArgumentOutOfRangeException
  - System.NullReferenceException
  - System.InvalidOperationException
- Catch those exceptions at the appropriate method, with better message names to assist with Rollbar item grouping.
- Provide an audible message to alert users when these exceptions occur.

Resolves #1861