### PR TITLE
Don't disable all SSML tags when a user chooses to disable phonetic speech.

### DIFF
--- a/EDDI/MainWindow.xaml
+++ b/EDDI/MainWindow.xaml
@@ -317,8 +317,7 @@
                         <TextBlock Grid.Column="0" Grid.Row="8" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_phonetic_speech_desc}" />
                         <Label x:Name="disableSsmltLabel" VerticalAlignment="Top" Grid.Column="0" Grid.Row="9" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_disable_phonetic_speech_label}" />
                         <DockPanel Grid.Column="1" Grid.Row="9" Margin="0, 5">
-                            <CheckBox Grid.Column="1" x:Name="disableSsmlCheckbox" Margin="5" VerticalAlignment="Top" Checked="disableSsmlUpdated" Unchecked="disableSsmlUpdated"/>
-                            <TextBlock Margin="5" HorizontalAlignment="Stretch" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_disable_phonetic_speech_note}" />
+                            <CheckBox Grid.Column="1" x:Name="DisableIpaCheckbox" Margin="5" VerticalAlignment="Top" Checked="disableIpaUpdated" Unchecked="disableIpaUpdated"/>
                         </DockPanel>
                         <TextBlock Grid.Column="0" Grid.Row="10" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:MainWindow.tab_tts_icao_desc}" />
                         <Label x:Name="enableIcaoLabel" Grid.Column="0" Grid.Row="11" Margin="0, 5" Content="{x:Static resx:MainWindow.tab_tts_icao_label}" />

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -434,7 +434,7 @@ namespace Eddi
             ttsRateSlider.Value = speechServiceConfiguration.Rate;
             ttsEffectsLevelSlider.Value = speechServiceConfiguration.EffectsLevel;
             ttsDistortCheckbox.IsChecked = speechServiceConfiguration.DistortOnDamage;
-            disableSsmlCheckbox.IsChecked = speechServiceConfiguration.DisableSsml;
+            DisableIpaCheckbox.IsChecked = speechServiceConfiguration.DisableIpa;
             enableIcaoCheckbox.IsChecked = speechServiceConfiguration.EnableIcao;
 
             ttsTestShipDropDown.ItemsSource = ShipDefinitions.ShipModels; // already sorted
@@ -1073,7 +1073,7 @@ namespace Eddi
             SpeechService.Instance.Say(testShip, message, 0);
         }
 
-        private void disableSsmlUpdated(object sender, RoutedEventArgs e)
+        private void disableIpaUpdated(object sender, RoutedEventArgs e)
         {
             ttsUpdated();
         }
@@ -1095,7 +1095,7 @@ namespace Eddi
                 Rate = (int)ttsRateSlider.Value,
                 EffectsLevel = (int)ttsEffectsLevelSlider.Value,
                 DistortOnDamage = ttsDistortCheckbox.IsChecked.Value,
-                DisableSsml = disableSsmlCheckbox.IsChecked.Value,
+                DisableIpa = DisableIpaCheckbox.IsChecked.Value,
                 EnableIcao = enableIcaoCheckbox.IsChecked.Value
             };
             SpeechService.Instance.Configuration = speechConfiguration;

