### PR TITLE
Fix embedded broken links

### DIFF
--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -1249,7 +1249,14 @@ namespace Eddi
 
         private void EDDIClicked(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/EDCD/EDDI/blob/master/README.md");
+            if (EDDI.Instance.EddiIsBeta())
+            {
+                Process.Start("https://github.com/EDCD/EDDI/blob/develop/README.md");
+            }
+            else
+            {
+                Process.Start("https://github.com/EDCD/EDDI/blob/stable/README.md");
+            }
         }
 
         private void WikiClicked(object sender, RoutedEventArgs e)
@@ -1259,7 +1266,14 @@ namespace Eddi
 
         private void TroubleshootClicked(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/EDCD/EDDI/blob/master/TROUBLESHOOTING.md");
+            if (EDDI.Instance.EddiIsBeta())
+            {
+                Process.Start("https://github.com/EDCD/EDDI/blob/develop/TROUBLESHOOTING.md");
+            }
+            else
+            {
+                Process.Start("https://github.com/EDCD/EDDI/blob/stable/TROUBLESHOOTING.md");
+            }
         }
     }
 }


### PR DESCRIPTION
- Revise embedded links broken by renaming the release branch from `master` to `stable`.
- Open either the `stable` or the `develop` version of the documentation, depending on which is applicable to the EDDI version.

Fixes #1876.

Note: I also checked the other tabs for similar issues and found no additional broken links.