### PR TITLE
Add a simple splash screen

### DIFF
--- a/EDDI/Eddi.csproj
+++ b/EDDI/Eddi.csproj
@@ -282,6 +282,9 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <SplashScreen Include="..\graphics\logo.png" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -157,6 +157,9 @@ namespace Eddi
 
         public MainWindow()
         {
+            SplashScreen splashScreen = new SplashScreen("logo.png");
+            splashScreen.Show(true);
+
             InitializeComponent();
             DataContext = EDDI.Instance;
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -157,8 +157,11 @@ namespace Eddi
 
         public MainWindow()
         {
-            SplashScreen splashScreen = new SplashScreen("logo.png");
-            splashScreen.Show(true);
+            if (!App.FromVA)
+            {
+                SplashScreen splashScreen = new SplashScreen("logo.png");
+                splashScreen.Show(true);
+            }
 
             InitializeComponent();
             DataContext = EDDI.Instance;


### PR DESCRIPTION
Fixes #1856.

The automatic support described in [MS's docs](https://docs.microsoft.com/en-us/dotnet/framework/wpf/app-development/how-to-add-a-splash-screen-to-a-wpf-application) didn't seem to work, but this is working fine.

Please could VA-using devs verify that the VA user experience is unchanged.
