### PR TITLE
Always load required monitors

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -260,7 +260,7 @@ namespace EddiCore
                         enabled = true;
                     }
 
-                    if (!enabled)
+                    if (!enabled && !monitor.IsRequired())
                     {
                         Logging.Debug(monitor.MonitorName() + " is disabled; not starting");
                     }

--- a/EDDI/EDDIMonitor.cs
+++ b/EDDI/EDDIMonitor.cs
@@ -26,7 +26,7 @@ namespace EddiCore
         string MonitorDescription();
 
         /// <summary>
-        /// If the monitor is required to be running
+        /// If the monitor is required to be running. This must be true unless the monitor does not consume events (e.g. the event and profile handler methods are empty).
         /// </summary>
         bool IsRequired();
 

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -339,7 +339,7 @@ namespace Eddi
                 // Only show a tab if this can be turned off or has configuration elements
                 if (monitorConfiguration != null || !monitor.IsRequired())
                 {
-                    PluginSkeleton skeleton = new PluginSkeleton(monitor.MonitorName());
+                    PluginSkeleton skeleton = new PluginSkeleton(monitor.MonitorName(), !monitor.IsRequired());
                     skeleton.plugindescription.Text = monitor.MonitorDescription();
 
                     if (eddiConfiguration.Plugins.TryGetValue(monitor.MonitorName(), out bool enabled))

--- a/EDDI/PluginSkeleton.xaml
+++ b/EDDI/PluginSkeleton.xaml
@@ -9,7 +9,7 @@
              d:DesignHeight="300" d:DesignWidth="400">
     <DockPanel x:Name="panel" LastChildFill="False" Background="#FFE5E5E5">
         <TextBlock DockPanel.Dock="Top" x:Name="plugindescription" TextWrapping="Wrap" Margin="5" />
-        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="5">
+        <StackPanel Name="PluginSkeletonCheckbox" DockPanel.Dock="Top" Orientation="Horizontal" Margin="5">
             <CheckBox x:Name="pluginenabled" Checked="pluginenabled_Checked" Unchecked="pluginenabled_Unchecked"></CheckBox>
             <TextBlock Margin="5,0" Text="{x:Static resx:EddiResources.plugin_enabled}" />
         </StackPanel>

--- a/EDDI/PluginSkeleton.xaml.cs
+++ b/EDDI/PluginSkeleton.xaml.cs
@@ -11,10 +11,11 @@ namespace Eddi
     {
         string pluginName;
 
-        public PluginSkeleton(string pluginName)
+        public PluginSkeleton(string pluginName, bool isDisableable = true)
         {
             InitializeComponent();
             this.pluginName = pluginName;
+            PluginSkeletonCheckbox.Visibility = isDisableable ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void pluginenabled_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Required monitors can no longer be disabled.
Fixes #1975.