### PR TITLE
Fix "Frontier API connection operational" dialog when cAPI token is refreshed

### DIFF
--- a/CompanionAppService/CompanionAppService.cs
+++ b/CompanionAppService/CompanionAppService.cs
@@ -43,6 +43,7 @@ namespace EddiCompanionAppService
             AwaitingCallback,
             Authorized,
             NoClientIDConfigured,
+            TokenRefresh,
         };
         private State _currentState;
         public State CurrentState
@@ -307,7 +308,7 @@ namespace EddiCompanionAppService
                 throw new EliteDangerousCompanionAppAuthenticationException("Refresh token not found, need full login");
             }
 
-            CurrentState = State.AwaitingCallback;
+            CurrentState = State.TokenRefresh;
             HttpWebRequest request = GetRequest(AUTH_SERVER + TOKEN_URL);
             request.ContentType = "application/x-www-form-urlencoded";
             request.Method = "POST";

--- a/EDDI/MainWindow.xaml.cs
+++ b/EDDI/MainWindow.xaml.cs
@@ -971,6 +971,7 @@ namespace Eddi
                     companionAppText.Text = Properties.EddiResources.frontier_api_please_authenticate;
                     break;
                 case CompanionAppService.State.Authorized:
+                case CompanionAppService.State.TokenRefresh:
                     companionAppStatusValue.Text = Properties.EddiResources.frontierApiConnected;
                     companionAppButton.Content = Properties.MainWindow.reset_button;
                     companionAppButton.IsEnabled = true;


### PR DESCRIPTION
Resolves #2028