### PR TITLE
Fix unexpected military slot exceptions during EngineerCraft event

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -2254,7 +2254,7 @@ namespace EddiJournalMonitor
                                     decimal? quality = JsonParsing.getOptionalDecimal(data, "Quality"); //
                                     string experimentalEffect = JsonParsing.getString(data, "ApplyExperimentalEffect"); //
 
-                                    string ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip().model;
+                                    string ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip().EDName;
                                     Compartment compartment = parseShipCompartment(ship, JsonParsing.getString(data, "Slot")); //
                                     compartment.module = Module.FromEDName(JsonParsing.getString(data, "Module"));
                                     List<CommodityAmount> commodities = new List<CommodityAmount>();


### PR DESCRIPTION
Fixes exceptions like https://rollbar.com/EDCD/EDDI/items/18941/.
The `parseShipCompartment method expects the edName of the ship. By passing the model, we were passing the invariantName of the ship rather than the edName.