### PR TITLE
Discard system signal sources when updating our current star system

### DIFF
--- a/EDDI/EDDI.cs
+++ b/EDDI/EDDI.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1655,6 +1656,12 @@ namespace EddiCore
         private void updateCurrentSystem(string name)
         {
             if (name == null || CurrentStarSystem?.systemname == name) { return; }
+
+            // Discard any signal sources from the current star system
+            if (CurrentStarSystem != null)
+            {
+                CurrentStarSystem.signalSources = ImmutableList<SignalSource>.Empty;
+            }
 
             // We have changed system so update the old one as to when we left
             StarSystemSqLiteRepository.Instance.LeaveStarSystem(CurrentStarSystem);


### PR DESCRIPTION
Prevents accumulating duplicate signal sources when re-logging.
Resolves #2074.