### PR TITLE
Fix stacked missions not all updating

### DIFF
--- a/DataDefinitions/MissionStatus.cs
+++ b/DataDefinitions/MissionStatus.cs
@@ -14,9 +14,9 @@ namespace EddiDataDefinitions
             resourceManager.IgnoreCase = false;
 
             var Active = new MissionStatus("Active", 0);
-            var Complete = new MissionStatus("Complete", 1);
-            var Failed = new MissionStatus("Failed", 2);
-            var Claim = new MissionStatus("Claim", 3);
+            var Complete = new MissionStatus("Complete", 1); // Missions where a `MissionCompleted` event has been written and which are pending removal from the missions log. 
+            var Failed = new MissionStatus("Failed", 2); // Missions where a `MissionFailed` or `MissionAbandoned` event has been written and which are pending removal from the missions log.
+            var Claim = new MissionStatus("Claim", 3); // The requirements have been satisfied and any timer has been set to zero. Rewards have yet to be claimed.
         }
 
         public int status { get; private set; }


### PR DESCRIPTION
Fixes #2018.
- If there are multiple events with the same timestamp, the mission monitor will no longer process the first and ignore the remainder.
- Revises all missions to use the `Claim` status (rather than using `Complete` in some instances) after conditions are satisfied and before they are claimed. `Complete` status is now reserved for the `MissionComplete` event.