### PR TITLE
Fix localization of fallback ship descriptions

### DIFF
--- a/DataDefinitions/EddiDataDefinitions.csproj
+++ b/DataDefinitions/EddiDataDefinitions.csproj
@@ -689,10 +689,18 @@
     <EmbeddedResource Include="Properties\SecurityLevels.pt-BR.resx" />
     <EmbeddedResource Include="Properties\SecurityLevels.ru.resx" />
     <EmbeddedResource Include="Properties\Ship.cs.resx" />
+    <EmbeddedResource Include="Properties\Ship.de.resx" />
+    <EmbeddedResource Include="Properties\Ship.es.resx" />
+    <EmbeddedResource Include="Properties\Ship.fr.resx" />
+    <EmbeddedResource Include="Properties\Ship.hu.resx" />
+    <EmbeddedResource Include="Properties\Ship.it.resx" />
+    <EmbeddedResource Include="Properties\Ship.ja.resx" />
+    <EmbeddedResource Include="Properties\Ship.pt-BR.resx" />
     <EmbeddedResource Include="Properties\Ship.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Ship.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Ship.ru.resx" />
     <EmbeddedResource Include="Properties\ShipRoles.cs.resx" />
     <EmbeddedResource Include="Properties\ShipRoles.pt-BR.resx" />
     <EmbeddedResource Include="Properties\ShipRoles.ru.resx" />

