### PR TITLE
Fix startup exception from corrupt elite.json

### DIFF
--- a/EDDI/EliteConfiguration.cs
+++ b/EDDI/EliteConfiguration.cs
@@ -50,8 +50,12 @@ namespace EddiCore
                     }
                 }
             }
-            configuration.dataPath = filename;
+            if (configuration == null)
+            {
+                configuration = new EliteConfiguration();
+            }
 
+            configuration.dataPath = filename;
             return configuration;
         }
 


### PR DESCRIPTION
Replace the EliteConfiguration with a fresh copy if the old copy is corrupt / fails to deserialize correctly.
Resolves #1897.

Additional observation: elite.json isn't really necessary except that the current method for initializing the CompanionAppService relies on passing a stale property from elite.json (from the last time EDDI ran). 