### PR TITLE
Calculate cargo price using a weighted average of acquisition prices

### DIFF
--- a/BgsService/EddiBgsService.csproj
+++ b/BgsService/EddiBgsService.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/BgsService/packages.config
+++ b/BgsService/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/BuildInstaller/BuildInstaller.csproj
+++ b/BuildInstaller/BuildInstaller.csproj
@@ -52,6 +52,9 @@ if "$(ConfigurationName)" == "Release" (
     <Compile Include="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>

--- a/BuildInstaller/packages.config
+++ b/BuildInstaller/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
 </packages>

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -60,14 +60,18 @@ namespace EddiCargoMonitor
             return true;
         }
 
-        public CargoMonitor()
+        /// <summary>
+        /// Create a new CargoMonitor, optionally passing in a non-default configuration
+        /// </summary>
+        /// <param name="configuration">The configuration to use. If null, it will be read from the file system</param>
+        public CargoMonitor(CargoMonitorConfiguration configuration = null)
         {
             inventory = new ObservableCollection<Cargo>();
             BindingOperations.CollectionRegistering += Inventory_CollectionRegistering;
-            initializeCargoMonitor();
+            initializeCargoMonitor(configuration);
         }
 
-        public void initializeCargoMonitor(CargoMonitorConfiguration configuration = null)
+        private void initializeCargoMonitor(CargoMonitorConfiguration configuration = null)
         {
             readInventory(configuration);
             Logging.Info($"Initialized {MonitorName()}");

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -3,6 +3,7 @@ using EddiCore;
 using EddiDataDefinitions;
 using EddiEvents;
 using EddiMissionMonitor;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -61,10 +62,18 @@ namespace EddiCargoMonitor
         }
 
         /// <summary>
+        /// Create a new CargoMonitor, reading the configuration from the default location on the file system.
+        /// This is required for the DLL to load
+        /// </summary>
+        [PublicAPI]
+        public CargoMonitor() : this(null)
+        {}
+
+        /// <summary>
         /// Create a new CargoMonitor, optionally passing in a non-default configuration
         /// </summary>
         /// <param name="configuration">The configuration to use. If null, it will be read from the file system</param>
-        public CargoMonitor(CargoMonitorConfiguration configuration = null)
+        public CargoMonitor(CargoMonitorConfiguration configuration)
         {
             inventory = new ObservableCollection<Cargo>();
             BindingOperations.CollectionRegistering += Inventory_CollectionRegistering;

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -1005,15 +1005,21 @@ namespace EddiCargoMonitor
             if (cargo == null) { return; }
             lock (inventoryLock)
             {
+                bool found = false;
                 for (int i = 0; i < inventory.Count; i++)
                 {
                     if (string.Equals(inventory[i].edname, cargo.edname, StringComparison.InvariantCultureIgnoreCase))
                     {
+                        found = true;
                         inventory[i] = cargo;
-                        return;
+                        break;
                     }
                 }
-                inventory.Add(cargo);
+
+                if (!found)
+                {
+                    inventory.Add(cargo);
+                }
             }
         }
 

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -316,15 +316,15 @@ namespace EddiCargoMonitor
                 {
                     if (haulage != null)
                     {
-                        cargo.AddDetailedQty(CargoType.haulage, 1);
+                        cargo.AddDetailedQty(CargoType.haulage, 1, 0);
                     }
                     else if (@event.stolen)
                     {
-                        cargo.AddDetailedQty(CargoType.stolen, 1);
+                        cargo.AddDetailedQty(CargoType.stolen, 1, 0);
                     }
                     else
                     {
-                        cargo.AddDetailedQty(CargoType.owned, 1);
+                        cargo.AddDetailedQty(CargoType.owned, 1, 0);
                     }
                     cargo.CalculateNeed();
                     update = true;
@@ -428,11 +428,11 @@ namespace EddiCargoMonitor
             {
                 haulage.sourcesystem = EDDI.Instance?.CurrentStarSystem?.systemname;
                 haulage.sourcebody = EDDI.Instance?.CurrentStation?.name;
-                cargo.AddDetailedQty(CargoType.haulage, @event.amount, haulage, @event.price);
+                cargo.AddDetailedQty(CargoType.haulage, @event.amount, @event.price, haulage);
             }
             else
             {
-                cargo.AddDetailedQty(CargoType.owned, @event.amount, null, @event.price);
+                cargo.AddDetailedQty(CargoType.owned, @event.amount, @event.price);
             }
             AddOrUpdateCargo(cargo);
             return true;
@@ -667,7 +667,7 @@ namespace EddiCargoMonitor
         private bool _handleLimpetPurchasedEvent(LimpetPurchasedEvent @event)
         {
             Cargo cargo = GetCargoWithEDName("Drones") ?? new Cargo("Drones");
-            cargo.AddDetailedQty(CargoType.owned, @event.amount, null, @event.price);
+            cargo.AddDetailedQty(CargoType.owned, @event.amount, @event.price);
             AddOrUpdateCargo(cargo);
             return true;
         }
@@ -724,7 +724,7 @@ namespace EddiCargoMonitor
                 Cargo cargo = GetCargoWithMissionId(@event.missionid ?? 0);
                 int onboard = haulage.remaining - haulage.need;
                 cargo.RemoveDetailedQty(CargoType.haulage, onboard, @event.missionid);
-                cargo.AddDetailedQty(CargoType.stolen, onboard);
+                cargo.AddDetailedQty(CargoType.stolen, onboard, cargo.price);
                 RemoveCargo(cargo);
                 update = true;
             }
