### PR TITLE
Prefer 64-bit for the standalone app

### DIFF
--- a/EDDI/Eddi.csproj
+++ b/EDDI/Eddi.csproj
@@ -42,6 +42,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -51,6 +52,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>EDDI.ico</ApplicationIcon>


### PR DESCRIPTION
Note that this only affects a flag in the built EXE.

The EXE and DLLs remain compatible with any CPU, and when loaded as a VA plug-in, EDDI will run in whichever instruction set VA is in.

If a VA-using dev could verify that, we're good.

Background: EDDI standalone used to default to 64-bit but at some point MS silently flipped the default to "prefer 32-bit". So now we opt-in.

There are really no downsides to preferring 64-bit: notably many more registers are available, reducing cache hits.