--- a/EDDI/Properties/MainWindow.Designer.cs
+++ b/EDDI/Properties/MainWindow.Designer.cs
@@ -403,15 +403,6 @@ namespace Eddi.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (this will disable all functions using SSML speech tags, as noted in the Speech Responder&apos;s Help file).
-        /// </summary>
-        public static string tab_tts_disable_phonetic_speech_note {
-            get {
-                return ResourceManager.GetString("tab_tts_disable_phonetic_speech_note", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Distort the voice on ship damage:.
         /// </summary>
         public static string tab_tts_distort_label {

--- a/EDDI/Properties/MainWindow.de.resx
+++ b/EDDI/Properties/MainWindow.de.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Phonetische Sprache deaktivieren:</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(Dies deaktiviert alle Funktionen mit SSML-Sprach-Tags, wie in der Hilfedatei unter der Reiterkarte "_Sprachausgabe auf Ereignisse" angegeben.)</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI kann die Aussprache laut ICAO verwenden, zum Beispiel "alpha" statt "A", wenn man Stern- und Körpernamen sagt. Dies kann das Verständnis der Systemnamen erleichtern, dauert jedoch länger. Wenn Sie die ICAO-Aussprache hören möchten, aktivieren Sie die Option unten. Beachten Sie, dass dies nicht funktioniert, wenn Sie die phonetische Sprache oben deaktiviert haben.</value>

--- a/EDDI/Properties/MainWindow.es.resx
+++ b/EDDI/Properties/MainWindow.es.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Desactivar el lenguaje fonético:</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(Desactivará las funciones que utilicen tags SSML, como se indica en la ayuda del 'Asistente Vocal')</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI puede usar OACI, por ejemplo, usando 'alfa' en lugar de 'A', cuando dice nombres de estrellas y cuerpos. Esto puede facilitar la comprensión de los nombres del sistema, pero lleva más tiempo pronunciarlo. Si desea escuchar las pronunciaciones de la OACI, marque esta opción. Tenga en cuenta que no funcionará si ha deshabilitado la opción anterior de habla fonética.</value>

--- a/EDDI/Properties/MainWindow.fr.resx
+++ b/EDDI/Properties/MainWindow.fr.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Désactiver le langage phonétique :</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(Ceci désactivera toutes les fonctions utilisant les tags SSML, comme décrit dans le fichier d'aide du répondeur de dialogue)</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI peut utiliser l'ICAO, par exemple utiliser 'alpha' plutôt que 'A' pour nommer le noms des étoile ou des astres. Cela facilite la compréhension des noms de systèmes mais les rend plus long à prononcer. Pour utiliser ce type de prononciation, veuillez cochez l'option ci-dessous. À noter que cela ne fonctionnera pas si vous avez désactivé le langage phonétique.</value>

--- a/EDDI/Properties/MainWindow.hu.resx
+++ b/EDDI/Properties/MainWindow.hu.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -123,12 +123,9 @@
   <data name="EDDI_status_label" xml:space="preserve">
     <value>EDDI státusz: </value>
   </data>
-  
-  
   <data name="paragraph_2" xml:space="preserve">
     <value>A második csoport megszerzi az események információit. Ezek a fülek a amelyek Monitorral végződnek. Ezek megszerzik az eseményeket különböző helyekről és némi konfigurációt igényelnek mielőtt használhatóak lesznek.</value>
   </data>
-  
   <data name="paragraph_4" xml:space="preserve">
     <value>További információkat olvashat az EDDI funkcióriól a</value>
   </data>
@@ -139,8 +136,6 @@
     <value>Általános problémák megoldása</value>
     <comment>A hyperlink to the troubleshooting URL (in english)</comment>
   </data>
-  
-  
   <data name="version_hyperlink" xml:space="preserve">
     <value>Verzió:</value>
   </data>
@@ -150,11 +145,9 @@
   <data name="choose_lang_label" xml:space="preserve">
     <value>EDDI felület nyelve (EDDI újraindítása szükséges):</value>
   </data>
-  
   <data name="tab_frontier_header" xml:space="preserve">
     <value>Frontier API</value>
   </data>
-  
   <data name="tab_tts_desc" xml:space="preserve">
     <value>Az EDDI egy szöveg felovasó motort használ, ami feldolgozza a hangot a hajó sérülési állapotának és pilótafülkéjének méretéhez megfelelően. Ennek paramétereit itt állíthatja be.</value>
   </data>
@@ -167,7 +160,6 @@
   <data name="tab_tts_level_label" xml:space="preserve">
     <value>Hangfeldolgozás szintje:</value>
   </data>
-  
   <data name="tab_tts_rate_label" xml:space="preserve">
     <value>Beszéd sebessége:</value>
   </data>
@@ -189,20 +181,12 @@
   <data name="upgrade_button" xml:space="preserve">
     <value>EDDI frissítése</value>
   </data>
-  
-  
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Fonetikus beszéd kikapcsolása:</value>
   </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(ez kikapcsolja az összes SSML beszéd címkét használó funkciót, ahogy az a Speech Responder segítség fájljában is megtalálható)</value>
-  </data>
-  
   <data name="tab_tts_icao_label" xml:space="preserve">
     <value>ICAO engedélyezése:</value>
   </data>
-  
-  
   <data name="tab_commander_gender_f" xml:space="preserve">
     <value>Nő</value>
   </data>
@@ -212,22 +196,4 @@
   <data name="tab_commander_gender_n" xml:space="preserve">
     <value>Egyik sem</value>
   </data>
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
 </root>

--- a/EDDI/Properties/MainWindow.it.resx
+++ b/EDDI/Properties/MainWindow.it.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Disabilita Dizione Fonetica:</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(questo disabiliterà ogni funzione che utilizzi le schede di pronuncia SSML, come specificato nel file di Aiuto Sintesi Vocale)</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI è in grado di utilizzare ICAO, ad esempio utilizzando 'alfa' al posto di 'a', quando pronuncia i nomi di stelle o corpi celesti. Questo potrebbe rendere più facile comprendere i suddetti nomi, ma renderà la dizione considerevolmente più lunga. Per sentire la pronuncia ICAO selezionare l'opzione qui sotto. Notare che essa non funzionerà se la Dizione Fonetica è stata disabilitata.</value>

--- a/EDDI/Properties/MainWindow.ja.resx
+++ b/EDDI/Properties/MainWindow.ja.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>フォネティック・コードによる読み上げを無効化:</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(Speech Responderのヘルプに記載された、音声合成マークアップ言語(SSML)機能を全て無効化します。)</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDIは、星系名や惑星名の読み上げに、ICAO発音(例:「A」を「アルファ」と発音)を使用可能です。これにより、星系名を理解しやすくなりますが、読み上げには時間が必要です。ICAO発音を使用するには、下記にチェックしてください。フォネティック・コードによる読み上げを無効化している場合、この設定は機能しません。</value>

--- a/EDDI/Properties/MainWindow.pt-BR.resx
+++ b/EDDI/Properties/MainWindow.pt-BR.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -213,9 +213,6 @@
   </data>
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Desabilitar pronúncia fonética:</value>
-  </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(isso desligará as funções usando tags de voz SSML, como visto no arquivo de Ajuda do Relator de Fala)</value>
   </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>O EDDI pode usar ICAO, por exemplo, usando 'alfa' em vez de 'A', ao dizer nomes de estrela e corpos. Isso pode facilitar a compreensão dos nomes do sistema, mas demora mais para ser pronunciado. Se você quiser ouvir pronunciações ICAO, marque a opção abaixo. Note que isso não funcionará se você tiver desativado a fala fonética acima.</value>

--- a/EDDI/Properties/MainWindow.resx
+++ b/EDDI/Properties/MainWindow.resx
@@ -214,9 +214,6 @@
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Disable phonetic speech:</value>
   </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(this will disable all functions using SSML speech tags, as noted in the Speech Responder's Help file)</value>
-  </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI can use ICAO, for example using 'alpha' rather than 'A', when saying star and body names. This can make it easier to understand system names, but does take longer to pronounce. If you want to hear ICAO pronunciations then check the option below. Note that this will not work if you have disabled phonetic speech above.</value>
   </data>

--- a/EDDI/Properties/MainWindow.ru.resx
+++ b/EDDI/Properties/MainWindow.ru.resx
@@ -60,45 +60,45 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -214,9 +214,6 @@
   <data name="tab_tts_disable_phonetic_speech_label" xml:space="preserve">
     <value>Отключить фонетическую речь:</value>
   </data>
-  <data name="tab_tts_disable_phonetic_speech_note" xml:space="preserve">
-    <value>(отключит все функции, использующие речевые теги SSML, как отмечено в файле справки речевого респондента)</value>
-  </data>
   <data name="tab_tts_icao_desc" xml:space="preserve">
     <value>EDDI может использовать ICAO, например, произносить «альфа», а не «А», когда произносит имена звезд и тел. Это может облегчить понимание сложных системных имен, но для произнесения требуется больше времени. Если вы хотите услышать произношение ICAO, включите опцию ниже. Обратите внимание, что функция не будет работать, если вы отключили фонетическую речь выше.</value>
   </data>
@@ -271,11 +268,4 @@
   <data name="no_station" xml:space="preserve">
     <value>Станций нет</value>
   </data>
-  
-  
-  
-  
-  
-  
-  
 </root>

--- a/SpeechResponder/CustomFunctions/Spacialise.cs
+++ b/SpeechResponder/CustomFunctions/Spacialise.cs
@@ -14,25 +14,7 @@ namespace EddiSpeechResponder.CustomFunctions
         public NativeFunction function => new NativeFunction((values) =>
         {
             if (values[0].AsString == null) { return ""; }
-
-            bool useSSML = !SpeechServiceConfiguration.FromFile().DisableSsml;
-            if (useSSML)
-            {
-                return Translations.sayAsLettersOrNumbers(values[0].AsString);
-            }
-            else
-            {
-                string Entree = values[0].AsString;
-                if (Entree == "")
-                { return ""; }
-                string Sortie = "";
-                foreach (char c in Entree)
-                {
-                    Sortie = Sortie + c + " ";
-                }
-                var UpperSortie = Sortie.ToUpper();
-                return UpperSortie.Trim();
-            }
+            return Translations.sayAsLettersOrNumbers(values[0].AsString);
         }, 1);
     }
 }

--- a/SpeechResponder/ScriptResolverService/ScriptResolver.cs
+++ b/SpeechResponder/ScriptResolverService/ScriptResolver.cs
@@ -160,7 +160,7 @@ namespace EddiSpeechResponder.Service
                 ["va_active"] = App.FromVA,
                 ["vehicle"] = EDDI.Instance.Vehicle,
                 ["icao_active"] = SpeechService.Instance.Configuration.EnableIcao,
-                ["ssml_active"] = !SpeechService.Instance.Configuration.DisableSsml,
+                ["ipa_active"] = !SpeechService.Instance.Configuration.DisableIpa,
             };
 
             // Boolean constants

--- a/SpeechResponder/Variables.md
+++ b/SpeechResponder/Variables.md
@@ -20,7 +20,7 @@ Information on game state is available at the top level i.e. these values can be
 
     - `capi_active` true when the companion API is active
     - `icao_active` true if ICAO is currently enabled
-    - `ssml_active` true if ssml tags are currently enabled
+    - `ipa_active` true if phonetic speech ssml tags are currently enabled
     - `va_active` true when the Voice Attack plug-in is active
 
 ---

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -165,10 +165,7 @@ namespace EddiSpeechService
             // If the user wants to disable IPA then we remove any IPA phoneme tags here
             if (Configuration.DisableIpa && speech.Contains("<phoneme"))
             {
-                // User has disabled IPA so remove all IPA phoneme tags
-                Logging.Debug("Phonetic speech is disabled, removing.");
-                speech = Regex.Replace(speech, @"<phoneme.*?>", string.Empty);
-                speech = Regex.Replace(speech, @"<\/phoneme>", string.Empty);
+                speech = DisableIPA(speech);
             }
 
             if (string.IsNullOrWhiteSpace(voice))
@@ -231,6 +228,15 @@ namespace EddiSpeechService
                     play(source, priority);
                 }
             }
+        }
+
+        private static string DisableIPA(string speech)
+        {
+            // User has disabled IPA so remove all IPA phoneme tags
+            Logging.Debug("Phonetic speech is disabled, removing.");
+            speech = Regex.Replace(speech, @"<phoneme.*?>", string.Empty);
+            speech = Regex.Replace(speech, @"<\/phoneme>", string.Empty);
+            return speech;
         }
 
         private static List<string> SeparateSpeechStatements(string speech, string separators)

