### PR TITLE
Fix `Distance()` function returning incorrect results.

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -450,7 +450,7 @@ namespace EddiDataDefinitions
             // Work out the distance to the system where the ship is stored if we can
             if (x != null && y != null && z != null && fromX != null && fromY != null && fromZ != null) 
             { 
-                return Functions.DistanceFromCoordinates((decimal) x, (decimal) y, (decimal) z, (decimal) fromX, (decimal) fromY, (decimal) fromZ); 
+                return Functions.DistanceFromCoordinates((decimal)x, (decimal)y, (decimal)z, (decimal)fromX, (decimal)fromY, (decimal)fromZ); 
             }
             // We don't know how far away the ship is
             return null;

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -448,12 +448,7 @@ namespace EddiDataDefinitions
         public decimal? Distance(decimal? fromX, decimal? fromY, decimal? fromZ)
         {
             // Work out the distance to the system where the ship is stored if we can
-            if (x != null && y != null && z != null && fromX != null && fromY != null && fromZ != null) 
-            { 
-                return Functions.DistanceFromCoordinates((decimal)x, (decimal)y, (decimal)z, (decimal)fromX, (decimal)fromY, (decimal)fromZ); 
-            }
-            // We don't know how far away the ship is
-            return null;
+            return Functions.DistanceFromCoordinates(x, y, z, fromX, fromY, fromZ);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfectly correct    

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -448,15 +448,12 @@ namespace EddiDataDefinitions
         public decimal? Distance(decimal? fromX, decimal? fromY, decimal? fromZ)
         {
             // Work out the distance to the system where the ship is stored if we can
-            if (x is null || y is null || z is null || fromX is null || fromY is null || fromZ is null)
-            {
-                // We don't know how far away the ship is
-                return null;
+            if (x != null && y != null && z != null && fromX != null && fromY != null && fromZ != null) 
+            { 
+                return Functions.DistanceFromCoordinates((decimal) x, (decimal) y, (decimal) z, (decimal) fromX, (decimal) fromY, (decimal) fromZ); 
             }
-            decimal dx = (fromX - x) ?? 0M;
-            decimal dy = (fromY - y) ?? 0M;
-            decimal dz = (fromZ - z) ?? 0M;
-            return (decimal)(Math.Sqrt((double)((dx * dx) + (dy * dy) + (dz * dz))));
+            // We don't know how far away the ship is
+            return null;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")] // this usage is perfectly correct    

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using Utilities;
 
 namespace EddiDataDefinitions
 {
@@ -366,6 +367,15 @@ namespace EddiDataDefinitions
             }
 
             return value;
+        }
+
+        public decimal? DistanceFromStarSystem(StarSystem other)
+        {
+            if (x != null && y != null && z != null && other?.x != null && other.y != null && other.z != null)
+            {
+                return Functions.DistanceFromCoordinates((decimal)x, (decimal)y, (decimal)z, (decimal)other.x, (decimal)other.y, (decimal)other.z);
+            }
+            return null;
         }
     }
 }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -371,13 +371,7 @@ namespace EddiDataDefinitions
 
         public decimal? DistanceFromStarSystem(StarSystem other)
         {
-            // Work out the distance to the other star system if we can 
-            if (x != null && y != null && z != null && other?.x != null && other.y != null && other.z != null)
-            {
-                return Functions.DistanceFromCoordinates((decimal)x, (decimal)y, (decimal)z, (decimal)other.x, (decimal)other.y, (decimal)other.z);
-            }
-            // We don't know how far way the other star system is
-            return null;
+            return Functions.DistanceFromCoordinates(x, y, z, other.x, other.y, other.z);
         }
     }
 }

