### PR TITLE
Resolves "Failed to speak; missing media pack?" exceptions recorded on Rollbar

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -276,7 +276,7 @@ namespace EddiSpeechService
                     }
                     catch (System.Runtime.InteropServices.COMException ce)
                     {
-                        Logging.Error("Failed to speak; missing media pack?", ce);
+                        Logging.Warn($"Failed to speak; {ce.Source} not registered. Installation may be corrupt or Windows version may be incompatible.", ce);
                         return;
                     }
                     soundOut.Stopped += (s, e) => waitHandle.Set();


### PR DESCRIPTION
Resolves exceptions like https://rollbar.com/EDCD/EDDI/items/18697/ being reported repeatedly to Rollbar.