### PR TITLE
Added an indirection level to allow tests to specify different configs

### DIFF
--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -14,7 +14,8 @@ namespace Utilities
         public const string EDDI_SERVER_URL = "https://edcd.github.io/EDDP/";
         public static readonly string EDDI_SYSTEM_MUTEX_NAME = $"{EDDI_SERVER_URL}/{EDDI_NAME}/{Environment.GetEnvironmentVariable("UserName")}";
 
-        public static readonly string DATA_DIR = Environment.GetEnvironmentVariable("AppData") + "\\" + EDDI_NAME;
+        public static string BASE_DIR = Environment.GetEnvironmentVariable("AppData");
+        public static readonly string DATA_DIR = BASE_DIR + "\\" + EDDI_NAME;
 
         public static readonly string ENVIRONMENT_WITCH_SPACE = "Witch Space";
         public static readonly string ENVIRONMENT_SUPERCRUISE = "Supercruise";


### PR DESCRIPTION
I added a variable in Constants to be used from tests code.
So we can avoid re-using our gaming environments to do debugging and running tests.

For an example of usage, see https://github.com/GioVAX/EDDI/blob/1781-Part2/Tests/MainWindowResponderTests.cs#L17