--- a/DataDefinitions/StarSystem.cs
+++ b/DataDefinitions/StarSystem.cs
@@ -371,10 +371,12 @@ namespace EddiDataDefinitions
 
         public decimal? DistanceFromStarSystem(StarSystem other)
         {
+            // Work out the distance to the other star system if we can 
             if (x != null && y != null && z != null && other?.x != null && other.y != null && other.z != null)
             {
                 return Functions.DistanceFromCoordinates((decimal)x, (decimal)y, (decimal)z, (decimal)other.x, (decimal)other.y, (decimal)other.z);
             }
+            // We don't know how far way the other star system is
             return null;
         }
     }

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -2497,15 +2497,7 @@ namespace EddiCore
 
         public decimal getSystemDistance(StarSystem curr, StarSystem dest)
         {
-            double square(double x) => x * x;
-            decimal distance = 0;
-            if (curr?.x != null && dest?.x != null)
-            {
-                distance = (decimal)Math.Round(Math.Sqrt(square((double)(curr.x - dest.x))
-                            + square((double)(curr.y - dest.y))
-                            + square((double)(curr.z - dest.z))), 2);
-            }
-            return distance;
+            return curr?.DistanceFromStarSystem(dest) ?? 0;
         }
 
         /// <summary>Work out the title for the commander in the current system</summary>

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -1185,9 +1185,9 @@ namespace EddiSpeechResponder
                     var distance = curr.DistanceFromStarSystem(dest);
                     if (distance is null)
                     {
-                        Logging.Warn($"Unable to calculate distance between {curr.systemname} and {dest.systemname}. Could not obtain system coordinates.");
+                        return $"Unable to calculate distance between {curr.systemname} and {dest.systemname}. Could not obtain system coordinates.";
                     }
-                    result = distance ?? 0;
+                    result = (decimal)distance;
                 }
                 else if (values.Count == 6 && numVal)
                 {
@@ -1198,6 +1198,10 @@ namespace EddiSpeechResponder
                     var y2 = values[4].AsNumber;
                     var z2 = values[5].AsNumber;
                     result = Functions.DistanceFromCoordinates(x1, y1, z1, x2, y2, z2);
+                }
+                else
+                {
+                    return "The Distance function is used improperly. Please review the documentation for correct usage.";
                 }
                 return new ReflectionValue(result);
             }, 1, 6);

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -1166,7 +1166,6 @@ namespace EddiSpeechResponder
             {
                 bool numVal = values[0].Type == Cottle.ValueContent.Number;
                 bool stringVal = values[0].Type == Cottle.ValueContent.String;
-                decimal result = 0;
 
                 StarSystem curr = null;
                 StarSystem dest = null;
@@ -1182,12 +1181,12 @@ namespace EddiSpeechResponder
                 }
                 if (curr != null && dest != null)
                 {
-                    var distance = curr.DistanceFromStarSystem(dest);
-                    if (distance is null)
+                    var result = curr.DistanceFromStarSystem(dest);
+                    if (result is null)
                     {
                         return $"Unable to calculate distance between {curr.systemname} and {dest.systemname}. Could not obtain system coordinates.";
                     }
-                    result = (decimal)distance;
+                    return new ReflectionValue(result);
                 }
                 else if (values.Count == 6 && numVal)
                 {
@@ -1197,13 +1196,13 @@ namespace EddiSpeechResponder
                     var x2 = values[3].AsNumber;
                     var y2 = values[4].AsNumber;
                     var z2 = values[5].AsNumber;
-                    result = Functions.DistanceFromCoordinates(x1, y1, z1, x2, y2, z2);
+                    var result = Functions.DistanceFromCoordinates(x1, y1, z1, x2, y2, z2);
+                    return new ReflectionValue(result);
                 }
                 else
                 {
                     return "The Distance function is used improperly. Please review the documentation for correct usage.";
                 }
