### PR TITLE
Fix `Humanise()` bugged outputs.

### DIFF
--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -814,8 +814,8 @@ namespace EddiSpeechService
 
             if (number < 100)
             {
-                // See if we have a number whose value can be expressed with a short description (i.e 1.3 million)
-                if (number + ((decimal)nextDigit / 10) == (decimal)value / orderMultiplier)
+                // See if we have a number whose value can be expressed with a short decimal (i.e 1.3 million)
+                if (number + ((decimal)nextDigit / 10) == Math.Round((decimal)value / orderMultiplier, 2))
                 {
                     return maybeMinus + (number + (decimal)nextDigit / 10) + order;
                 }

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -726,11 +726,11 @@ namespace EddiSpeechService
                 return null;
             }
 
-            string minus = "";
+            string maybeMinus = "";
             if (value < 0)
             {
-                minus = Properties.Phrases.minus + " ";
-                value *= -1;
+                maybeMinus = Properties.Phrases.minus + " ";
+                value = -value;
             }
 
             if (value == 0)
@@ -748,109 +748,123 @@ namespace EddiSpeechService
                     numzeros++;
                 }
                 // Now round it to 2sf
-                return minus + (Math.Round((double)value * 10) / (Math.Pow(10, numzeros + 2))).ToString();
+                return maybeMinus + (Math.Round((double)value * 10) / (Math.Pow(10, numzeros + 2))).ToString();
+            }
+
+            (int number, int nextDigit) Normalize(decimal inputValue, long orderMultiplierVal)
+            {
+                return (
+                    number: (int)(inputValue / orderMultiplierVal),
+                    nextDigit: (int)((inputValue % orderMultiplierVal) / ((decimal)orderMultiplierVal / 10))
+                );
             }
 
             int number;
             int nextDigit;
             string order;
