### PR TITLE
Update EDDN responder shipyard data to include `allowCobraMkIV` property

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -651,8 +651,8 @@ namespace EddiCompanionAppService
                 {
                     var contexts = new ProfileContexts 
                     { 
-                        allowCobraMkIV = (bool) json["commander"]["capabilities"]["AllowCobraMkIV"], 
-                        inHorizons = (bool) json["commander"]["capabilities"]["Horizons"] 
+                        allowCobraMkIV = (bool)json["commander"]["capabilities"]["AllowCobraMkIV"], 
+                        inHorizons = (bool)json["commander"]["capabilities"]["Horizons"] 
                     };
                     Profile.contexts = contexts;
                 }

--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -647,6 +647,16 @@ namespace EddiCompanionAppService
                 Profile.docked = (bool)json["commander"]["docked"];
                 Profile.alive = (bool)json["commander"]["alive"];
 
+                if (json["commander"]["capabilities"] != null)
+                {
+                    var contexts = new ProfileContexts 
+                    { 
+                        allowCobraMkIV = (bool) json["commander"]["capabilities"]["AllowCobraMkIV"], 
+                        inHorizons = (bool) json["commander"]["capabilities"]["Horizons"] 
+                    };
+                    Profile.contexts = contexts;
+                }
+
                 string systemName = json["lastSystem"] == null ? null : (string)json["lastSystem"]["name"];
                 if (systemName != null)
                 {

--- a/CompanionAppService/Profile.cs
+++ b/CompanionAppService/Profile.cs
@@ -29,5 +29,17 @@ namespace EddiCompanionAppService
 
         /// <summary>Whether this profile describes a currently living commander</summary>
         public bool alive { get; set; }
+
+        /// <summary>The contexts (i.e. "capabilities") associated with this profile </summary>
+        public ProfileContexts contexts { get; set; }
+    }
+
+    public class ProfileContexts
+    {
+        /// <summary>Whether this profile describes a commander with access to the Cobra Mk IV</summary>
+        public bool allowCobraMkIV { get; set; }
+
+        /// <summary>Whether this profile describes a commander with the Horizons expanion running</summary>
+        public bool inHorizons { get; set; }
     }
 }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1605,7 +1605,7 @@ namespace EddiCore
 
                         // Post an update event for new market data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, null, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1650,7 +1650,7 @@ namespace EddiCore
 
                         // Post an update event for new outfitting data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, null, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1695,7 +1695,7 @@ namespace EddiCore
 
                         // Post an update event for new shipyard data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, info.AllowCobraMkIV, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -2711,6 +2711,14 @@ namespace EddiCore
                         Profile profile = CompanionAppService.Instance?.Profile();
                         if (profile != null)
                         {
+                            // Sanity check
+                            if (profile.Cmdr.EDID != Cmdr.EDID)
+                            {
+                                Logging.Warn("Frontier API incorrectly configured: Returning information for Commander " +
+                                    profile.Cmdr.name + " rather than for " + Cmdr.name + ". Disregarding incorrect information.");
+                                return;
+                            }
+
                             // If we're docked, the lastStation information is located within the lastSystem identified by the profile
                             if (profile.docked && Environment == Constants.ENVIRONMENT_DOCKED)
                             {
@@ -2718,7 +2726,7 @@ namespace EddiCore
                                 Profile stationProfile = CompanionAppService.Instance.Station(CurrentStarSystem.systemname);
 
                                 // Post an update event
-                                Event @event = new MarketInformationUpdatedEvent(profile.timestamp, inHorizons, stationProfile.CurrentStarSystem.systemname, stationProfile.LastStation.name, stationProfile.LastStation.marketId, stationProfile.LastStation.commodities, stationProfile.LastStation.prohibited, stationProfile.LastStation.outfitting, stationProfile.LastStation.shipyard);
+                                Event @event = new MarketInformationUpdatedEvent(profile.timestamp, profile.contexts.inHorizons, profile.contexts.allowCobraMkIV, stationProfile.CurrentStarSystem.systemname, stationProfile.LastStation.name, stationProfile.LastStation.marketId, stationProfile.LastStation.commodities, stationProfile.LastStation.prohibited, stationProfile.LastStation.outfitting, stationProfile.LastStation.shipyard);
                                 enqueueEvent(@event);
 
                                 // See if we need to update our current station

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1605,7 +1605,7 @@ namespace EddiCore
 
                         // Post an update event for new market data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, null, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, theEvent.system, theEvent.station, theEvent.marketId, quotes, null, null, null, inHorizons);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1650,7 +1650,7 @@ namespace EddiCore
 
                         // Post an update event for new outfitting data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, null, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, theEvent.system, theEvent.station, theEvent.marketId, null, null, modules, null, inHorizons);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -1695,7 +1695,7 @@ namespace EddiCore
 
                         // Post an update event for new shipyard data
                         if (theEvent.fromLoad) { return true; } // Don't fire this event when loading pre-existing logs
-                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, inHorizons, info.AllowCobraMkIV, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships);
+                        Event @event = new MarketInformationUpdatedEvent(info.timestamp, theEvent.system, theEvent.station, theEvent.marketId, null, null, null, ships, inHorizons, info.AllowCobraMkIV);
                         enqueueEvent(@event);
                     }
                     return true;