-                return new ReflectionValue(result);
             }, 1, 6);
 
             store["Log"] = new NativeFunction((values) =>

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -1186,9 +1186,13 @@ namespace EddiSpeechResponder
 
                 if (curr?.x != null && dest?.x != null)
                 {
-                    result = (decimal)Math.Round(Math.Sqrt(square((double)(curr.x - dest.x))
-                                + square((double)(curr.y ?? 0 - dest.y ?? 0))
-                                + square((double)(curr.z ?? 0 - dest.z ?? 0))), 2);
+                    result = (decimal)Math.Round(
+                        Math.Sqrt(
+                                square((double)(curr.x - dest.x)) +
+                                square((double)((curr.y ?? 0) - (dest.y ?? 0))) +
+                                square((double)((curr.z ?? 0) - (dest.z ?? 0)))
+                                ), 
+                        2);
                 }
 
                 return new ReflectionValue(result);

--- a/SpeechResponder/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolver.cs
@@ -1186,13 +1186,11 @@ namespace EddiSpeechResponder
 
                 if (curr?.x != null && dest?.x != null)
                 {
-                    result = (decimal)Math.Round(
-                        Math.Sqrt(
-                                square((double)(curr.x - dest.x)) +
-                                square((double)((curr.y ?? 0) - (dest.y ?? 0))) +
-                                square((double)((curr.z ?? 0) - (dest.z ?? 0)))
-                                ), 
-                        2);
+                    var diffX = (double)(curr.x - dest.x);
+                    var diffY = (double)((curr.y ?? 0) - (dest.y ?? 0));
+                    var diffZ = (double)((curr.z ?? 0) - (dest.z ?? 0));
+                    var distance = Math.Sqrt(square(diffX) + square(diffY) + square(diffZ));
+                    result = (decimal)Math.Round(distance, 2);
                 }
 
                 return new ReflectionValue(result);

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -161,29 +161,6 @@ namespace UnitTests
         }
 
         [TestMethod]
