### PR TITLE
Fix SSML exception for faction named "Brazilian Armada X"

### DIFF
--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -472,49 +472,49 @@ namespace EddiSpeechService
             string result = text;
 
             // We need to make sure file names for the play function include a "/" (e.g. C:/)
-            result = Regex.Replace(result, "(<.+?src=\")(.:)(.*?" + @"\/>)", "$1" + "$2SSSSS" + "$3");
+            result = Regex.Replace(result, "(<.+?src=\")(.:)(.*?" + @"\/>)", "$1" + "$2%SSS%" + "$3");
 
             // Our valid SSML elements are audio, break, emphasis, play, phoneme, & prosody so encode these differently for now
             // Also escape any double quotes or single quotes inside the elements
-            result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\"", "$1ZZZZZ");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
-            result = Regex.Replace(result, "(<[^>]*)\'", "$1WWWWW");
-            result = Regex.Replace(result, "<(audio.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(break.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(play.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(phoneme.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/phoneme)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(prosody.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/prosody)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(emphasis.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/emphasis)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(transmit.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/transmit)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(voice.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/voice)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(say-as.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/say-as)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "(<[^>]*)\"", "$1%ZZZ%");
+            result = Regex.Replace(result, "(<[^>]*)\"", "$1%ZZZ%");
+            result = Regex.Replace(result, "(<[^>]*)\"", "$1%ZZZ%");
+            result = Regex.Replace(result, "(<[^>]*)\"", "$1%ZZZ%");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1%WWW%");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1%WWW%");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1%WWW%");
+            result = Regex.Replace(result, "(<[^>]*)\'", "$1%WWW%");
+            result = Regex.Replace(result, "<(audio.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(break.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(play.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(phoneme.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/phoneme)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(prosody.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/prosody)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(emphasis.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/emphasis)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(transmit.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/transmit)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(voice.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/voice)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(say-as.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/say-as)>", "%XXX%$1%YYY%");
 
             // Cereproc uses some additional custom SSML tags (documented in https://www.cereproc.com/files/CereVoiceCloudGuide.pdf)
-            result = Regex.Replace(result, "<(usel.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/usel)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(spurt.*?)>", "XXXXX$1YYYYY");
-            result = Regex.Replace(result, "<(/spurt)>", "XXXXX$1YYYYY");
+            result = Regex.Replace(result, "<(usel.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/usel)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(spurt.*?)>", "%XXX%$1%YYY%");
+            result = Regex.Replace(result, "<(/spurt)>", "%XXX%$1%YYY%");
 
             // Now escape anything that is still present
             result = SecurityElement.Escape(result) ?? "";
 
             // Put back the characters we hid
-            result = Regex.Replace(result, "XXXXX", "<");
-            result = Regex.Replace(result, "YYYYY", ">");
-            result = Regex.Replace(result, "ZZZZZ", "\"");
-            result = Regex.Replace(result, "WWWWW", "\'");
-            result = Regex.Replace(result, "SSSSS", @"\");
+            result = Regex.Replace(result, "%XXX%", "<");
+            result = Regex.Replace(result, "%YYY%", ">");
+            result = Regex.Replace(result, "%ZZZ%", "\"");
+            result = Regex.Replace(result, "%WWW%", "\'");
+            result = Regex.Replace(result, "%SSS%", @"\");
             return result;
         }
 


### PR DESCRIPTION
Resolves #2015 (transposition of characters during SSML escaping leading to invalid SSML).
Uses a more complex string to escape valid SSML elements. We are choosing to use the `%` characer because it is preserved when escaping reserved SSML characters and is interpreted literally with Regex.