### PR TITLE
Resolve possible EDDN validation exception from DateTime.ToString() method

### DIFF
--- a/EDDNResponder/EDDNResponder.cs
+++ b/EDDNResponder/EDDNResponder.cs
@@ -374,7 +374,7 @@ namespace EDDNResponder
                 {
                     IDictionary<string, object> data = new Dictionary<string, object>
                     {
-                        { "timestamp", theEvent.timestamp.ToString("yyyy-MM-ddTHH:mm:ssZ") },
+                        { "timestamp", Dates.FromDateTimeToString(theEvent.timestamp) },
                         { "systemName", theEvent.starSystem },
                         { "stationName", theEvent.stationName },
                         { "marketId", theEvent.marketId },
@@ -442,7 +442,7 @@ namespace EDDNResponder
                 {
                     IDictionary<string, object> data = new Dictionary<string, object>
                     {
-                        { "timestamp", theEvent.timestamp.ToString("yyyy-MM-ddTHH:mm:ssZ") },
+                        { "timestamp", Dates.FromDateTimeToString(theEvent.timestamp) },
                         { "systemName", theEvent.starSystem },
                         { "stationName", theEvent.stationName },
                         { "marketId", theEvent.marketId },
@@ -474,7 +474,7 @@ namespace EDDNResponder
                 {
                     IDictionary<string, object> data = new Dictionary<string, object>
                     {
-                        { "timestamp", theEvent.timestamp.ToString("yyyy-MM-ddTHH:mm:ssZ") },
+                        { "timestamp", Dates.FromDateTimeToString(theEvent.timestamp) },
                         { "systemName", theEvent.starSystem },
                         { "stationName", theEvent.stationName },
                         { "marketId", theEvent.marketId },

--- a/EddiInaraService/InaraAPIEvent.cs
+++ b/EddiInaraService/InaraAPIEvent.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Utilities;
 
 namespace EddiInaraService
 {
@@ -8,7 +9,7 @@ namespace EddiInaraService
     {
         public string eventName { get; private set; }
 
-        public string eventTimestamp => eventTimeStamp.ToString("s") + "Z";
+        public string eventTimestamp => Dates.FromDateTimeToString(eventTimeStamp);
 
         public object eventData { get; private set; }
 

--- a/InaraResponder/InaraResponder.cs
+++ b/InaraResponder/InaraResponder.cs
@@ -341,7 +341,7 @@ namespace EddiInaraResponder
                     { "communitygoalName", @event.name[i] },
                     { "starsystemName", @event.system[i] },
                     { "stationName", @event.station[i] },
-                    { "goalExpiry", @event.expiryDateTime[i].ToString("yyyy-MM-ddTHH:mm:ssZ") },
+                    { "goalExpiry", Dates.FromDateTimeToString(@event.expiryDateTime[i])},
                     { "tierReached", int.Parse(@event.tier[i].Replace("Tier ", "")) },
                     { "isCompleted", @event.iscomplete[i] },
                     { "contributorsNum", @event.contributors[i] },

--- a/StarMapService/StarMapService.cs
+++ b/StarMapService/StarMapService.cs
@@ -312,7 +312,7 @@ namespace EddiStarMapService
             {
                 if (since.HasValue)
                 {
-                    request.AddParameter("startdatetime", since.Value.ToString("yyyy-MM-dd HH:mm:ss"));
+                    request.AddParameter("startdatetime", Dates.FromDateTimeToString(since.Value));
                 }
                 else
                 {

--- a/Tests/BgsDataTests.cs
+++ b/Tests/BgsDataTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using Tests.Properties;
+using Utilities;
 
 namespace UnitTests
 {
@@ -62,8 +63,6 @@ namespace UnitTests
         [TestMethod]
         public void TestFaction()
         {
-            string dateTimeStringFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.fff'Z'";
-
             // Test faction data
             JObject response = DeserializeJsonResource<JObject>(Resources.bgsFaction);
             Faction faction = fakeBgsService.ParseFaction(response);
@@ -75,7 +74,7 @@ namespace UnitTests
             Assert.AreEqual("Independent", faction.Allegiance.invariantName);
             Assert.AreEqual("Democracy", faction.Government.invariantName);
             Assert.IsNull(faction.isplayer);
-            Assert.AreEqual("2019-04-13T03:37:17.000Z", faction.updatedAt.ToString(dateTimeStringFormat));
+            Assert.AreEqual("2019-04-13T03:37:17Z", Dates.FromDateTimeToString(faction.updatedAt));
 
             // Test The Dark Wheel faction presence data
             string systemName = "Shinrarta Dezhra";
@@ -88,7 +87,7 @@ namespace UnitTests
             Assert.AreEqual("Boom", factionPresence.ActiveStates[0].invariantName);
             Assert.AreEqual(0, factionPresence.PendingStates.Count());
             Assert.AreEqual(0, factionPresence.RecoveringStates.Count());
-            Assert.AreEqual("2019-04-13T03:37:17.000Z", factionPresence.updatedAt.ToString(dateTimeStringFormat));
+            Assert.AreEqual("2019-04-13T03:37:17Z", Dates.FromDateTimeToString(faction.updatedAt));
 
             systemName = "LFT 926";
             factionPresence = faction.presences.FirstOrDefault(p => p.systemName == systemName);
@@ -101,7 +100,7 @@ namespace UnitTests
             Assert.AreEqual(1, factionPresence.RecoveringStates.Count());
             Assert.AreEqual("War", factionPresence.RecoveringStates[0].factionState.invariantName);
             Assert.AreEqual(0, factionPresence.RecoveringStates[0].trend);
-            Assert.AreEqual("2019-04-13T03:27:28.000Z", factionPresence.updatedAt.ToString(dateTimeStringFormat));
+            Assert.AreEqual("2019-04-13T03:27:28Z", Dates.FromDateTimeToString(faction.updatedAt));
         }
 
         [TestMethod]

--- a/Tests/DataProviderTests.cs
+++ b/Tests/DataProviderTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Tests.Properties;
+using Utilities;
 
 namespace UnitTests
 {
@@ -204,7 +205,7 @@ namespace UnitTests
             Assert.AreEqual(20, result.totalbodies);
             Assert.AreEqual(8557, result.bodies?.FirstOrDefault(b => b?.bodyId == 0)?.EDSMID);
             Assert.AreEqual(17, result.visits);
-            Assert.AreEqual("2017-12-11T06:17:06", result.lastvisit?.ToString("s"));
+            Assert.AreEqual("2017-12-11T06:17:06Z", Dates.FromDateTimeToString(result.lastvisit));
         }
     }
 }

--- a/Tests/UtilityTests.cs
+++ b/Tests/UtilityTests.cs
@@ -1,4 +1,6 @@
-﻿using EddiDataDefinitions;
+﻿using System;
+using System.Globalization;
+using EddiDataDefinitions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utilities;
 
@@ -60,6 +62,22 @@ namespace UnitTests
 
             var result = dest.DistanceFromStarSystem(curr);
             Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void TestDateTimeToString()
+        {
+            // Parse the DateTime value and test 
+            if (DateTime.TryParseExact("2020-07-30T19:16:42Z", "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var date))
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("fi");
+                Assert.AreEqual("2020-07-30T19.16.42Z", date.ToString("yyyy-MM-ddTHH:mm:ssZ"), @"Should yield ""."" rather than "":"" as a time separator, which is invalid for EDDN and other 3rd party services");
+                Assert.AreEqual("2020-07-30T19:16:42Z", Dates.FromDateTimeToString(date), @"Should yield a string using the invariant culture, including the invariant "":"" time separator");
+            }
+            else
+            {
+                Assert.Fail("Failed to parse our DateTime string");
+            }
         }
     }
 }

--- a/Utilities/Dates.cs
+++ b/Utilities/Dates.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Utilities
 {
@@ -20,6 +21,11 @@ namespace Utilities
         public static long fromDateTimeToSeconds(DateTime dateTime)
         {
             return (long)(dateTime.Subtract(new DateTime(1970, 1, 1, 0, 0, 0))).TotalSeconds;
+        }
+
+        public static string FromDateTimeToString(DateTime? dateTime)
+        {
+            return dateTime?.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture) ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
Resolves exceptions like https://rollbar.com/EDCD/EDDI/items/18691/ which can occur when the current culture would cause the DateTime.ToString() method to return a string that does not match the invariant (the "fi" culture, for example, uses "." rather than ":" as a time separator in the rendered string. The fails EDDN's timestamp format validation.)