### PR TITLE
Fix exceptions related to starting in an SRV

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -33,11 +33,11 @@ namespace EddiDataDefinitions
 
         /// <summary>the size of this ship</summary>
         [JsonIgnore]
-        public LandingPadSize Size { get; set; }
+        public LandingPadSize Size { get; set; } = LandingPadSize.Small;
 
         /// <summary>the spoken size of this ship</summary>
         [JsonIgnore]
-        public string size => Size.localizedName;
+        public string size => (Size ?? LandingPadSize.Small).localizedName;
 
         /// <summary>the size of the military compartment slots</summary>
         [JsonIgnore]

--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -1977,7 +1977,7 @@ namespace EddiCore
         private bool eventCommanderContinued(CommanderContinuedEvent theEvent)
         {
             // Set Vehicle state for commander from ship model
-            if (theEvent.ship == "SRV")
+            if (theEvent.shipEDModel == "TestBuggy" || theEvent.shipEDModel == "SRV")
             {
                 Vehicle = Constants.VEHICLE_SRV;
             }

--- a/Events/CommanderContinuedEvent.cs
+++ b/Events/CommanderContinuedEvent.cs
@@ -35,7 +35,7 @@ namespace EddiEvents
         public bool horizons { get; private set; }
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => shipEDModel == "TestBuggy" ? "SRV" : ShipDefinitions.FromEDModel(shipEDModel).model;
 
         [JsonProperty("shipid")]
         public int? shipid { get; private set; }
@@ -72,14 +72,15 @@ namespace EddiEvents
 
         // Not intended to be user facing
         public string frontierID { get; private set; }
+        public string shipEDModel { get; private set; }
 
-        public CommanderContinuedEvent(DateTime timestamp, string commander, string frontierID, bool horizons, int shipId, string ship, string shipName, string shipIdent, bool? startedLanded, bool? startDead, GameMode mode, string group, long credits, long loan, decimal? fuel, decimal? fuelcapacity) : base(timestamp, NAME)
+        public CommanderContinuedEvent(DateTime timestamp, string commander, string frontierID, bool horizons, int shipId, string shipEdModel, string shipName, string shipIdent, bool? startedLanded, bool? startDead, GameMode mode, string group, long credits, long loan, decimal? fuel, decimal? fuelcapacity) : base(timestamp, NAME)
         {
             this.commander = commander;
             this.frontierID = frontierID;
             this.horizons = horizons;
             this.shipid = shipId;
-            this.ship = ship == "TestBuggy" ? "SRV" : ShipDefinitions.FromEDModel(ship).model;
+            this.shipEDModel = shipEdModel;
             this.shipname = shipName;
             this.shipident = shipIdent;
             this.startlanded = startedLanded;

--- a/ShipMonitor/ShipDeliveredEvent.cs
+++ b/ShipMonitor/ShipDeliveredEvent.cs
@@ -26,11 +26,12 @@ namespace EddiShipMonitor
         public string ship => shipDefinition?.model;
 
         // Not intended to be user facing
-        public Ship shipDefinition { get; private set; }
+        public Ship shipDefinition => ShipDefinitions.FromEDModel(edModel);
+        public string edModel { get; private set; }
 
         public ShipDeliveredEvent(DateTime timestamp, string ship, int? shipId) : base(timestamp, NAME)
         {
-            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
+            this.edModel = ship;
             this.shipid = shipId;
         }
     }

--- a/ShipMonitor/ShipLoadoutEvent.cs
+++ b/ShipMonitor/ShipLoadoutEvent.cs
@@ -50,11 +50,12 @@ namespace EddiShipMonitor
         public List<Compartment> compartments { get; private set; }
 
         // Not intended to be user facing
-        public Ship shipDefinition;
+        public Ship shipDefinition => ShipDefinitions.FromEDModel(edModel);
+        public string edModel { get; private set; }
 
         public ShipLoadoutEvent(DateTime timestamp, string ship, int? shipId, string shipName, string shipIdent, long? hullValue, long? modulesValue, decimal hullHealth, decimal unladenmass, decimal maxjumprange, decimal optimalmass, long rebuy, bool hot, List<Compartment> compartments, List<Hardpoint> hardpoints, string paintjob) : base(timestamp, NAME)
         {
-            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
+            this.edModel = ship;
             this.shipid = shipId;
             this.shipname = shipName;
             this.shipident = shipIdent;

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1804,7 +1804,7 @@ namespace EddiShipMonitor
         /// <summary> See if we're in a buggy / SRV </summary>
         private bool inBuggy(string model)
         {
-            return model.Contains("Buggy");
+            return model.Contains("Buggy") || model.Contains("SRV");
         }
 
         private Task _refreshProfileDelayed;

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -475,7 +475,7 @@ namespace EddiShipMonitor
                     Ship ship = ParseShipLoadoutEvent(@event);
 
                     // Update the local and global variables
-                    SetCurrentShip(ship.LocalId, ship.model);
+                    SetCurrentShip(ship.LocalId, ship.EDName);
                     EDDI.Instance.CurrentShip = ship;
 
                     AddShip(ship);
@@ -1237,7 +1237,7 @@ namespace EddiShipMonitor
                 List<StoredModule> newModuleList = configuration.storedmodules.OrderBy(s => s.slot).ToList();
 
                 // There was a bug (ref. #1894) that added the SRV as a ship. Clean that up here.
-                newShiplist = newShiplist.Where(s => s.model != "SRV").ToList();
+                newShiplist = newShiplist.Where(s => s.EDName != "SRV").ToList();
 
                 // Update the shipyard
                 shipyard = new ObservableCollection<Ship>(newShiplist);
@@ -1361,7 +1361,7 @@ namespace EddiShipMonitor
             return ship;
         }
 
-        public void SetCurrentShip(int? localId, string model = null)
+        public void SetCurrentShip(int? localId, string EDName = null)
         {
             lock (shipyardLock)
             {
@@ -1371,10 +1371,10 @@ namespace EddiShipMonitor
                 {
                     // We don't know about this ship yet
                     Logging.Debug("Unknown ship ID " + localId);
-                    if (localId.HasValue && model != null)
+                    if (localId.HasValue && EDName != null)
                     {
                         // We can make one though
-                        ship = ShipDefinitions.FromEDModel(model);
+                        ship = ShipDefinitions.FromEDModel(EDName);
                         ship.LocalId = (int)localId;
                         ship.Role = Role.MultiPurpose;
                         AddShip(ship);

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -468,12 +468,14 @@ namespace EddiShipMonitor
         {
             if (@event.timestamp > updatedAt)
             {
+                // If we're in the SRV when we start the game, we'll still get a Loadout event for our parent ship
                 updatedAt = @event.timestamp;
-                if (!inFighter(@event.ship) && !inBuggy(@event.ship))
+                if (!inFighter(@event.ship))
                 {
                     Ship ship = ParseShipLoadoutEvent(@event);
 
-                    // Update the global variable
+                    // Update the local and global variables
+                    SetCurrentShip(ship.LocalId, ship.model);
                     EDDI.Instance.CurrentShip = ship;
 
                     AddShip(ship);

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -1236,6 +1236,9 @@ namespace EddiShipMonitor
                 List<Ship> newShiplist = configuration.shipyard.OrderBy(s => s.model).ToList();
                 List<StoredModule> newModuleList = configuration.storedmodules.OrderBy(s => s.slot).ToList();
 
+                // There was a bug (ref. #1894) that added the SRV as a ship. Clean that up here.
+                newShiplist = newShiplist.Where(s => s.model != "SRV").ToList();
+
                 // Update the shipyard
                 shipyard = new ObservableCollection<Ship>(newShiplist);
                 currentShipId = configuration.currentshipid;

--- a/ShipMonitor/ShipMonitor.cs
+++ b/ShipMonitor/ShipMonitor.cs
@@ -290,14 +290,14 @@ namespace EddiShipMonitor
             if (@event.timestamp > updatedAt)
             {
                 updatedAt = @event.timestamp;
-                if (!inFighter(@event.ship) && !inBuggy(@event.ship))
+                if (!inFighter(@event.shipEDModel) && !inBuggy(@event.shipEDModel))
                 {
-                    SetCurrentShip(@event.shipid, @event.ship);
+                    SetCurrentShip(@event.shipid, @event.shipEDModel);
                     Ship ship = GetCurrentShip();
                     if (ship == null)
                     {
                         // We don't know of this ship so need to create it
-                        ship = ShipDefinitions.FromEDModel(@event.ship);
+                        ship = ShipDefinitions.FromEDModel(@event.shipEDModel);
                         ship.LocalId = (int)@event.shipid;
                         ship.Role = Role.MultiPurpose;
                         AddShip(ship);
@@ -379,7 +379,7 @@ namespace EddiShipMonitor
             {
                 updatedAt = @event.timestamp;
                 // Set this as our current ship
-                SetCurrentShip(@event.shipid, @event.ship);
+                SetCurrentShip(@event.shipid, @event.edModel);
                 if (!@event.fromLoad) { writeShips(); }
             }
         }
@@ -397,7 +397,7 @@ namespace EddiShipMonitor
                 EDDI.Instance?.refreshProfile();
 
                 // Update our current ship
-                SetCurrentShip(@event.shipid, @event.ship);
+                SetCurrentShip(@event.shipid, @event.edModel);
 
                 if (@event.storedshipid != null)
                 {
@@ -470,7 +470,7 @@ namespace EddiShipMonitor
             {
                 // If we're in the SRV when we start the game, we'll still get a Loadout event for our parent ship
                 updatedAt = @event.timestamp;
-                if (!inFighter(@event.ship))
+                if (!inFighter(@event.edModel))
                 {
                     Ship ship = ParseShipLoadoutEvent(@event);
 
@@ -503,7 +503,7 @@ namespace EddiShipMonitor
             ship.raw = @event.raw;
 
             // Update model (in case it was solely from the edname), name, ident & paintjob if required
-            ship.model = @event.ship;
+            ship.model = @event.edModel;
             setShipName(ship, @event.shipname);
             setShipIdent(ship, @event.shipident);
             ship.paintjob = @event.paintjob;
@@ -1805,9 +1805,9 @@ namespace EddiShipMonitor
         }
 
         /// <summary> See if we're in a buggy / SRV </summary>
-        private bool inBuggy(string model)
+        private bool inBuggy(string edModel)
         {
-            return model.Contains("Buggy") || model.Contains("SRV");
+            return edModel.Contains("Buggy") || edModel.Contains("SRV");
         }
 
         private Task _refreshProfileDelayed;

--- a/ShipMonitor/ShipSwappedEvent.cs
+++ b/ShipMonitor/ShipSwappedEvent.cs
@@ -42,17 +42,19 @@ namespace EddiShipMonitor
         public string storedship => storedShipDefinition?.model;
 
         // Not intended to be user facing
-        public Ship shipDefinition { get; private set; }
-        public Ship storedShipDefinition { get; private set; }
-        public Ship soldShipDefinition { get; private set; }
-
+        public Ship shipDefinition => ShipDefinitions.FromEDModel(edModel);
+        public Ship storedShipDefinition => string.IsNullOrEmpty(storedEdModel) ? null : ShipDefinitions.FromEDModel(storedEdModel);
+        public Ship soldShipDefinition => string.IsNullOrEmpty(soldEdModel) ? null : ShipDefinitions.FromEDModel(soldEdModel);
+        public string edModel { get; private set; }
+        public string storedEdModel { get; private set; }
+        public string soldEdModel { get; private set; }
         public long marketId { get; private set; }
 
         public ShipSwappedEvent(DateTime timestamp, string ship, int shipId, string soldship, int? soldshipid, string storedship, int? storedshipid, long marketId) : base(timestamp, NAME)
         {
-            this.shipDefinition = ShipDefinitions.FromEDModel(ship);
-            this.storedShipDefinition = ShipDefinitions.FromEDModel(storedship);
-            this.soldShipDefinition = ShipDefinitions.FromEDModel(soldship);
+            this.edModel = ship;
+            this.storedEdModel = storedship;
+            this.soldEdModel = soldship;
             this.shipid = shipId;
             this.soldshipid = soldshipid;
             this.storedshipid = storedshipid;

--- a/Tests/ShipTests.cs
+++ b/Tests/ShipTests.cs
@@ -598,10 +598,17 @@ namespace UnitTests
             Assert.IsNotNull(@event);
             Assert.IsInstanceOfType(@event, typeof(CommanderContinuedEvent));
 
-            // Handle the event
-            shipMonitor.PreHandle(@event);
-
             // Test the result to verify that the ship monitor's `currentShipId` property remains "9999" rather than changing to "9998"
+            shipMonitor.PreHandle(@event);
+            Assert.AreEqual("SRV", @event.ship);
+            Assert.AreEqual(9999, (int?)privateObject.GetFieldOrProperty("currentShipId"), @"Because the ""ship"" reported by the event is an SRV, the `currentShipId` property of the ship monitor should be unchanged");
+
+            // Re-test the event, except exchange "SRV" for "TestBuggy" in the `ship` property
+            // Verify once again that the ship monitor's `currentShipId` property remains "9999" rather than changing to "9998"
+            var privateEvent = new PrivateObject(@event);
+            privateEvent.SetFieldOrProperty("ship", "TestBuggy");
+            shipMonitor.PreHandle(@event);
+            Assert.AreEqual("TestBuggy", @event.ship);
             Assert.AreEqual(9999, (int?)privateObject.GetFieldOrProperty("currentShipId"), @"Because the ""ship"" reported by the event is an SRV, the `currentShipId` property of the ship monitor should be unchanged");
         }
     }


### PR DESCRIPTION
Fixes #1894, fixes #1899, and fixes #1907. 

1. The ship model is being passed from the `Commander continued` event as "SRV" rather than as "TestBuggy" (the FDev internal name for the SRV).
2. Starting the game in an SRV isn't supposed to create a new entry in the ship monitor and change your currently active ship, but because the ship model is set to "SRV" (rather than "TestBuggy", which is what the Ship monitor currently expects), our internal filter on creating a new ship and setting it as the active ship fails in this circumstance.
3. That leaves us with an unintended SRV "ship" with various null / undefined values. 
4. In particular, this creates a null reference exception when trying to access the "Size" property of the SRV "ship" (since the size is determined by the ship model and there is no ship model matching "SRV")