@@ -884,7 +884,7 @@ namespace EddiCargoMonitor
                 Cargo cargo = GetCargoWithMissionId(@event.missionid ?? 0);
                 int onboard = haulage.remaining - haulage.need;
                 cargo.RemoveDetailedQty(CargoType.haulage, onboard, haulage);
-                cargo.AddDetailedQty(CargoType.stolen, onboard);
+                cargo.AddDetailedQty(CargoType.stolen, onboard, cargo.price);
                 RemoveCargo(cargo);
                 return true;
             }
@@ -942,7 +942,7 @@ namespace EddiCargoMonitor
             if (@event.synthesis.Contains("Limpet"))
             {
                 Cargo cargo = GetCargoWithEDName("Drones") ?? new Cargo("Drones");
-                cargo.AddDetailedQty(CargoType.owned, 4);
+                cargo.AddDetailedQty(CargoType.owned, 4, 0);
                 AddOrUpdateCargo(cargo);
                 return true;
             }
@@ -1026,7 +1026,6 @@ namespace EddiCargoMonitor
                         break;
                     }
                 }
-
                 if (!found)
                 {
                     inventory.Add(cargo);

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -305,7 +305,7 @@ namespace EddiCargoMonitor
                 {
                     if (haulage != null)
                     {
-                        cargo.AddDetailedQty(CargoType.haulage, 1, haulage);
+                        cargo.AddDetailedQty(CargoType.haulage, 1);
                     }
                     else if (@event.stolen)
                     {

--- a/CargoMonitor/CargoMonitor.cs
+++ b/CargoMonitor/CargoMonitor.cs
@@ -19,9 +19,7 @@ using Utilities;
 
 namespace EddiCargoMonitor
 {
-    /**
-     * Monitor cargo for the current ship
-     */
+    /// Monitor cargo for the current ship
     public class CargoMonitor : EDDIMonitor
     {
         // Observable collection for us to handle changes

--- a/CargoMonitor/CargoMonitorConfiguration.cs
+++ b/CargoMonitor/CargoMonitorConfiguration.cs
@@ -87,22 +87,16 @@ namespace EddiCargoMonitor
 
         /// <summary>
         /// Write configuration to a file.  If the filename is not supplied then the path used
-        /// when reading in the configuration will be used, or the default path of 
-        /// Constants.Data_DIR\cargomonitor.json will be used
+        /// when reading in the configuration will be used, unless it too is null, for example
+        /// a test config purely based on JSON, in which case nothing will be written.
         /// </summary>
         public void ToFile(string filename = null)
         {
             // Remove any items that are all NULL
             //limits = limits.Where(x => x.Value.minimum.HasValue || x.Value.desired.HasValue || x.Value.maximum.HasValue).ToDictionary(x => x.Key, x => x.Value);
 
-            if (filename == null)
-            {
-                filename = dataPath;
-            }
-            if (filename == null)
-            {
-                filename = Constants.DATA_DIR + @"\cargomonitor.json";
-            }
+            filename = filename ?? dataPath;
+            if (filename == null) { return; }
 
             string json = JsonConvert.SerializeObject(this, Formatting.Indented);
             Logging.Debug("Configuration to file: " + json);

--- a/CargoMonitor/EddiCargoMonitor.csproj
+++ b/CargoMonitor/EddiCargoMonitor.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/CargoMonitor/EddiCargoMonitor.csproj
+++ b/CargoMonitor/EddiCargoMonitor.csproj
@@ -49,8 +49,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/CargoMonitor/packages.config
+++ b/CargoMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/CargoMonitor/packages.config
+++ b/CargoMonitor/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net48" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/CompanionAppService/EddiCompanionAppService.csproj
+++ b/CompanionAppService/EddiCompanionAppService.csproj
@@ -52,6 +52,9 @@
     <Reference Include="CredentialManagement, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CredentialManagement.1.0.2\lib\net35\CredentialManagement.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/CompanionAppService/packages.config
+++ b/CompanionAppService/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CredentialManagement" version="1.0.2" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/CrimeMonitor/EddiCrimeMonitor.csproj
+++ b/CrimeMonitor/EddiCrimeMonitor.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/CrimeMonitor/packages.config
+++ b/CrimeMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/DataDefinitions/Cargo.cs
+++ b/DataDefinitions/Cargo.cs
@@ -183,6 +183,11 @@ namespace EddiDataDefinitions
             NotifyPropertyChanged("price");
         }
 
+        /// <summary> </summary>
+        /// <param name="cargoType">The type of cargo to add</param>
+        /// <param name="amount">The amount of cargo to add</param>
+        /// <param name="cargoHaulageData">Add or update haulage instance</param>
+        /// <param name="_price">The acquisition price per unit (if not zero)</param>
         public void AddDetailedQty(CargoType cargoType, int amount, Haulage cargoHaulageData = null, int _price = 0)
         {
             CalculateWeightedPrice(_price, amount);
@@ -191,7 +196,18 @@ namespace EddiDataDefinitions
                 case CargoType.haulage:
                     {
                         haulage += amount;
-                        if (cargoHaulageData != null) { haulageData.Add(cargoHaulageData); }
+                        if (cargoHaulageData != null) 
+                        {
+                            for (int i = 0; i < haulageData.Count; i++)
+                            {
+                                if (haulageData[i].missionid == cargoHaulageData.missionid)
+                                {
+                                    haulageData[i] = cargoHaulageData;
+                                    return;
+                                }
+                            }
+                            haulageData.Add(cargoHaulageData); 
+                        }
                         break;
                     }
                 case CargoType.stolen:
@@ -207,12 +223,18 @@ namespace EddiDataDefinitions
             }
         }
 
+        /// <param name="cargoType">The type of cargo to remove</param>
+        /// <param name="amount">The amount of cargo to remove</param>
+        /// <param name="missionId">Remove haulage instance by mission ID</param>
         public void RemoveDetailedQty(CargoType cargoType, int amount, long? missionId)
         {
             var thisHaulageData = haulageData.FirstOrDefault(h => h.missionid == missionId);
             RemoveDetailedQty(cargoType, amount, thisHaulageData);
         }
 
+        /// <param name="cargoType">The type of cargo to remove</param>
+        /// <param name="amount">The amount of cargo to remove</param>
+        /// <param name="cargoHaulageData">Remove haulage instance</param>
         public void RemoveDetailedQty(CargoType cargoType, int amount, Haulage cargoHaulageData = null)
         {
             switch (cargoType)

--- a/DataDefinitions/Cargo.cs
+++ b/DataDefinitions/Cargo.cs
@@ -174,85 +174,89 @@ namespace EddiDataDefinitions
             }
         }
 
-        public void CalculateWeightedPrice(int thisPrice, int amount)
+        public void UpdateWeightedPrice(decimal newPrice, int newAmount)
         {
-            if (amount == 0) { return; }
-            var weightedValueSum = (weightedAvgPrice * total) + (thisPrice * amount);
-            var weightedQtySum = total + amount;
-            weightedAvgPrice = weightedValueSum / weightedQtySum;
-            NotifyPropertyChanged("price");
+            if (newAmount == 0) { return; }
+            var weightedValueSum = (weightedAvgPrice * total) + (newPrice * newAmount);
+            var weightedQtySum = total + newAmount;
+
+            if (weightedQtySum > 0)
+            {
+                weightedAvgPrice = weightedValueSum / weightedQtySum;
+                NotifyPropertyChanged("price");
+            }
         }
 
         /// <summary> </summary>
         /// <param name="cargoType">The type of cargo to add</param>
-        /// <param name="amount">The amount of cargo to add</param>
+        /// <param name="acquistionAmount">The amount of cargo to add</param>
         /// <param name="cargoHaulageData">Add or update haulage instance</param>
-        /// <param name="_price">The acquisition price per unit (if not zero)</param>
-        public void AddDetailedQty(CargoType cargoType, int amount, Haulage cargoHaulageData = null, int _price = 0)
+        /// <param name="acquistionPrice">The acquisition price per unit (if not zero)</param>
+        public void AddDetailedQty(CargoType cargoType, int acquistionAmount, decimal acquistionPrice, Haulage cargoHaulageData = null)
         {
-            CalculateWeightedPrice(_price, amount);
+            UpdateWeightedPrice(acquistionPrice, acquistionAmount);
             switch (cargoType)
             {
                 case CargoType.haulage:
                     {
-                        haulage += amount;
+                        haulage += acquistionAmount;
                         if (cargoHaulageData != null) 
                         {
-                            for (int i = 0; i < haulageData.Count; i++)
+                            var haulageIndex = haulageData.FindIndex(h => h.missionid == cargoHaulageData.missionid);
+                            if (haulageIndex > -1)
                             {
-                                if (haulageData[i].missionid == cargoHaulageData.missionid)
-                                {
-                                    haulageData[i] = cargoHaulageData;
-                                    return;
-                                }
+                                haulageData[haulageIndex] = cargoHaulageData;
                             }
-                            haulageData.Add(cargoHaulageData); 
+                            else
+                            {
+                                haulageData.Add(cargoHaulageData);
+                            }
                         }
                         break;
                     }
                 case CargoType.stolen:
                     {
-                        stolen += amount;
+                        stolen += acquistionAmount;
                         break;
                     }
                 default:
                     {
-                        owned += amount;
+                        owned += acquistionAmount;
                         break;
                     }
             }
         }
 
         /// <param name="cargoType">The type of cargo to remove</param>
-        /// <param name="amount">The amount of cargo to remove</param>
+        /// <param name="removedAmount">The amount of cargo to remove</param>
         /// <param name="missionId">Remove haulage instance by mission ID</param>
-        public void RemoveDetailedQty(CargoType cargoType, int amount, long? missionId)
+        public void RemoveDetailedQty(CargoType cargoType, int removedAmount, long? missionId)
         {
             var thisHaulageData = haulageData.FirstOrDefault(h => h.missionid == missionId);
-            RemoveDetailedQty(cargoType, amount, thisHaulageData);
+            RemoveDetailedQty(cargoType, removedAmount, thisHaulageData);
         }
 
         /// <param name="cargoType">The type of cargo to remove</param>
-        /// <param name="amount">The amount of cargo to remove</param>
+        /// <param name="removedAmount">The amount of cargo to remove</param>
         /// <param name="cargoHaulageData">Remove haulage instance</param>
-        public void RemoveDetailedQty(CargoType cargoType, int amount, Haulage cargoHaulageData = null)
+        public void RemoveDetailedQty(CargoType cargoType, int removedAmount, Haulage cargoHaulageData = null)
         {
             switch (cargoType)
             {
                 case CargoType.haulage:
                     {
-                        haulage -= amount;
+                        haulage -= removedAmount;
                         if (cargoHaulageData != null) { haulageData.Remove(cargoHaulageData); }
                         break;
                     }
                 case CargoType.stolen:
                     {
-                        stolen -= amount;
+                        stolen -= removedAmount;
                         break;
                     }
                 default:
                     {
-                        owned -= amount;
+                        owned -= removedAmount;
                         break;
                     }
             }

--- a/DataDefinitions/CommodityDefinition.cs
+++ b/DataDefinitions/CommodityDefinition.cs
@@ -448,7 +448,7 @@ namespace EddiDataDefinitions
 
         // The average price of a commodity can change - thus this cannot be read only.
         // Instead, this value should be updated whenever revised data is received.
-        public int avgprice { get; set; }
+        public decimal avgprice { get; set; }
 
         // dummy used to ensure that the static constructor has run
         public CommodityDefinition() : this(0, null, "", Unknown)

--- a/DataDefinitions/CommodityMarketQuote.cs
+++ b/DataDefinitions/CommodityMarketQuote.cs
@@ -63,14 +63,14 @@ namespace EddiDataDefinitions
             }
         }
 
-        // Per-station information
-        public int buyprice { get; set; }
+        // Per-station information (prices are usually integers but not always)
+        public decimal buyprice { get; set; }
         public int stock { get; set; }
 
         // StockBracket can contain the values 0, 1, 2, 3 or "" (yes, really) so needs to be dynamic
         public CommodityBracket? stockbracket { get; set; }
 
-        public int sellprice { get; set; }
+        public decimal sellprice { get; set; }
         public int demand { get; set; }
 
         // DemandBracket can contain the values 0, 1, 2, 3 or "" (yes, really) so needs to be dynamic
@@ -85,7 +85,7 @@ namespace EddiDataDefinitions
         // Update the definition with the new galactic average price whenever this is set.
         // Fleet carriers return zero and do not display the true average price. We must disregard that information so preserve the true average price.
         // The average pricing data is the only data which may reference our internal definition, and even then only to obtain an average price.
-        public int avgprice
+        public decimal avgprice
         {
             get => definition?.avgprice ?? 0;
             set

--- a/DataDefinitions/EddiDataDefinitions.csproj
+++ b/DataDefinitions/EddiDataDefinitions.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="MathNet.Numerics, Version=4.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.7.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>

--- a/DataDefinitions/packages.config
+++ b/DataDefinitions/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="MathNet.Numerics" version="4.7.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/DataProviderService/EddiDataProviderService.csproj
+++ b/DataProviderService/EddiDataProviderService.csproj
@@ -57,6 +57,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/DataProviderService/packages.config
+++ b/DataProviderService/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.2.0" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Data.SQLite" version="1.0.108.0" targetFramework="net471" />

--- a/EDDI/Eddi.csproj
+++ b/EDDI/Eddi.csproj
@@ -92,6 +92,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/EDDI/packages.config
+++ b/EDDI/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="CommonMark.NET" version="0.15.1" targetFramework="net471" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
   <package id="System.Data.SQLite" version="1.0.108.0" targetFramework="net471" />

--- a/EDDNResponder/EddiEddnResponder.csproj
+++ b/EDDNResponder/EddiEddnResponder.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/EDDNResponder/packages.config
+++ b/EDDNResponder/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/EDDPMonitor/EddiEddpMonitor.csproj
+++ b/EDDPMonitor/EddiEddpMonitor.csproj
@@ -52,6 +52,9 @@
     <Reference Include="AsyncIO, Version=0.1.25.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
       <HintPath>..\packages\AsyncIO.0.1.26.0\lib\net40\AsyncIO.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="NetMQ, Version=4.0.0.1, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
       <HintPath>..\packages\NetMQ.4.0.0.1\lib\net40\NetMQ.dll</HintPath>
     </Reference>

--- a/EDDPMonitor/packages.config
+++ b/EDDPMonitor/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="NetMQ" version="4.0.0.1" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/EDSMResponder/EddiEdsmResponder.csproj
+++ b/EDSMResponder/EddiEdsmResponder.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/EDSMResponder/packages.config
+++ b/EDSMResponder/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/EddiCore/EddiCore.csproj
+++ b/EddiCore/EddiCore.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations, Version=7.1.3000.2254, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\ReSharper.Annotations.7.1.3.130415\lib\net\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/EddiCore/EddiCore.csproj
+++ b/EddiCore/EddiCore.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=7.1.3000.2254, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\ReSharper.Annotations.7.1.3.130415\lib\net\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -43,6 +46,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/EddiCore/packages.config
+++ b/EddiCore/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ReSharper.Annotations" version="7.1.3.130415" targetFramework="net48" />
+</packages>

--- a/EddiCore/packages.config
+++ b/EddiCore/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="ReSharper.Annotations" version="7.1.3.130415" targetFramework="net48" />
 </packages>

--- a/EddiInaraService/EddiInaraService.csproj
+++ b/EddiInaraService/EddiInaraService.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/EddiInaraService/packages.config
+++ b/EddiInaraService/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
 </packages>

--- a/Events/EddiEvents.csproj
+++ b/Events/EddiEvents.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/Events/packages.config
+++ b/Events/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/GalnetMonitor/EddiGalnetMonitor.csproj
+++ b/GalnetMonitor/EddiGalnetMonitor.csproj
@@ -57,6 +57,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/GalnetMonitor/packages.config
+++ b/GalnetMonitor/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.2.0" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="SimpleFeedReader" version="1.0.7" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/InaraResponder/EddiInaraResponder.csproj
+++ b/InaraResponder/EddiInaraResponder.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/InaraResponder/packages.config
+++ b/InaraResponder/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
 </packages>

--- a/JournalMonitor/EddiJournalMonitor.csproj
+++ b/JournalMonitor/EddiJournalMonitor.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/JournalMonitor/packages.config
+++ b/JournalMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/MaterialMonitor/EddiMaterialMonitor.csproj
+++ b/MaterialMonitor/EddiMaterialMonitor.csproj
@@ -51,6 +51,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/MaterialMonitor/packages.config
+++ b/MaterialMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/MissionMonitor/EddiMissionMonitor.csproj
+++ b/MissionMonitor/EddiMissionMonitor.csproj
@@ -53,6 +53,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/MissionMonitor/packages.config
+++ b/MissionMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/NavigationService/EddiNavigationService.csproj
+++ b/NavigationService/EddiNavigationService.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>

--- a/NavigationService/packages.config
+++ b/NavigationService/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/ShipMonitor/EddiShipMonitor.csproj
+++ b/ShipMonitor/EddiShipMonitor.csproj
@@ -52,6 +52,9 @@
     <Reference Include="CommonMark, Version=0.1.0.0, Culture=neutral, PublicKeyToken=001ef8810438905d, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonMark.NET.0.15.1\lib\net45\CommonMark.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/ShipMonitor/packages.config
+++ b/ShipMonitor/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonMark.NET" version="0.15.1" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/SpeechResponder/EddiSpeechResponder.csproj
+++ b/SpeechResponder/EddiSpeechResponder.csproj
@@ -59,6 +59,9 @@
     <Reference Include="ICSharpCode.AvalonEdit, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9cc39be672370310, processorArchitecture=MSIL">
       <HintPath>..\packages\AvalonEdit.6.0.0\lib\net45\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/SpeechResponder/packages.config
+++ b/SpeechResponder/packages.config
@@ -3,6 +3,7 @@
   <package id="AvalonEdit" version="6.0.0" targetFramework="net471" />
   <package id="CommonMark.NET" version="0.15.1" targetFramework="net471" />
   <package id="Cottle" version="1.4.0.4" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/SpeechService/EddiSpeechService.csproj
+++ b/SpeechService/EddiSpeechService.csproj
@@ -52,6 +52,9 @@
     <Reference Include="CSCore, Version=1.2.1.2, Culture=neutral, PublicKeyToken=5a08f2b6f4415dea, processorArchitecture=MSIL">
       <HintPath>..\packages\CSCore.1.2.1.2\lib\net35-client\CSCore.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/SpeechService/packages.config
+++ b/SpeechService/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CSCore" version="1.2.1.2" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/StarMapService/EddiStarMapService.csproj
+++ b/StarMapService/EddiStarMapService.csproj
@@ -49,6 +49,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/StarMapService/packages.config
+++ b/StarMapService/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="RestSharp" version="106.3.1" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />

--- a/StatusMonitor/EddiStatusMonitor.csproj
+++ b/StatusMonitor/EddiStatusMonitor.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/StatusMonitor/packages.config
+++ b/StatusMonitor/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>

--- a/Tests/BgsDataTests.cs
+++ b/Tests/BgsDataTests.cs
@@ -50,6 +50,7 @@ namespace UnitTests
     public class BgsDataTests : TestBase
     {
         FakeBgsRestClient fakeBgsRestClient;
+        FakeBgsRestClient fakeEddbRestClient;
         BgsService fakeBgsService;
 
         [TestInitialize]
@@ -180,7 +181,6 @@ namespace UnitTests
             string resource = "v4/populatedsystems?";
             string json = Encoding.UTF8.GetString(Resources.bgsEddbSystemResponse);
             RestRequest data = new RestRequest();
-            fakeEddbRestClient.Expect(resource, json, data);
 
             StarSystem expectedSol = new StarSystem()
             {
@@ -189,12 +189,14 @@ namespace UnitTests
                 EDSMID = 27,
                 Power = Power.FromEDName("ZacharyHudson"),
                 powerState = PowerplayState.FromEDName("Controlled"),
-                updatedat = 1604805221
+                updatedat = 1599446773
             };
 
             // Act
+            fakeEddbRestClient.Expect(resource, json, data);
             StarSystem solByName = fakeBgsService.GetSystemByName("Sol");
             StarSystem solByAddress = fakeBgsService.GetSystemBySystemAddress(10477373803);
+            fakeEddbRestClient.Expect(resource, "", data);
             StarSystem nonExistentSystem = fakeBgsService.GetSystemByName("No such system");
 
             // Assert

--- a/Tests/BgsDataTests.cs
+++ b/Tests/BgsDataTests.cs
@@ -50,7 +50,6 @@ namespace UnitTests
     public class BgsDataTests : TestBase
     {
         FakeBgsRestClient fakeBgsRestClient;
-        FakeBgsRestClient fakeEddbRestClient;
         BgsService fakeBgsService;
 
         [TestInitialize]
@@ -183,30 +182,25 @@ namespace UnitTests
             RestRequest data = new RestRequest();
             fakeEddbRestClient.Expect(resource, json, data);
 
-            StarSystem expectedStarSystem = new StarSystem()
+            StarSystem expectedSol = new StarSystem()
             {
                 systemAddress = 10477373803,
                 systemname = "Sol",
                 EDSMID = 27,
                 Power = Power.FromEDName("ZacharyHudson"),
                 powerState = PowerplayState.FromEDName("Controlled"),
-                updatedat = 1599446773
+                updatedat = 1604805221
             };
 
             // Act
-            StarSystem system = fakeBgsService.GetSystemByName("Sol");
-            StarSystem system2 = fakeBgsService.GetSystemBySystemAddress(10477373803);
-            fakeEddbRestClient.Expect(resource, null, data);
-            StarSystem system3 = fakeBgsService.GetSystemByName("No such system");
+            StarSystem solByName = fakeBgsService.GetSystemByName("Sol");
+            StarSystem solByAddress = fakeBgsService.GetSystemBySystemAddress(10477373803);
+            StarSystem nonExistentSystem = fakeBgsService.GetSystemByName("No such system");
 
             // Assert
-            Assert.IsNotNull(system);
-            Assert.IsTrue(system.DeepEquals(expectedStarSystem));
-
-            Assert.IsNotNull(system2);
-            Assert.IsTrue(system2.DeepEquals(expectedStarSystem));
-
-            Assert.IsNull(system3);
+            Assert.IsTrue(solByName.DeepEquals(expectedSol));
+            Assert.IsTrue(solByAddress.DeepEquals(expectedSol));
+            Assert.IsNull(nonExistentSystem);
         }
 
         [TestMethod]

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -86,9 +86,6 @@ namespace UnitTests
                 }],
                 ""cargocarried"": 29
             }";
-            // Save original data
-            CargoMonitorConfiguration data = CargoMonitorConfiguration.FromFile();
-
             CargoMonitorConfiguration config = CargoMonitorConfiguration.FromJsonString(cargoConfigJson);
 
             Assert.AreEqual(3, config.cargo.Count);
@@ -110,17 +107,11 @@ namespace UnitTests
             Assert.AreEqual(4, haulage.amount);
             Assert.AreEqual(4, haulage.remaining);
             Assert.IsFalse(haulage.shared);
-
-            // Restore original data
-            data.ToFile();
         }
 
         [TestMethod]
         public void TestCargoEventsScenario()
         {
-            // Save original data
-            CargoMonitorConfiguration data = CargoMonitorConfiguration.FromFile();
-
             var privateObject = new PrivateObject(cargoMonitor);
             Haulage haulage = new Haulage();
 
@@ -183,17 +174,11 @@ namespace UnitTests
             cargo = cargoMonitor.inventory.ToList().FirstOrDefault(c => c.edname == "Biowaste");
             haulage = cargo.haulageData.FirstOrDefault(h => h.missionid == 426282789);
             Assert.AreEqual("Failed", haulage.status);
-
-            // Restore original data
-            data.ToFile();
         }
 
         [TestMethod]
         public void TestCargoMissionScenario()
         {
-            // Save original data
-            CargoMonitorConfiguration data = CargoMonitorConfiguration.FromFile();
-
             var privateObject = new PrivateObject(cargoMonitor);
             Haulage haulage = new Haulage();
 
@@ -339,17 +324,12 @@ namespace UnitTests
             Assert.AreEqual(0, haulage.remaining);
             Assert.AreEqual(0, haulage.need);
             Assert.AreEqual(0, cargo.need);
-
-            // Restore original data
-            data.ToFile();
         }
 
         [TestMethod]
         public void TestCargoPriceScenario()
         {
             // Test that average cargo price dynamically updates based on the aquisition prices and quantities
-            CargoMonitorConfiguration data = CargoMonitorConfiguration.FromFile();
-
             var privateObject = new PrivateObject(cargoMonitor);
 
             // Synthesise 4 drones
@@ -397,14 +377,6 @@ namespace UnitTests
             Assert.AreEqual(0, cargo.stolen);
             Assert.AreEqual(15, cargo.owned);
             Assert.AreEqual(51, cargo.price); // weighted price: 51.13
-
-            // Restore original data
-            data.ToFile();
-        }
-
-        [TestCleanup]
-        private void StopTestCargoMonitor()
-        {
         }
     }
 }

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests
     [TestClass]
     public class CargoMonitorTests : TestBase
     {
-        CargoMonitor cargoMonitor = new CargoMonitor();
+        CargoMonitor cargoMonitor = new CargoMonitor(new CargoMonitorConfiguration());
         Cargo cargo;
         string line;
         List<Event> events;

--- a/Tests/CargoMonitorTests.cs
+++ b/Tests/CargoMonitorTests.cs
@@ -18,7 +18,7 @@ namespace UnitTests
         List<Event> events;
 
         [TestInitialize]
-        private void StartTestCargoMonitor()
+        public void StartTestCargoMonitor()
         {
             MakeSafe();
         }

--- a/Tests/CrimeMonitorTests.cs
+++ b/Tests/CrimeMonitorTests.cs
@@ -143,7 +143,7 @@ namespace UnitTests
         }";
 
         [TestInitialize]
