### PR TITLE
Fix broken link in wiki

### DIFF
--- a/SpeechResponder/Properties/CustomFunctions.Untranslated.Designer.cs
+++ b/SpeechResponder/Properties/CustomFunctions.Untranslated.Designer.cs
@@ -286,7 +286,7 @@ namespace EddiSpeechResponder.Properties {
         /// <summary>
         ///   Looks up a localized string similar to EDDI&apos;s Speech Responder uses [Cottle templating language](https://cottle.readthedocs.io/en/stable/) to generate verbal responses to various events.
         ///
-        ///Cottle&apos;s library is extended with several functions listed below ([detailed documentation](https://github.com/EDCD/EDDI/blob/beta/SpeechResponder/Help.md)):.
+        ///Cottle&apos;s library is extended with several functions listed below ([detailed documentation](https://github.com/EDCD/EDDI/wiki/Help)):.
         /// </summary>
         public static string FunctionsHeader {
             get {

--- a/SpeechResponder/Properties/CustomFunctions.Untranslated.resx
+++ b/SpeechResponder/Properties/CustomFunctions.Untranslated.resx
@@ -749,6 +749,6 @@ In addition to the basic Cottle features EDDI has a number of features that prov
   <data name="FunctionsHeader" xml:space="preserve">
     <value>EDDI's Speech Responder uses [Cottle templating language](https://cottle.readthedocs.io/en/stable/) to generate verbal responses to various events.
 
-Cottle's library is extended with several functions listed below ([detailed documentation](https://github.com/EDCD/EDDI/blob/beta/SpeechResponder/Help.md)):</value>
+Cottle's library is extended with several functions listed below ([detailed documentation](https://github.com/EDCD/EDDI/wiki/Help)):</value>
   </data>
 </root>


### PR DESCRIPTION
(Help.md is generated at build and is not linkable from source).
Resolves #2083.