-            int digits = (int)Math.Log10((double)value);
-            if (digits < 3)
+            long orderMultiplier = 1;
+            int magnitude = (int)Math.Log10((double)value);
+            if (magnitude < 3)
             {
                 // Units
-                number = (int)value;
                 order = "";
-                nextDigit = (int)((value - number) * 10);
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
-            else if (digits < 6)
+            else if (magnitude < 6)
             {
                 // Thousands
-                number = (int)(value / 1E3M);
                 order = " " + Properties.Phrases.thousand;
-                nextDigit = (int)((value - (number * 1E3M)) / 1E2M);
+                orderMultiplier = (long)1E3;
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
-            else if (digits < 9)
+            else if (magnitude < 9)
             {
                 // Millions
-                number = (int)(value / 1E6M);
                 order = " " + Properties.Phrases.million;
-                nextDigit = (int)((value - (number * 1E6M)) / 1E5M);
+                orderMultiplier = (long)1E6;
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
-            else if (digits < 12)
+            else if (magnitude < 12)
             {
                 // Billions
-                number = (int)(value / 1E9M);
                 order = " " + Properties.Phrases.billion;
-                nextDigit = (int)((value - (number * 1E9M)) / 1E8M);
+                orderMultiplier = (long)1E9;
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
-            else if (digits < 15)
+            else if (magnitude < 15)
             {
                 // Trillions
-                number = (int)(value / 1E12M);
                 order = " " + Properties.Phrases.trillion;
-                nextDigit = (int)((value - (number * 1E12M)) / 1E11M);
+                orderMultiplier = (long)1E12;
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
             else
             {
                 // Quadrillions
-                number = (int)(value / 1E15M);
                 order = " " + Properties.Phrases.quadrillion;
-                nextDigit = (int)((value - (number * 1E15M)) / 1E14M);
+                orderMultiplier = (long)1E15M;
+                (number, nextDigit) = Normalize((decimal)value, orderMultiplier);
             }
-
-            // See if we have an exact match
-            if (((long)(((decimal)value) / (decimal)Math.Pow(10, digits - 1))) * (decimal)(Math.Pow(10, digits - 1)) == value)
+            
+            // See if we have a whole number that is fully described within the largest order
+            if (number * orderMultiplier == value)
             {
-                return minus + number + order;
+                return maybeMinus + number + order;
             }
 
-            // Describe decimal values
             if (number < 100)
             {
+                // See if we have a number whose value can be expressed with a short description (i.e 1.3 million)
+                if (number + ((decimal)nextDigit / 10) == (decimal)value / orderMultiplier)
+                {
+                    return maybeMinus + (number + (decimal)nextDigit / 10) + order;
+                }
+
+                // Describe values for complex numbers where the largest order number does not exceed one hundred
                 string andahalf = " " + Properties.Phrases.andahalf;
                 switch (nextDigit)
                 {
                     case 0:
-                        return Properties.Phrases.justover + " " + minus + number + order;
+                        return Properties.Phrases.justover + " " + maybeMinus + number + order;
                     case 1:
                     case 2:
-                        return Properties.Phrases.over + " " + minus + number + order;
+                        return Properties.Phrases.over + " " + maybeMinus + number + order;
                     case 3:
-                        return Properties.Phrases.wellover + " " + minus + number + order;
+                        return Properties.Phrases.wellover + " " + maybeMinus + number + order;
                     case 4:
-                        return Properties.Phrases.nearly + " " + minus + number + andahalf + order;
+                        return Properties.Phrases.nearly + " " + maybeMinus + number + andahalf + order;
                     case 5:
-                        return Properties.Phrases.around + " " + minus + number + andahalf + order;
+                        return Properties.Phrases.around + " " + maybeMinus + number + andahalf + order;
                     case 6:
                     case 7:
-                        return Properties.Phrases.over + " " + minus + number + andahalf + order;
+                        return Properties.Phrases.over + " " + maybeMinus + number + andahalf + order;
                     case 8:
-                        return Properties.Phrases.wellover + " " + minus + number + andahalf + order;
+                        return Properties.Phrases.wellover + " " + maybeMinus + number + andahalf + order;
                     case 9:
-                        return Properties.Phrases.nearly + " " + minus + (number + 1) + order;
+                        return Properties.Phrases.nearly + " " + maybeMinus + (number + 1) + order;
                 }
             }
-            // Describe (less precisely) decimal values for more complex numbers    
+            // Describe (less precisely) values for complex numbers where the largest order number exceeds one hundred
             else
             {
                 if (nextDigit < 2)
                 {
-                    return Properties.Phrases.justover + " " + minus + number + order;
+                    return Properties.Phrases.justover + " " + maybeMinus + number + order;
                 }
                 else if (nextDigit < 6)
                 {
-                    return Properties.Phrases.over + " " + minus + number + order;
+                    return Properties.Phrases.over + " " + maybeMinus + number + order;
                 }
                 else if (nextDigit < 8)
                 {
-                    return Properties.Phrases.wellover + " " + minus + number + order;
+                    return Properties.Phrases.wellover + " " + maybeMinus + number + order;
                 }
                 else if (nextDigit < 10)
                 {
-                    return Properties.Phrases.nearly + " " + minus + (number + 1) + order;
+                    return Properties.Phrases.nearly + " " + maybeMinus + (number + 1) + order;
                 }
             }
-            return Properties.Phrases.around + " " + minus + number + order;
+            return Properties.Phrases.around + " " + maybeMinus + number + order;
         }
     }
 }

--- a/SpeechService/Translations.cs
+++ b/SpeechService/Translations.cs
@@ -825,8 +825,10 @@ namespace EddiSpeechService
                 switch (nextDigit)
                 {
                     case 0:
-                        return Properties.Phrases.justover + " " + maybeMinus + number + order;
+                        // the figure we are saying is round enough already
+                        return maybeMinus + number + order;
                     case 1:
+                        return Properties.Phrases.justover + " " + maybeMinus + number + order;
                     case 2:
                         return Properties.Phrases.over + " " + maybeMinus + number + order;
                     case 3:
@@ -847,17 +849,25 @@ namespace EddiSpeechService
             // Describe (less precisely) values for complex numbers where the largest order number exceeds one hundred
             else
             {
-                if (nextDigit < 2)
+                // Round largest order numbers in the hundreds to the nearest 10, except where the number after the hundreds place is 20 or less
+                if (number - (int)((decimal)number/100) * 100 >= 20)
+                {
+                    (number, nextDigit) = Normalize(number, 10);
+                    number *= 10;
+                }
+                
+                if (nextDigit == 0)
+                {
+                    // the figure we are saying is round enough already
+                    return maybeMinus + number + order;
+                }
+                else if (nextDigit < 2)
                 {
                     return Properties.Phrases.justover + " " + maybeMinus + number + order;
                 }
-                else if (nextDigit < 6)
+                else if (nextDigit < 7)
                 {
                     return Properties.Phrases.over + " " + maybeMinus + number + order;
-                }
-                else if (nextDigit < 8)
-                {
-                    return Properties.Phrases.wellover + " " + maybeMinus + number + order;
                 }
                 else if (nextDigit < 10)
                 {

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -357,7 +357,7 @@ namespace UnitTests
         [TestMethod]
         public void TestSpeechHumanize14()
         {
-            Assert.AreEqual("over minus 12", Translations.Humanize(-12.1M));
+            Assert.AreEqual("minus 12.1", Translations.Humanize(-12.1M));
         }
 
         [TestMethod]

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -321,7 +321,7 @@ namespace UnitTests
         [TestMethod]
         public void TestSpeechHumanize8()
         {
-            Assert.AreEqual("just over 51 million", Translations.Humanize(51000001));
+            Assert.AreEqual("51 million", Translations.Humanize(51000001));
         }
 
         [TestMethod]
@@ -400,6 +400,12 @@ namespace UnitTests
         public void TestSpeechHumanize21()
         {
             Assert.AreEqual("1.8 million", Translations.Humanize(1.8E6M));
+        }
+
+        [TestMethod]
+        public void TestSpeechHumanize22()
+        {
+            Assert.AreEqual("1.8 million", Translations.Humanize(1800001));
         }
 
         [TestMethod]

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -391,6 +391,18 @@ namespace UnitTests
         }
 
         [TestMethod]
+        public void TestSpeechHumanize20()
+        {
+            Assert.AreEqual("456", Translations.Humanize(456));
+        }
+
+        [TestMethod]
+        public void TestSpeechHumanize21()
+        {
+            Assert.AreEqual("1.8 million", Translations.Humanize(1.8E6M));
+        }
+
+        [TestMethod]
         public void TestTranslationVesper()
         {
             Assert.AreEqual(Translations.GetTranslation("VESPER-M4"), "Vesper M 4");

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -363,19 +363,19 @@ namespace UnitTests
         [TestMethod]
         public void TestSpeechHumanize15()
         {
-            Assert.AreEqual("just over minus 12", Translations.Humanize(-12.01M));
+            Assert.AreEqual("minus 12", Translations.Humanize(-12.01M));
         }
 
         [TestMethod]
         public void TestSpeechHumanize16()
         {
-            Assert.AreEqual("just over 436 trillion", Translations.Humanize(4.36156E14M));
+            Assert.AreEqual("over 430 trillion", Translations.Humanize(4.36156E14M));
         }
 
         [TestMethod]
         public void TestSpeechHumanize17()
         {
-            Assert.AreEqual("well over 945 billion", Translations.Humanize(9.4571E11M));
+            Assert.AreEqual("over 940 billion", Translations.Humanize(9.4571E11M));
         }
 
         [TestMethod]
@@ -387,7 +387,7 @@ namespace UnitTests
         [TestMethod]
         public void TestSpeechHumanize19()
         {
-            Assert.AreEqual("nearly 646 thousand", Translations.Humanize(6.459E5M));
+            Assert.AreEqual("over 640 thousand", Translations.Humanize(6.459E5M));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #2000.
Proposing this also as an alternative to PR #1928 to reduce verbosity and resolve #1927. @intelfx 

- Revises the algorithm to prevent certain numbers from returning inaccurate as discussed in #2000 
- Returns short decimal values where those values are able to accurately and succinctly describe the number (preferring something like `1.8 million` to something like `well over 1 and a half million`).
- Rounds largest order numbers in the hundreds to the nearest 10, except where the number after the hundreds place is 20 or less, to further reduce verbosity. As discussed in #1928 comments.

Inspired from PR #1928:
- Implements a "Normalize" local function to standardize "number" and "nextDigit" calculations.
- Revises "minus" to "maybeMinus" for better code clarity.
