### PR TITLE
Convert body properties `alreadydiscovered` and `alreadymapped` to optional bool.

### DIFF
--- a/DataDefinitions/Body.cs
+++ b/DataDefinitions/Body.cs
@@ -64,13 +64,13 @@ namespace EddiDataDefinitions
         // Scan data
 
         /// <summary>Whether we're the first commander to discover this body</summary>
-        public bool alreadydiscovered { get; set; }
+        public bool? alreadydiscovered { get; set; }
 
         /// <summary>When we scanned this object, if we have (DateTime)</summary>
         public DateTime? scanned { get; set; }
 
         /// <summary>Whether we're the first commander to map this body</summary>
-        public bool alreadymapped { get; set; }
+        public bool? alreadymapped { get; set; }
 
         /// <summary>When we mapped this object, if we have (DateTime)</summary>
         public DateTime? mapped { get; set; }
@@ -224,7 +224,7 @@ namespace EddiDataDefinitions
             (decimal?)StarClass.DistanceFromStarForTemperature(StarClass.minHabitableTempKelvin, Convert.ToDouble(radius), Convert.ToDouble(temperature)) : null;
 
         /// <summary> Star definition </summary>
-        public Body(string bodyName, long? bodyId, List<IDictionary<string, object>> parents, decimal? distanceLs, string stellarclass, int? stellarsubclass, decimal? solarmass, decimal radiusKm, decimal? absolutemagnitude, long? ageMegaYears, decimal? temperatureKelvin, string luminosityclass, decimal? semimajoraxisLs, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, decimal? orbitalPeriodDays, decimal? rotationPeriodDays, decimal? axialTiltDegrees, List<Ring> rings, bool alreadydiscovered, bool alreadymapped, string systemName = null, long? systemAddress = null)
+        public Body(string bodyName, long? bodyId, List<IDictionary<string, object>> parents, decimal? distanceLs, string stellarclass, int? stellarsubclass, decimal? solarmass, decimal radiusKm, decimal? absolutemagnitude, long? ageMegaYears, decimal? temperatureKelvin, string luminosityclass, decimal? semimajoraxisLs, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, decimal? orbitalPeriodDays, decimal? rotationPeriodDays, decimal? axialTiltDegrees, List<Ring> rings, bool? alreadydiscovered, bool? alreadymapped, string systemName = null, long? systemAddress = null)
         {
             this.bodyname = bodyName;
             this.radius = radiusKm;
@@ -370,7 +370,7 @@ namespace EddiDataDefinitions
         public ReserveLevel reserveLevel { get; set; } = ReserveLevel.None;
 
         /// <summary> Planet or Moon definition </summary>
-        public Body(string bodyName, long? bodyId, List<IDictionary<string, object>> parents, decimal? distanceLs, bool? tidallylocked, TerraformState terraformstate, PlanetClass planetClass, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereCompositions, Volcanism volcanism, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? landable, List<MaterialPresence> materials, List<SolidComposition> solidCompositions, decimal? semimajoraxisLs, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, decimal? orbitalPeriodDays, decimal? rotationPeriodDays, decimal? axialtiltDegrees, List<Ring> rings, ReserveLevel reserveLevel, bool alreadydiscovered, bool alreadymapped, string systemName = null, long? systemAddress = null)
+        public Body(string bodyName, long? bodyId, List<IDictionary<string, object>> parents, decimal? distanceLs, bool? tidallylocked, TerraformState terraformstate, PlanetClass planetClass, AtmosphereClass atmosphereClass, List<AtmosphereComposition> atmosphereCompositions, Volcanism volcanism, decimal? earthmass, decimal? radiusKm, decimal gravity, decimal? temperatureKelvin, decimal? pressureAtm, bool? landable, List<MaterialPresence> materials, List<SolidComposition> solidCompositions, decimal? semimajoraxisLs, decimal? eccentricity, decimal? orbitalinclinationDegrees, decimal? periapsisDegrees, decimal? orbitalPeriodDays, decimal? rotationPeriodDays, decimal? axialtiltDegrees, List<Ring> rings, ReserveLevel reserveLevel, bool? alreadydiscovered, bool? alreadymapped, string systemName = null, long? systemAddress = null)
         {
             this.bodyname = bodyName;
             this.bodyType = (bool)parents?.Exists(p => p.ContainsKey("Planet"))
@@ -446,6 +446,9 @@ namespace EddiDataDefinitions
             int k_terraformable = 93328;
             double mappingMultiplier = 1;
 
+            var alreadyDiscovered = (alreadydiscovered ?? false);
+            var alreadyMapped = (alreadymapped ?? false);
+
             // Override constants for specific types of bodies
             if (planetClass.edname == "AmmoniaWorld")
             {
@@ -485,11 +488,11 @@ namespace EddiDataDefinitions
 
             if (mapped != null)
             {
-                if (!alreadydiscovered && !alreadymapped) // First to discover and first to map
+                if (!alreadyDiscovered && !alreadyMapped) // First to discover and first to map
                 {
                     mappingMultiplier = 3.699622554;
                 }
-                else if (!alreadymapped) // Not first to discover but first to map
+                else if (!alreadyMapped) // Not first to discover but first to map
                 {
                     mappingMultiplier = 8.0956;
                 }
@@ -502,7 +505,7 @@ namespace EddiDataDefinitions
 
             // Calculate exploration scan values
             double result = Math.Max(scanMinValue, (k + (k * q * Math.Pow((double)earthmass, scanPower))) * mappingMultiplier);
-            result *= (!alreadydiscovered) ? firstDiscoveryMultiplier : 1;
+            result *= !alreadyDiscovered ? firstDiscoveryMultiplier : 1;
             return (long)Math.Round(result);
         }
 

--- a/Events/BodyMappedEvent.cs
+++ b/Events/BodyMappedEvent.cs
@@ -155,9 +155,9 @@ namespace EddiEvents
 
         public DateTime? mapped => body?.mapped;
 
-        public bool alreadydiscovered => body?.alreadydiscovered ?? false;
+        public bool? alreadydiscovered => body?.alreadydiscovered;
 
-        public bool alreadymapped => body?.alreadymapped ?? false;
+        public bool? alreadymapped => body?.alreadymapped;
 
         public int probesused { get; private set; }
 

--- a/Events/BodyScannedEvent.cs
+++ b/Events/BodyScannedEvent.cs
@@ -156,9 +156,9 @@ namespace EddiEvents
 
         public DateTime? mapped => body.mapped;
 
-        public bool alreadydiscovered => body.alreadydiscovered;
+        public bool? alreadydiscovered => body.alreadydiscovered;
 
-        public bool alreadymapped => body.alreadymapped;
+        public bool? alreadymapped => body.alreadymapped;
 
         // Variables below are not intended to be user facing
         public Body body { get; private set; }

--- a/Events/StarScannedEvent.cs
+++ b/Events/StarScannedEvent.cs
@@ -69,7 +69,7 @@ namespace EddiEvents
 
         public decimal? ageprobability => star.ageprobability;
 
-        public bool alreadydiscovered => star.alreadydiscovered;
+        public bool? alreadydiscovered => star.alreadydiscovered;
 
         public string bodyname => star.bodyname;
 
@@ -147,7 +147,7 @@ namespace EddiEvents
         public decimal? tiltprobability => star.tiltprobability;
 
         // Variables below are not intended to be user facing
-        public bool alreadymapped => star.alreadymapped;
+        public bool? alreadymapped => star.alreadymapped;
         public long? bodyId => star.bodyId;
         public DateTime? mapped => star.mapped;
         public List<IDictionary<string, object>> parents => star.parents;

--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -837,8 +837,8 @@ namespace EddiJournalMonitor
                                     }
 
                                     // Scan status
-                                    bool alreadydiscovered = JsonParsing.getOptionalBool(data, "WasDiscovered") ?? true;
-                                    bool alreadymapped = JsonParsing.getOptionalBool(data, "WasMapped") ?? false;
+                                    bool? alreadydiscovered = JsonParsing.getOptionalBool(data, "WasDiscovered");
+                                    bool? alreadymapped = JsonParsing.getOptionalBool(data, "WasMapped");
 
                                     // Rings
                                     data.TryGetValue("Rings", out object val);

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -531,8 +531,8 @@ All bodies have the following data:
 	- `rings` (when applicable) (an array of ring objects)
     - `scanned` a DateTime value that is set when the body is scanned and unset otherwise.
     - `mapped` a DateTime value that is set when the body is mapped and unset otherwise.
-    - `alreadydiscovered` whether another commander has already submitted a scan of the body to Universal Cartographics
-    - `alreadymapped` whether another commander has already submitted mapping data for the body to Universal Cartographics
+    - `alreadydiscovered` whether another commander has already submitted a scan of the body to Universal Cartographics (scan required to fill this value)
+    - `alreadymapped` whether another commander has already submitted mapping data for the body to Universal Cartographics (scan required to fill this value)
     - `estimatedvalue` the current estimated value of the body, taking into account scans and mapping.
     - `periapsis` the argument of periapsis of the body, in degrees (as applicable)
     - `tilt` the axial tilt of the body, in degrees  (as applicable)

--- a/Tests/JournalMonitorTests.cs
+++ b/Tests/JournalMonitorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Tests.Properties;
@@ -150,8 +151,10 @@ namespace UnitTests
             BodyScannedEvent ev = events[0] as BodyScannedEvent;
             Assert.IsNotNull(ev);
             Assert.AreEqual("Planet", ev.body.bodyType.invariantName);
-            Assert.IsTrue(ev.alreadydiscovered);
-            Assert.IsTrue(ev.alreadymapped);
+            Debug.Assert(ev.alreadydiscovered != null, "ev.alreadydiscovered != null");
+            Assert.IsTrue((bool)ev.alreadydiscovered);
+            Debug.Assert(ev.alreadymapped != null, "ev.alreadymapped != null");
+            Assert.IsTrue((bool)ev.alreadymapped);
         }
 
         [TestMethod]
@@ -210,7 +213,8 @@ namespace UnitTests
 
             StarScannedEvent theEvent = (StarScannedEvent)events[0];
             Assert.AreEqual(8, theEvent.stellarsubclass);
-            Assert.IsTrue(theEvent.alreadydiscovered);
+            Debug.Assert(theEvent.alreadydiscovered != null, "theEvent.alreadydiscovered != null");
+            Assert.IsTrue((bool)theEvent.alreadydiscovered);
             Assert.AreEqual(4916.66378995466M, theEvent.density);
             Assert.AreEqual(1204, theEvent.estimatedvalue);
             Assert.AreEqual(0.00456994738549848M, theEvent.luminosity);
@@ -219,7 +223,8 @@ namespace UnitTests
             Assert.AreEqual(32.983871M, theEvent.periapsis);
             Assert.IsTrue(theEvent.scoopable);
             Assert.AreEqual(0M, theEvent.tilt);
-            Assert.IsFalse(theEvent.alreadymapped);
+            Debug.Assert(theEvent.alreadymapped != null, "theEvent.alreadymapped != null");
+            Assert.IsFalse((bool)theEvent.alreadymapped);
             Assert.AreEqual(2, theEvent.bodyId);
             Assert.IsNull(theEvent.mapped);
             Assert.IsInstanceOfType(theEvent.scanned, typeof(System.DateTime));


### PR DESCRIPTION
Fixes https://forums.frontier.co.uk/threads/eddi-scripts-and-eddi-enabled-va-commands-thread.311614/post-8705030.

We don't actually learn whether a body is known to Universal Cartographics until the commander scans the body but we still set a default value (false) when we instantiate the body. With this change, the value will instead be null until the body is scanned.