--- a/SpeechService/SpeechService.cs
+++ b/SpeechService/SpeechService.cs
@@ -162,12 +162,13 @@ namespace EddiSpeechService
         {
             if (speech == null || speech.Trim() == "") { return; }
 
-            // If the user wants to disable SSML then we remove any tags here
-            if (Configuration.DisableSsml && (speech.Contains("<")))
+            // If the user wants to disable IPA then we remove any IPA phoneme tags here
+            if (Configuration.DisableIpa && speech.Contains("<phoneme"))
             {
-                Logging.Debug("Removing SSML");
-                // User has disabled SSML so remove all tags
-                speech = Regex.Replace(speech, "<.*?>", string.Empty);
+                // User has disabled IPA so remove all IPA phoneme tags
+                Logging.Debug("Phonetic speech is disabled, removing.");
+                speech = Regex.Replace(speech, @"<phoneme.*?>", string.Empty);
+                speech = Regex.Replace(speech, @"<\/phoneme>", string.Empty);
             }
 
             if (string.IsNullOrWhiteSpace(voice))

--- a/SpeechService/SpeechServiceConfiguration.cs
+++ b/SpeechService/SpeechServiceConfiguration.cs
@@ -25,8 +25,8 @@ namespace EddiSpeechService
         [JsonProperty("rate")]
         public int Rate { get; set; }
 
-        [JsonProperty("disablessml")]
-        public bool DisableSsml { get; set; }
+        [JsonProperty("disableipa")]
+        public bool DisableIpa { get; set; }
 
         [JsonProperty("enableicao")]
         public bool EnableIcao { get; set; }
@@ -54,6 +54,9 @@ namespace EddiSpeechService
                     string data = Files.Read(filename);
                     if (data != null)
                     {
+                        // Fix up legacy configuration data
+                        data = data.Replace("disablessml", "disableipa");
+
                         configuration = JsonConvert.DeserializeObject<SpeechServiceConfiguration>(data);
                     }
                 }
