### PR TITLE
Fix failing Inara / EDSM sync on closing or stopping

### DIFF
--- a/EddiInaraService/IInaraService.cs
+++ b/EddiInaraService/IInaraService.cs
@@ -11,7 +11,7 @@ namespace EddiInaraService
 
         // API Event Queue Management
         void EnqueueAPIEvent(InaraAPIEvent inaraAPIEvent);
-        List<InaraResponse> SendEventBatch(List<InaraAPIEvent> events, InaraConfiguration inaraConfiguration = null, bool eddiIsBeta = false);
+        List<InaraResponse> SendEventBatch(List<InaraAPIEvent> events, InaraConfiguration inaraConfiguration = null);
 
         // Commander Profiles
         InaraCmdr GetCommanderProfile(string cmdrName);


### PR DESCRIPTION
Revise Inara and EDSM sync so that if services are stopped, the final sync no longer occurs on a canceled thread.
Removed an unnecessary while() loop by moving `GetConsumingEnumerable` into the top level sync method.
Extended default sync interval for EDSM from 10 seconds to 1 minute.
Resolves #1965.