-        private void StartTestCrimeMonitor()
+        public void StartTestCrimeMonitor()
         {
             MakeSafe();
         }

--- a/Tests/MissionMonitorTests.cs
+++ b/Tests/MissionMonitorTests.cs
@@ -19,7 +19,7 @@ namespace UnitTests
         List<Event> events;
 
         [TestInitialize]
-        private void StartTestMissionMonitor()
+        public void StartTestMissionMonitor()
         {
             MakeSafe();
         }

--- a/Tests/NavigationServiceTests.cs
+++ b/Tests/NavigationServiceTests.cs
@@ -11,7 +11,7 @@ namespace IntegrationTests
     public class NavigationServiceTests : TestBase
     {
         [TestInitialize]
-        private void StartTestMissionMonitor()
+        public void StartTestMissionMonitor()
         {
             MakeSafe();
         }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -72,6 +72,9 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="MathNet.Numerics, Version=4.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.4.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Cottle" version="1.4.0.4" targetFramework="net471" />
   <package id="CSCore" version="1.2.1.2" targetFramework="net471" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net471" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="MathNet.Numerics" version="4.4.0" targetFramework="net471" />
   <package id="Microsoft.NETCore.Platforms" version="2.0.1" targetFramework="net471" />
   <package id="NetMQ" version="4.0.0.1" targetFramework="net471" />

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -51,6 +51,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="MathNet.Numerics, Version=4.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.7.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>

--- a/Utilities/packages.config
+++ b/Utilities/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitInfo" version="2.0.10" targetFramework="net471" developmentDependency="true" />
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="MathNet.Numerics" version="4.7.0" targetFramework="net471" />
   <package id="Microsoft.CSharp" version="4.4.0" targetFramework="net48" />
   <package id="Microsoft.Data.Sqlite.Core" version="2.0.0" targetFramework="net48" />

--- a/VoiceAttackResponder/EddiVoiceAttackResponder.csproj
+++ b/VoiceAttackResponder/EddiVoiceAttackResponder.csproj
@@ -51,6 +51,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2020.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2020.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/VoiceAttackResponder/packages.config
+++ b/VoiceAttackResponder/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2020.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Fixes #1978.
Revises the cargo monitor to calculate a weighted average of the commander's acquisition price for each cargo item (rather than the galactic average price).
Fixes inaccurate projected profits for the `Commodity sales check` script.