--- a/DataDefinitions/Properties/Ship.Designer.cs
+++ b/DataDefinitions/Properties/Ship.Designer.cs
@@ -77,5 +77,347 @@ namespace EddiDataDefinitions.Properties {
                 return ResourceManager.GetString("your", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAdder {
+            get {
+                return ResourceManager.GetString("yourAdder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAllChallenger {
+            get {
+                return ResourceManager.GetString("yourAllChallenger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAllChieftain {
+            get {
+                return ResourceManager.GetString("yourAllChieftain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAllCrusader {
+            get {
+                return ResourceManager.GetString("yourAllCrusader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAnaconda {
+            get {
+                return ResourceManager.GetString("yourAnaconda", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAspEx {
+            get {
+                return ResourceManager.GetString("yourAspEx", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourAspS {
+            get {
+                return ResourceManager.GetString("yourAspS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourBeluga {
+            get {
+                return ResourceManager.GetString("yourBeluga", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourCobraMkIII {
+            get {
+                return ResourceManager.GetString("yourCobraMkIII", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourCobraMkIV {
+            get {
+                return ResourceManager.GetString("yourCobraMkIV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourDBS {
+            get {
+                return ResourceManager.GetString("yourDBS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourDBX {
+            get {
+                return ResourceManager.GetString("yourDBX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourDolphin {
+            get {
+                return ResourceManager.GetString("yourDolphin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourEagle {
+            get {
+                return ResourceManager.GetString("yourEagle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourFDL {
+            get {
+                return ResourceManager.GetString("yourFDL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourFedAssaultShip {
+            get {
+                return ResourceManager.GetString("yourFedAssaultShip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourFedCorvette {
+            get {
+                return ResourceManager.GetString("yourFedCorvette", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourFedDropship {
+            get {
+                return ResourceManager.GetString("yourFedDropship", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourFedGunship {
+            get {
+                return ResourceManager.GetString("yourFedGunship", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourHauler {
+            get {
+                return ResourceManager.GetString("yourHauler", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourImpClipper {
+            get {
+                return ResourceManager.GetString("yourImpClipper", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourImpCourier {
+            get {
+                return ResourceManager.GetString("yourImpCourier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourImpCutter {
+            get {
+                return ResourceManager.GetString("yourImpCutter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourImpEagle {
+            get {
+                return ResourceManager.GetString("yourImpEagle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourKeelback {
+            get {
+                return ResourceManager.GetString("yourKeelback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourKraitMkII {
+            get {
+                return ResourceManager.GetString("yourKraitMkII", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourMamba {
+            get {
+                return ResourceManager.GetString("yourMamba", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourOrca {
+            get {
+                return ResourceManager.GetString("yourOrca", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourPhantom {
+            get {
+                return ResourceManager.GetString("yourPhantom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourPython {
+            get {
+                return ResourceManager.GetString("yourPython", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourSidewinder {
+            get {
+                return ResourceManager.GetString("yourSidewinder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourType10 {
+            get {
+                return ResourceManager.GetString("yourType10", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourType6 {
+            get {
+                return ResourceManager.GetString("yourType6", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourType7 {
+            get {
+                return ResourceManager.GetString("yourType7", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourType9 {
+            get {
+                return ResourceManager.GetString("yourType9", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourViperMkIII {
+            get {
+                return ResourceManager.GetString("yourViperMkIII", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourViperMkIV {
+            get {
+                return ResourceManager.GetString("yourViperMkIV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to your.
+        /// </summary>
+        public static string yourVulture {
+            get {
+                return ResourceManager.GetString("yourVulture", resourceCulture);
+            }
+        }
     }
 }

--- a/DataDefinitions/Properties/Ship.resx
+++ b/DataDefinitions/Properties/Ship.resx
@@ -99,8 +99,162 @@
   </resheader>
   <data name="your" xml:space="preserve">
     <value>your</value>
+    <comment>e.g. *your* ship</comment>
   </data>
   <data name="_ship" xml:space="preserve">
     <value>ship</value>
+    <comment>e.g. your *ship*</comment>
+  </data>
+  <data name="yourAdder" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Adder</comment>
+  </data>
+  <data name="yourAnaconda" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Anaconda</comment>
+  </data>
+  <data name="yourAspEx" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Asp Explorer</comment>
+  </data>
+  <data name="yourAspS" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Asp Scout</comment>
+  </data>
+  <data name="yourBeluga" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Beluga</comment>
+  </data>
+  <data name="yourCobraMkIII" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Cobra Mk. III</comment>
+  </data>
+  <data name="yourCobraMkIV" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Cobra Mk. IV</comment>
+  </data>
+  <data name="yourDBX" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Diamondback Explorer</comment>
+  </data>
+  <data name="yourDBS" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Diamondback Scout</comment>
+  </data>
+  <data name="yourDolphin" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Dolphin</comment>
+  </data>
+  <data name="yourEagle" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Eagle</comment>
+  </data>
+  <data name="yourFedAssaultShip" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Federal Assault Ship</comment>
+  </data>
+  <data name="yourFedCorvette" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Federal Corvette</comment>
+  </data>
+  <data name="yourFedDropship" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Federal Dropship</comment>
+  </data>
+  <data name="yourFedGunship" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Federal Gunship</comment>
+  </data>
+  <data name="yourFDL" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Fer-de-Lance</comment>
+  </data>
+  <data name="yourImpClipper" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Imperial Clipper</comment>
+  </data>
+  <data name="yourImpCourier" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Imperial Courier</comment>
+  </data>
+  <data name="yourImpCutter" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Imperial Cutter</comment>
+  </data>
+  <data name="yourImpEagle" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Imperial Eagle</comment>
+  </data>
+  <data name="yourHauler" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Hauler</comment>
+  </data>
+  <data name="yourKeelback" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Keelback</comment>
+  </data>
+  <data name="yourOrca" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Orca</comment>
+  </data>
+  <data name="yourPython" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Python</comment>
+  </data>
+  <data name="yourSidewinder" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Sidewinder</comment>
+  </data>
+  <data name="yourType6" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Type-6 Transporter</comment>
+  </data>
+  <data name="yourType7" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Type-7 Transporter</comment>
+  </data>
+  <data name="yourType9" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Type-9 Heavy</comment>
+  </data>
+  <data name="yourViperMkIII" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Viper Mk. III</comment>
+  </data>
+  <data name="yourViperMkIV" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Viper Mk. IV</comment>
+  </data>
+  <data name="yourVulture" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Vulture</comment>
+  </data>
+  <data name="yourType10" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Type-10 Defender</comment>
+  </data>
+  <data name="yourAllChieftain" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Alliance Chieftain</comment>
+  </data>
+  <data name="yourAllCrusader" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Alliance Crusader</comment>
+  </data>
+  <data name="yourAllChallenger" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Alliance Challenger</comment>
+  </data>
+  <data name="yourKraitMkII" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Krait Mk. II</comment>
+  </data>
+  <data name="yourPhantom" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Krait Phantom</comment>
+  </data>
+  <data name="yourMamba" xml:space="preserve">
+    <value>your</value>
+    <comment>e.g. *your* Mamba</comment>
   </data>
 </root>

--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -360,6 +360,8 @@ namespace EddiDataDefinitions
         public long EDID { get; set; }
         // The name in Elite: Dangerous' database
         public string EDName { get; set; }
+        [JsonIgnore]
+        internal string possessiveYour { get; set; }
 
         public Ship()
         {
@@ -378,12 +380,13 @@ namespace EddiDataDefinitions
             cargohatch = new Module();
         }
 
-        public Ship(long EDID, string EDName, string Manufacturer, string Model, List<Translation> PhoneticModel, LandingPadSize Size, int? MilitarySize, decimal reservoirFuelTankSize)
+        public Ship(long EDID, string EDName, string Manufacturer, string Model, string possessiveYour, List<Translation> PhoneticModel, LandingPadSize Size, int? MilitarySize, decimal reservoirFuelTankSize)
         {
             this.EDID = EDID;
             this.EDName = EDName;
             manufacturer = Manufacturer;
             model = Model;
+            this.possessiveYour = possessiveYour;
             phoneticModel = PhoneticModel;
             this.Size = Size;
             militarysize = MilitarySize;
@@ -422,8 +425,7 @@ namespace EddiDataDefinitions
             }
             else
             {
-                string ship = (defaultname ?? phoneticmodel) ?? Properties.Ship._ship;
-                result = Properties.Ship.your + " " + ship;
+                result = $"{possessiveYour ?? Properties.Ship.your} {(defaultname ?? phoneticmodel) ?? Properties.Ship._ship}";
             }
             return result;
         }
@@ -523,6 +525,7 @@ namespace EddiDataDefinitions
                 EDID = template.EDID;
                 EDName = template.EDName;
                 manufacturer = template.manufacturer;
+                possessiveYour = template.possessiveYour;
                 phoneticModel = template.phoneticModel;
                 Size = template.Size;
                 militarysize = template.militarysize;

--- a/DataDefinitions/ShipDefinitions.cs
+++ b/DataDefinitions/ShipDefinitions.cs
@@ -8,44 +8,44 @@ namespace EddiDataDefinitions
     {
         private static readonly Dictionary<long, Ship> ShipsByEliteID = new Dictionary<long, Ship>()
         {
-            { 128049267, new Ship(128049267, "Adder", "Zorgon Peterson", "Adder", null, LandingPadSize.Small, null, 0.36M) },
-            { 128049363, new Ship(128049363, "Anaconda", "Faulcon DeLacy", "Anaconda", null, LandingPadSize.Large, 5, 1.07M) },
-            { 128049303, new Ship(128049303, "Asp", "Lakon Spaceways", "Asp Explorer", null, LandingPadSize.Medium, null, 0.63M) },
-            { 128672276, new Ship(128672276, "Asp_Scout", "Lakon Spaceways", "Asp Scout", null, LandingPadSize.Medium, null, 0.47M) },
-            { 128049345, new Ship(128049345, "BelugaLiner", "Saud Kruger", "Beluga", new List<Translation> {new Translation("beluga", "bɪˈluːɡə") }, LandingPadSize.Large, null, 0.81M) },
-            { 128049279, new Ship(128049279, "CobraMkIII", "Faulcon DeLacy", "Cobra Mk. III", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, LandingPadSize.Small, null, 0.49M) },
-            { 128672262, new Ship(128672262, "CobraMkIV", "Faulcon DeLacy", "Cobra Mk. IV", new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, LandingPadSize.Small, null, 0.51M) },
-            { 128671831, new Ship(128671831, "DiamondbackXL", "Lakon Spaceways", "Diamondback Explorer", null, LandingPadSize.Small, null, 0.52M) },
-            { 128671217, new Ship(128671217, "Diamondback", "Lakon Spaceways", "Diamondback Scout", null, LandingPadSize.Small, null, 0.49M) },
-            { 128049291, new Ship(128049291, "Dolphin", "Saud Kruger", "Dolphin", null, LandingPadSize.Small, null, 0.50M) },
-            { 128049255, new Ship(128049255, "Eagle", "Core Dynamics", "Eagle", null, LandingPadSize.Small, 2, 0.34M) },
-            { 128672145, new Ship(128672145, "Federation_Dropship_MkII", "Core Dynamics", "Federal Assault Ship", null, LandingPadSize.Medium, 4, 0.72M) },
-            { 128049369, new Ship(128049369, "Federation_Corvette", "Core Dynamics", "Federal Corvette", null, LandingPadSize.Large, 5, 1.13M) },
-            { 128049321, new Ship(128049321, "Federation_Dropship", "Core Dynamics", "Federal Dropship", null, LandingPadSize.Medium, 4, 0.83M) },
-            { 128672152, new Ship(128672152, "Federation_Gunship", "Core Dynamics", "Federal Gunship", null, LandingPadSize.Medium, 4, 0.82M) },
-            { 128049351, new Ship(128049351, "FerDeLance", "Zorgon Peterson", "Fer-de-Lance", new List<Translation> {new Translation("fer-de-lance", "ˌfɛədəˈlɑːns") }, LandingPadSize.Medium, null, 0.67M) },
-            { 128049315, new Ship(128049315, "Empire_Trader", "Gutamaya", "Imperial Clipper", null, LandingPadSize.Large, 5, 0.74M) },
-            { 128671223, new Ship(128671223, "Empire_Courier", "Gutamaya", "Imperial Courier", null, LandingPadSize.Small, null, 0.41M) },
-            { 128049375, new Ship(128049375, "Cutter", "Gutamaya", "Imperial Cutter", null, LandingPadSize.Large, 5, 1.16M) },
-            { 128672138, new Ship(128672138, "Empire_Eagle", "Gutamaya", "Imperial Eagle", null, LandingPadSize.Small, 2, 0.37M) },
-            { 128049261, new Ship(128049261, "Hauler", "Zorgon Peterson", "Hauler", null, LandingPadSize.Small, null, 0.25M) },
-            { 128672269, new Ship(128672269, "Independant_Trader", "Lakon Spaceways", "Keelback", null, LandingPadSize.Medium, null, 0.39M) },
-            { 128049327, new Ship(128049327, "Orca", "Saud Kruger", "Orca", null, LandingPadSize.Large, null, 0.79M) },
-            { 128049339, new Ship(128049339, "Python", "Faulcon DeLacy", "Python", null, LandingPadSize.Medium, null, 0.83M)},
-            { 128049249, new Ship(128049249, "Sidewinder", "Faulcon DeLacy", "Sidewinder", null, LandingPadSize.Small, null, 0.3M) },
-            { 128049285, new Ship(128049285, "Type6", "Lakon Spaceways", "Type-6 Transporter", null, LandingPadSize.Medium, null, 0.39M) },
-            { 128049297, new Ship(128049297, "Type7", "Lakon Spaceways", "Type-7 Transporter", null, LandingPadSize.Large, null, 0.52M) },
-            { 128049333, new Ship(128049333, "Type9", "Lakon Spaceways", "Type-9 Heavy", null, LandingPadSize.Large, null, 0.77M) },
-            { 128049273, new Ship(128049273, "Viper", "Faulcon DeLacy", "Viper Mk. III", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, LandingPadSize.Small, 3, 0.41M) },
-            { 128672255, new Ship(128672255, "Viper_MkIV", "Faulcon DeLacy", "Viper Mk. IV", new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, LandingPadSize.Small, 3, 0.46M) },
-            { 128049309, new Ship(128049309, "Vulture", "Core Dynamics", "Vulture", new List<Translation> { new Translation("vulture", "ˈvʌltʃə") }, LandingPadSize.Small, 5, 0.57M) },
-            { 128785619, new Ship(128785619, "Type9_Military", "Lakon Spaceways", "Type-10 Defender", null, LandingPadSize.Large, 5, 0.77M) },
-            { 128816574, new Ship(128816574, "TypeX", "Lakon Spaceways", "Alliance Chieftain", null, LandingPadSize.Medium, 4, 0.77M) },
-            { 128816581, new Ship(128816581, "TypeX_2", "Lakon Spaceways", "Alliance Crusader", null, LandingPadSize.Medium, 4, 0.77M) },
-            { 128816588, new Ship(128816588, "TypeX_3", "Lakon Spaceways", "Alliance Challenger", null, LandingPadSize.Medium, 4, 0.77M) },
-            { 128816567, new Ship(128816567, "Krait_MkII", "Faulcon DeLacy", "Krait Mk. II", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Mark", "mɑːk"), new Translation("2", "ˈtuː") }, LandingPadSize.Medium, null, 0.63M) },
-            { 128839281, new Ship(128839281, "Krait_Light", "Faulcon DeLacy", "Krait Phantom", new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Phantom", "ˈfæntəm") }, LandingPadSize.Medium, null, 0.63M) },
-            { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", "Mamba", null, LandingPadSize.Medium, null, 0.5M) },
+            { 128049267, new Ship(128049267, "Adder", "Zorgon Peterson", "Adder", Properties.Ship.yourAdder, null, LandingPadSize.Small, null, 0.36M) },
+            { 128049363, new Ship(128049363, "Anaconda", "Faulcon DeLacy", "Anaconda", Properties.Ship.yourAnaconda, null, LandingPadSize.Large, 5, 1.07M) },
+            { 128049303, new Ship(128049303, "Asp", "Lakon Spaceways", "Asp Explorer", Properties.Ship.yourAspEx, null, LandingPadSize.Medium, null, 0.63M) },
+            { 128672276, new Ship(128672276, "Asp_Scout", "Lakon Spaceways", "Asp Scout", Properties.Ship.yourAspS, null, LandingPadSize.Medium, null, 0.47M) },
+            { 128049345, new Ship(128049345, "BelugaLiner", "Saud Kruger", "Beluga", Properties.Ship.yourBeluga, new List<Translation> {new Translation("beluga", "bɪˈluːɡə") }, LandingPadSize.Large, null, 0.81M) },
+            { 128049279, new Ship(128049279, "CobraMkIII", "Faulcon DeLacy", "Cobra Mk. III", Properties.Ship.yourCobraMkIII, new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, LandingPadSize.Small, null, 0.49M) },
+            { 128672262, new Ship(128672262, "CobraMkIV", "Faulcon DeLacy", "Cobra Mk. IV", Properties.Ship.yourCobraMkIV, new List<Translation> {new Translation("cobra", "ˈkəʊbrə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, LandingPadSize.Small, null, 0.51M) },
+            { 128671831, new Ship(128671831, "DiamondbackXL", "Lakon Spaceways", "Diamondback Explorer", Properties.Ship.yourDBX, null, LandingPadSize.Small, null, 0.52M) },
+            { 128671217, new Ship(128671217, "Diamondback", "Lakon Spaceways", "Diamondback Scout", Properties.Ship.yourDBS, null, LandingPadSize.Small, null, 0.49M) },
+            { 128049291, new Ship(128049291, "Dolphin", "Saud Kruger", "Dolphin", Properties.Ship.yourDolphin, null, LandingPadSize.Small, null, 0.50M) },
+            { 128049255, new Ship(128049255, "Eagle", "Core Dynamics", "Eagle", Properties.Ship.yourEagle, null, LandingPadSize.Small, 2, 0.34M) },
+            { 128672145, new Ship(128672145, "Federation_Dropship_MkII", "Core Dynamics", "Federal Assault Ship", Properties.Ship.yourFedAssaultShip, null, LandingPadSize.Medium, 4, 0.72M) },
+            { 128049369, new Ship(128049369, "Federation_Corvette", "Core Dynamics", "Federal Corvette", Properties.Ship.yourFedCorvette, null, LandingPadSize.Large, 5, 1.13M) },
+            { 128049321, new Ship(128049321, "Federation_Dropship", "Core Dynamics", "Federal Dropship", Properties.Ship.yourFedDropship, null, LandingPadSize.Medium, 4, 0.83M) },
+            { 128672152, new Ship(128672152, "Federation_Gunship", "Core Dynamics", "Federal Gunship", Properties.Ship.yourFedGunship, null, LandingPadSize.Medium, 4, 0.82M) },
+            { 128049351, new Ship(128049351, "FerDeLance", "Zorgon Peterson", "Fer-de-Lance", Properties.Ship.yourFDL, new List<Translation> {new Translation("fer-de-lance", "ˌfɛədəˈlɑːns") }, LandingPadSize.Medium, null, 0.67M) },
+            { 128049315, new Ship(128049315, "Empire_Trader", "Gutamaya", "Imperial Clipper", Properties.Ship.yourImpClipper, null, LandingPadSize.Large, 5, 0.74M) },
+            { 128671223, new Ship(128671223, "Empire_Courier", "Gutamaya", "Imperial Courier", Properties.Ship.yourImpCourier, null, LandingPadSize.Small, null, 0.41M) },
+            { 128049375, new Ship(128049375, "Cutter", "Gutamaya", "Imperial Cutter", Properties.Ship.yourImpCutter, null, LandingPadSize.Large, 5, 1.16M) },
+            { 128672138, new Ship(128672138, "Empire_Eagle", "Gutamaya", "Imperial Eagle", Properties.Ship.yourImpEagle, null, LandingPadSize.Small, 2, 0.37M) },
+            { 128049261, new Ship(128049261, "Hauler", "Zorgon Peterson", "Hauler", Properties.Ship.yourHauler, null, LandingPadSize.Small, null, 0.25M) },
+            { 128672269, new Ship(128672269, "Independant_Trader", "Lakon Spaceways", "Keelback", Properties.Ship.yourKeelback, null, LandingPadSize.Medium, null, 0.39M) },
+            { 128049327, new Ship(128049327, "Orca", "Saud Kruger", "Orca", Properties.Ship.yourOrca, null, LandingPadSize.Large, null, 0.79M) },
+            { 128049339, new Ship(128049339, "Python", "Faulcon DeLacy", "Python", Properties.Ship.yourPython, null, LandingPadSize.Medium, null, 0.83M)},
+            { 128049249, new Ship(128049249, "Sidewinder", "Faulcon DeLacy", "Sidewinder", Properties.Ship.yourSidewinder, null, LandingPadSize.Small, null, 0.3M) },
+            { 128049285, new Ship(128049285, "Type6", "Lakon Spaceways", "Type-6 Transporter", Properties.Ship.yourType6, null, LandingPadSize.Medium, null, 0.39M) },
+            { 128049297, new Ship(128049297, "Type7", "Lakon Spaceways", "Type-7 Transporter", Properties.Ship.yourType7, null, LandingPadSize.Large, null, 0.52M) },
+            { 128049333, new Ship(128049333, "Type9", "Lakon Spaceways", "Type-9 Heavy", Properties.Ship.yourType9, null, LandingPadSize.Large, null, 0.77M) },
+            { 128049273, new Ship(128049273, "Viper", "Faulcon DeLacy", "Viper Mk. III", Properties.Ship.yourViperMkIII, new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("3", "θriː") }, LandingPadSize.Small, 3, 0.41M) },
+            { 128672255, new Ship(128672255, "Viper_MkIV", "Faulcon DeLacy", "Viper Mk. IV", Properties.Ship.yourViperMkIV, new List<Translation> {new Translation("viper", "ˈvaɪpə"), new Translation("Mark", "mɑːk"), new Translation("4", "fɔː") }, LandingPadSize.Small, 3, 0.46M) },
+            { 128049309, new Ship(128049309, "Vulture", "Core Dynamics", "Vulture", Properties.Ship.yourVulture, new List<Translation> { new Translation("vulture", "ˈvʌltʃə") }, LandingPadSize.Small, 5, 0.57M) },
+            { 128785619, new Ship(128785619, "Type9_Military", "Lakon Spaceways", "Type-10 Defender", Properties.Ship.yourType10, null, LandingPadSize.Large, 5, 0.77M) },
+            { 128816574, new Ship(128816574, "TypeX", "Lakon Spaceways", "Alliance Chieftain", Properties.Ship.yourAllChieftain, null, LandingPadSize.Medium, 4, 0.77M) },
+            { 128816581, new Ship(128816581, "TypeX_2", "Lakon Spaceways", "Alliance Crusader", Properties.Ship.yourAllCrusader, null, LandingPadSize.Medium, 4, 0.77M) },
+            { 128816588, new Ship(128816588, "TypeX_3", "Lakon Spaceways", "Alliance Challenger", Properties.Ship.yourAllChallenger, null, LandingPadSize.Medium, 4, 0.77M) },
+            { 128816567, new Ship(128816567, "Krait_MkII", "Faulcon DeLacy", "Krait Mk. II", Properties.Ship.yourKraitMkII, new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Mark", "mɑːk"), new Translation("2", "ˈtuː") }, LandingPadSize.Medium, null, 0.63M) },
+            { 128839281, new Ship(128839281, "Krait_Light", "Faulcon DeLacy", "Krait Phantom", Properties.Ship.yourPhantom, new List<Translation>{new Translation("Krait", "ˈkreɪt"), new Translation("Phantom", "ˈfæntəm") }, LandingPadSize.Medium, null, 0.63M) },
+            { 128915979, new Ship(128915979, "Mamba", "Zorgon Peterson", "Mamba", Properties.Ship.yourMamba, null, LandingPadSize.Medium, null, 0.5M) },
         };
 
         public static readonly SortedSet<string> ShipModels = new SortedSet<string>(ShipsByEliteID.Select(kp => kp.Value.model));
@@ -71,6 +71,7 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
+                Ship.possessiveYour = Template.possessiveYour;
                 Ship.model = Template.model;
                 Ship.phoneticModel = Template.phoneticModel;
                 Ship.Size = Template.Size;
@@ -97,6 +98,7 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
+                Ship.possessiveYour = Template.possessiveYour;
                 Ship.model = Template.model;
                 Ship.phoneticModel = Template.phoneticModel;
                 Ship.Size = Template.Size;
@@ -129,6 +131,7 @@ namespace EddiDataDefinitions
                 Ship.EDID = Template.EDID;
                 Ship.EDName = Template.EDName;
                 Ship.manufacturer = Template.manufacturer;
+                Ship.possessiveYour = Template.possessiveYour;
                 Ship.model = Template.model;
                 Ship.phoneticModel = Template.phoneticModel;
                 Ship.Size = Template.Size;


### PR DESCRIPTION
(e.g. "your Asp Explorer")
Allows `your` to be customized per ship according to local language grammar rules (e.g. masculine or feminine).
Resolves #1608.