@@ -80,7 +83,7 @@ namespace EddiSpeechService
             Volume = 100;
             EffectsLevel = 50;
             DistortOnDamage = true;
-            DisableSsml = false;
+            DisableIpa = false;
             EnableIcao = false;
         }
 

--- a/Tests/SpeechUnitTests.cs
+++ b/Tests/SpeechUnitTests.cs
@@ -485,5 +485,17 @@ namespace UnitTests
             var result = SpeechService.escapeSsml(line);
             Assert.AreEqual(line, result);
         }
+
+        [TestMethod]
+        public void TestDisableIPA()
+        {
+            // Test removal of <phoneme> tags (and only phenome tags) when the user has indicated that they would like to disable phonetic speech
+            var line = @"<break time=""100ms""/><phoneme alphabet=""ipa"" ph=""ʃɪnˈrɑːrtə"">Shinrarta</phoneme> <phoneme alphabet='ipa' ph='ˈdezɦrə'>Dezhra</phoneme> & Co's shop";
+
+            var service = new PrivateType(typeof(SpeechService));
+            var result = service.InvokeStatic("DisableIPA", line)?.ToString();
+
+            Assert.AreEqual(@"<break time=""100ms""/>Shinrarta Dezhra & Co's shop", result);
+        }
     }
 }

