### PR TITLE
Speech responder - Improved exception reporting

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1252,7 +1252,14 @@ namespace EddiCore
                         }
                         catch (Exception ex)
                         {
-                            Logging.Error(responder.ResponderName() + " failed to handle event " + JsonConvert.SerializeObject(@event), ex);
+                            Dictionary<string, object> data = new Dictionary<string, object>
+                            {
+                                { "event", JsonConvert.SerializeObject(@event) },
+                                { "exception", ex.Message },
+                                { "stacktrace", ex.StackTrace }
+                            };
+
+                            Logging.Error(responder.ResponderName() + " failed to handle event " + @event.type, data);
                         }
                     });
                     responderTasks.Add(responderTask);

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -157,13 +157,7 @@ namespace EddiSpeechResponder
             }
             catch (Exception e)
             {
-                Dictionary<string, object> data = new Dictionary<string, object>
-                {
-                    { "exception", e },
-                    { "script", script },
-                    { "store", JsonConvert.SerializeObject(store) }
-                };
-                Logging.Error(e.Message, data);
+                Logging.Warn(e.Message, e);
                 return $"{e.Message}";
             }
         }

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -25,7 +25,6 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Utilities;
 

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -25,6 +25,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Utilities;
 
@@ -158,7 +159,7 @@ namespace EddiSpeechResponder
             catch (Exception e)
             {
                 Logging.Warn(e.Message, e);
-                return $"{e.Message}";
+                return $"Error with {scriptObject?.Name ?? "this"} script: {e.Message}";
             }
         }
 

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -155,6 +155,17 @@ namespace EddiSpeechResponder
                 Logging.Warn($"Failed to resolve {scriptName} at line {e.Line}. {e}");
                 return $"There is a problem with {scriptName} at line {e.Line}. {errorTranslation(e.Message)}";
             }
+            catch (Exception e)
+            {
+                Dictionary<string, object> data = new Dictionary<string, object>
+                {
+                    { "exception", e },
+                    { "script", script },
+                    { "store", JsonConvert.SerializeObject(store) }
+                };
+                Logging.Error(e.Message, data);
+                return $"{e.Message}";
+            }
         }
 
         private string errorTranslation(string msg)


### PR DESCRIPTION
- [Cottle related exceptions in the Speech Responder (other than parse exceptions) are being thrown all the way to EDDI.cs before they are being caught](https://rollbar.com/EDCD/all/items).
  - System.Reflection.TargetInvocationException
  - System.ArgumentOutOfRangeException
  - System.NullReferenceException
  - System.InvalidOperationException
- Catch those exceptions at the appropriate method.
- Use Logging.Warning rather than Logging.Error to prevent these from hitting Rollbar.
- Provide an audible message to alert users when these exceptions occur so that they can investigate those issues.

Resolves #1861