### PR TITLE
Implement post-build tests via batch file

### DIFF
--- a/BuildInstaller/BuildInstaller.csproj
+++ b/BuildInstaller/BuildInstaller.csproj
@@ -37,10 +37,15 @@
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "$(ConfigurationName)" == "Release" (
-  cd "$(SolutionDir)"
+    <PostBuildEvent>cd "$(SolutionDir)"
+if exist $(SolutionDir)postBuildTests.bat (
+  @echo Post-build script exists at: $(SolutionDir)postBuild.bat - executing...
+  call $(SolutionDir)postBuildTests.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir)$(OutDir)"
+)
+
+if "$(ConfigurationName)" == "Release" (
   build-installer
-) 
+)
 </PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>

--- a/EDDI.sln
+++ b/EDDI.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		images\MainProfile.jpg = images\MainProfile.jpg
 		images\OptionsPluginSupport.jpg = images\OptionsPluginSupport.jpg
 		images\OptionsVersion.jpg = images\OptionsVersion.jpg
+		postBuildTests.bat = postBuildTests.bat
 		images\ProfileOptions.jpg = images\ProfileOptions.jpg
 		images\ProfileOptionsOnLoad.jpg = images\ProfileOptionsOnLoad.jpg
 		README.md = README.md
@@ -237,9 +238,9 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {28C2EDB6-0FA0-409F-987C-7A24F542D0CF}
-		RESX_ShowErrorsInErrorList = False
-		RESX_AutoCreateNewLanguageFiles = True
 		RESX_TaskErrorCategory = Message
+		RESX_AutoCreateNewLanguageFiles = True
+		RESX_ShowErrorsInErrorList = False
+		SolutionGuid = {28C2EDB6-0FA0-409F-987C-7A24F542D0CF}
 	EndGlobalSection
 EndGlobal

--- a/postBuildTests.bat
+++ b/postBuildTests.bat
@@ -1,0 +1,28 @@
+:: Batch file assumes parameters: postBuild.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir)$(OutDir)"
+
+ECHO ****************************
+SET this=Post-build script
+
+:: Rename the passed parameters for clarity
+SET "buildConfiguration=%1"
+SET "devEnvDir=%~2"
+SET "buildDir=%~3"
+
+ECHO %this%: Build configuration is %buildConfiguration%
+
+:: Ref. vstest.console.exe documentation at https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2019
+:: We need to apply batch file rules for escaping certain characters in our command (using "^"), ref. https://www.robvanderwoude.com/escapechars.php
+IF %buildConfiguration%=="Release" (
+  :: Run all tests except Speech tests 
+  SET "testCaseFilter=^/TestCaseFilter:""TestCategory!=Speech"""
+) ELSE (
+  :: Run just our Credentials test
+  SET "testCaseFilter=^/TestCaseFilter:""TestCategory=Credentials"""
+)
+
+SET "command="%devEnvDir%CommonExtensions\Microsoft\TestWindow\vstest.console.exe" "%buildDir%Tests.dll" %testCaseFilter%"
+
+ECHO %this%: Invoking... %command%
+%command%
+
+ECHO ****************************


### PR DESCRIPTION
Resolves #1957. Allows post-build tests to be customized for each configuration by editing the batch file.