--- a/VoiceAttackResponder/VoiceAttackVariables.cs
+++ b/VoiceAttackResponder/VoiceAttackVariables.cs
@@ -419,7 +419,7 @@ namespace EddiVoiceAttackResponder
             try
             {
                 vaProxy.SetBoolean("cAPI active", CompanionAppService.Instance?.active ?? false);
-                vaProxy.SetBoolean("ssml active", !(SpeechService.Instance?.Configuration.DisableSsml ?? false));
+                vaProxy.SetBoolean("ipa active", !(SpeechService.Instance?.Configuration.DisableIpa ?? false));
                 vaProxy.SetBoolean("icao active", SpeechService.Instance?.Configuration.EnableIcao ?? false);
                 vaProxy.SetText("Environment", EDDI.Instance.Environment);
                 vaProxy.SetText("Vehicle", EDDI.Instance.Vehicle);

--- a/docs/VoiceAttack-Integration.md
+++ b/docs/VoiceAttack-Integration.md
@@ -317,7 +317,7 @@ Note: "Tiny" hardpoints are utility slots.
   * {TXT:Vehicle}: the vehicle the commander is currently controlling ("Ship", "SRV" or "Fighter")
   * {BOOL:cAPI active}: true if the cAPI is currently active 
   * {BOOL:icao active}: true if use of ICAO text replacements are currently enabled 
-  * {BOOL:ssml active}: true if ssml tags are currently enabled
+  * {BOOL:ipa active}: true if phonetic speech ssml tags are currently enabled
   * {TXT:EDDI uri}: uri's for EDDB, EDShipyard, and EDSM are written here when the appropriate plugin command is invoked.
   * {BOOL:EDDI speaking}: true if EDDI is currently speaking
 


### PR DESCRIPTION
Resolves #2029.

Documents updated
- Variables.md => `ipa_active` WAS `ssml_active`
- VoiceAttack-Intragtion.md => `{BOOL:ipa active}` WAS `{BOOL:ssml active}`

Notes: 
- The original tickets were all connected to users editing their registry to unlock additional voices.
- I tested this branch to make sure that it did not crash under the original conditions that led to the SSML disabling option being added.
  - Microsoft Anna does not appear to have any problems.
  - Our SpeechService class does not permit Microsoft Server voices like the other voices referenced in the tickets. 
- Ref. https://github.com/cmdrmcdonald/EliteDangerousDataProvider/issues/39 
- Ref. https://github.com/cmdrmcdonald/EliteDangerousDataProvider/issues/36