-        public void TestResolverDistance()
-        {
-            // Colonia
-            decimal? x1 = -9530.5M;
-            decimal? y1 = -910.28125M;
-            decimal? z1 = 19808.125M;
-
-            // Hephaestus
-            decimal? x2 = -9521.40625M;
-            decimal? y2 = -907.3125M;
-            decimal? z2 = 19801.65625M;
-
-            Dictionary<string, Script> scripts = new Dictionary<string, Script>
-            {
-                {"test", new Script("test", null, false, "{Distance(" + $"{x1}, {y1}, {z1}, {x2}, {y2}, {z2}" + ")}")}
-            };
-            ScriptResolver resolver = new ScriptResolver(scripts);
-            Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>();
-            string result = resolver.resolveFromName("test", dict, true);
-            Assert.AreEqual("11.55", result);
-        }
-
-        [TestMethod]
         public void TestUpgradeScript_FromDefault()
         {
             Script script = new Script("testScript", "Test script", false, "Test script", 3, "Test script");

--- a/Tests/ScriptResolverTest.cs
+++ b/Tests/ScriptResolverTest.cs
@@ -161,6 +161,29 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestResolverDistance()
+        {
+            // Colonia
+            decimal? x1 = -9530.5M;
+            decimal? y1 = -910.28125M;
+            decimal? z1 = 19808.125M;
+
+            // Hephaestus
+            decimal? x2 = -9521.40625M;
+            decimal? y2 = -907.3125M;
+            decimal? z2 = 19801.65625M;
+
+            Dictionary<string, Script> scripts = new Dictionary<string, Script>
+            {
+                {"test", new Script("test", null, false, "{Distance(" + $"{x1}, {y1}, {z1}, {x2}, {y2}, {z2}" + ")}")}
+            };
+            ScriptResolver resolver = new ScriptResolver(scripts);
+            Dictionary<string, Cottle.Value> dict = new Dictionary<string, Cottle.Value>();
+            string result = resolver.resolveFromName("test", dict, true);
+            Assert.AreEqual("11.55", result);
+        }
+
+        [TestMethod]
         public void TestUpgradeScript_FromDefault()
         {
             Script script = new Script("testScript", "Test script", false, "Test script", 3, "Test script");

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -142,6 +142,7 @@
   <ItemGroup>
     <Compile Include="CapiShipyardTests.cs" />
     <Compile Include="BgsDataTests.cs" />
+    <Compile Include="UtilityTests.cs" />
     <Compile Include="InaraTests.cs" />
     <Compile Include="CrimeMonitorTests.cs" />
     <Compile Include="NavigationServiceTests.cs" />

--- a/Tests/UtilityTests.cs
+++ b/Tests/UtilityTests.cs
@@ -1,0 +1,53 @@
+﻿using EddiDataDefinitions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utilities;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class UtilityTests : TestBase
+    {
+        [TestInitialize]
+        public void start()
+        {
+            MakeSafe();
+        }
+
+        [TestMethod]
+        public void TestDistanceFunctionFromCoordinates()
+        {
+            // Colonia
+            const decimal x1 = -9530.5M;
+            const decimal y1 = -910.28125M;
+            const decimal z1 = 19808.125M;
+
+            // Hephaestus
+            const decimal x2 = -9521.40625M;
+            const decimal y2 = -907.3125M;
+            const decimal z2 = 19801.65625M;
+
+            var result = Functions.DistanceFromCoordinates(x1, y1, z1, x2, y2, z2);
+            Assert.AreEqual(11.55M, result);
+        }
+
+        [TestMethod]
+        public void TestDistanceFunctionFromStarSystems()
+        {
+            var curr = new StarSystem() { systemname = "Sol", x = 0, y = 0, z = 0 };
+            var dest = new StarSystem() { systemname = "Alpha Centauri", x = 3.03125M, y = -0.09375M, z = 3.15625M };
+
+            var result = dest.DistanceFromStarSystem(curr);
+            Assert.AreEqual(4.38M, result);
+        }
+
+        [TestMethod]
+        public void TestDistanceFunctionFromUnknownStarSystems()
+        {
+            var curr = new StarSystem() { systemname = "Hephaestus", x = -9521.40625M, y = -907.3125M, z = 19801.65625M };
+            var dest = new StarSystem() { systemname = "UnknownStar", x = null, y = null, z = null };
+
+            var result = dest.DistanceFromStarSystem(curr);
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/Tests/UtilityTests.cs
+++ b/Tests/UtilityTests.cs
@@ -31,6 +31,18 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestDistanceFunctionFromNullCoordinates()
+        {
+            // Colonia
+            const decimal x1 = -9530.5M;
+            const decimal y1 = -910.28125M;
+            const decimal z1 = 19808.125M;
+
+            var result = Functions.DistanceFromCoordinates(x1, y1, z1, null, null, null);
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
         public void TestDistanceFunctionFromStarSystems()
         {
             var curr = new StarSystem() { systemname = "Sol", x = 0, y = 0, z = 0 };

--- a/Utilities/Functions.cs
+++ b/Utilities/Functions.cs
@@ -5,14 +5,22 @@ namespace Utilities
     // A collection of common functions used in code
     public class Functions
     {
-        public static decimal DistanceFromCoordinates(decimal x1, decimal y1, decimal z1, decimal x2, decimal y2, decimal z2)
+        public static decimal? DistanceFromCoordinates(decimal? x1, decimal? y1, decimal? z1, decimal? x2, decimal? y2, decimal? z2)
         {
-            double square(double x) => x * x;
-            var diffX = (double)(x1 - x2);
-            var diffY = (double)(y1 - y2);
-            var diffZ = (double)(z1 - z2);
-            var distance = Math.Sqrt(square(diffX) + square(diffY) + square(diffZ));
-            return (decimal)Math.Round(distance, 2);
+            var diffX = x1 - x2;
+            var diffY = y1 - y2;
+            var diffZ = z1 - z2;
+
+            if (diffX != null && diffY != null && diffZ != null)
+            {
+                double square(double x) => x * x;
+                var distance = Math.Sqrt(square((double)diffX) + square((double)diffY) + square((double)diffZ));
+                return (decimal)Math.Round(distance, 2);
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/Utilities/Functions.cs
+++ b/Utilities/Functions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Utilities
+{
+    // A collection of common functions used in code
+    public class Functions
+    {
+        public static decimal DistanceFromCoordinates(decimal x1, decimal y1, decimal z1, decimal x2, decimal y2, decimal z2)
+        {
+            double square(double x) => x * x;
+            var diffX = (double)(x1 - x2);
+            var diffY = (double)(y1 - y2);
+            var diffZ = (double)(z1 - z2);
+            var distance = Math.Sqrt(square(diffX) + square(diffY) + square(diffZ));
+            return (decimal)Math.Round(distance, 2);
+        }
+    }
+}

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -90,6 +90,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Functions.cs" />
     <Compile Include="LockManager.cs" />
     <Compile Include="Processes.cs" />
     <Compile Include="ExtensionMethods.cs" />


### PR DESCRIPTION
Fixes #1884.

```cs
(curr.y ?? 0 - dest.y ?? 0)
```
is being interpreted like
```cs
(curr.y ?? (0 - dest.y) ?? 0)
```
when
```cs
((curr.y ?? 0) - (dest.y ?? 0))
```
was intended.