@@ -2726,7 +2726,7 @@ namespace EddiCore
                                 Profile stationProfile = CompanionAppService.Instance.Station(CurrentStarSystem.systemname);
 
                                 // Post an update event
-                                Event @event = new MarketInformationUpdatedEvent(profile.timestamp, profile.contexts.inHorizons, profile.contexts.allowCobraMkIV, stationProfile.CurrentStarSystem.systemname, stationProfile.LastStation.name, stationProfile.LastStation.marketId, stationProfile.LastStation.commodities, stationProfile.LastStation.prohibited, stationProfile.LastStation.outfitting, stationProfile.LastStation.shipyard);
+                                Event @event = new MarketInformationUpdatedEvent(profile.timestamp, stationProfile.CurrentStarSystem.systemname, stationProfile.LastStation.name, stationProfile.LastStation.marketId, stationProfile.LastStation.commodities, stationProfile.LastStation.prohibited, stationProfile.LastStation.outfitting, stationProfile.LastStation.shipyard, profile.contexts.inHorizons, profile.contexts.allowCobraMkIV);
                                 enqueueEvent(@event);
 
                                 // See if we need to update our current station

--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -479,7 +479,8 @@ namespace EDDNResponder
                         { "stationName", theEvent.stationName },
                         { "marketId", theEvent.marketId },
                         { "ships", eddnShips },
-                        { "horizons", theEvent.inHorizons}
+                        { "horizons", theEvent.inHorizons},
+                        { "allowCobraMkIV", theEvent.allowCobraMkIV }
                     };
 
                     SendToEDDN("https://eddn.edcd.io/schemas/shipyard/2", data);

--- a/Events/MarketInformationUpdatedEvent.cs
+++ b/Events/MarketInformationUpdatedEvent.cs
@@ -14,6 +14,8 @@ namespace EddiEvents
 
         public bool inHorizons { get; private set; }
 
+        public bool? allowCobraMkIV { get; private set; }
+
         public string starSystem { get; private set; }
 
         public string stationName { get; private set; }
@@ -30,9 +32,10 @@ namespace EddiEvents
 
         /// <summary>The timestamp recorded for this event must be generated from game or server data.
         /// System time (e.g. DateTime.UtcNow) cannot be trusted for reporting to EDDN and may not be used.</summary>
-        public MarketInformationUpdatedEvent(DateTime timestamp, bool inHorizons, string starSystem, string stationName, long? marketId, List<CommodityMarketQuote> commodities, List<string> prohibitedCommodities, List<Module> outfitting, List<Ship> shipyard) : base(timestamp, NAME)
+        public MarketInformationUpdatedEvent(DateTime timestamp, bool inHorizons, bool? allowCobraMkIV, string starSystem, string stationName, long? marketId, List<CommodityMarketQuote> commodities, List<string> prohibitedCommodities, List<Module> outfitting, List<Ship> shipyard) : base(timestamp, NAME)
         {
             this.inHorizons = inHorizons;
+            this.allowCobraMkIV = allowCobraMkIV;
             this.starSystem = starSystem;
             this.stationName = stationName;
             this.marketId = marketId;

--- a/Events/MarketInformationUpdatedEvent.cs
+++ b/Events/MarketInformationUpdatedEvent.cs
@@ -32,7 +32,7 @@ namespace EddiEvents
 
         /// <summary>The timestamp recorded for this event must be generated from game or server data.
         /// System time (e.g. DateTime.UtcNow) cannot be trusted for reporting to EDDN and may not be used.</summary>
-        public MarketInformationUpdatedEvent(DateTime timestamp, bool inHorizons, bool? allowCobraMkIV, string starSystem, string stationName, long? marketId, List<CommodityMarketQuote> commodities, List<string> prohibitedCommodities, List<Module> outfitting, List<Ship> shipyard) : base(timestamp, NAME)
+        public MarketInformationUpdatedEvent(DateTime timestamp, string starSystem, string stationName, long? marketId, List<CommodityMarketQuote> commodities, List<string> prohibitedCommodities, List<Module> outfitting, List<Ship> shipyard, bool inHorizons, bool? allowCobraMkIV = null) : base(timestamp, NAME)
         {
             this.inHorizons = inHorizons;
             this.allowCobraMkIV = allowCobraMkIV;


### PR DESCRIPTION
Ref. https://github.com/EDCD/EDDN/pull/98
Update the cAPI profile parser to parse the "capabilities" property, e.g.
```cs
  "capabilities": {
   "AllowCobraMkIV": false,
   "Horizons": false
  }
```

Resolves #1881.