### PR TITLE
Fix Viper Mk III and similar mispronounced on ship transfer

### DIFF
--- a/DataDefinitions/Ship.cs
+++ b/DataDefinitions/Ship.cs
@@ -122,7 +122,7 @@ namespace EddiDataDefinitions
         }
 
         private string _model;
-        /// <summary>the model of the ship (Python, Anaconda, etc.)</summary>
+        /// <summary>the model of the ship (Python, Anaconda, Cobra Mk. III, etc.)</summary>
         public string model
         {
             get

--- a/InaraResponder/InaraResponder.cs
+++ b/InaraResponder/InaraResponder.cs
@@ -536,7 +536,7 @@ namespace EddiInaraResponder
         {
             inaraService.EnqueueAPIEvent(new InaraAPIEvent(@event.timestamp, "setCommanderShipTransfer", new Dictionary<string, object>()
             {
-                { "shipType", @event.edModel },
+                { "shipType", @event.Ship.EDName },
                 { "shipGameID", @event.shipid },
                 { "starsystemName", EDDI.Instance.CurrentStarSystem?.systemname },
                 { "stationName", EDDI.Instance.CurrentStation?.name },

--- a/ShipMonitor/ShipArrivedEvent.cs
+++ b/ShipMonitor/ShipArrivedEvent.cs
@@ -10,13 +10,14 @@ namespace EddiShipMonitor
     {
         public const string NAME = "Ship arrived";
         public const string DESCRIPTION = "Triggered when you complete a ship transfer";
-        public static ShipArrivedEvent SAMPLE = new ShipArrivedEvent(DateTime.UtcNow, "Adder", 1, "Eranin", 85.639145M, 580, 30, "Xuesen Orbital", 128035840, 3222994688);
+        public static ShipArrivedEvent SAMPLE = new ShipArrivedEvent(DateTime.Parse("2016-06-10T14:32:03Z").ToUniversalTime(), ShipDefinitions.FromEDModel("CobraMkIII"), "Eranin", 85.639145M, 580, 30, "Azeban City", 128168184, 128001536);
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
         static ShipArrivedEvent()
         {
             VARIABLES.Add("shipid", "The ID of the ship that was transferred");
-            VARIABLES.Add("ship", "The ship that was transferred");
+            VARIABLES.Add("ship", "The ship model that was transferred");
+            VARIABLES.Add("phoneticname", "The phonetic name of the ship that was transferred");
             VARIABLES.Add("station", "The station at which the ship shall arrive");
             VARIABLES.Add("system", "The system at which the ship shall arrive");
             VARIABLES.Add("distance", "The distance that the transferred ship travelled, in light years");
@@ -25,10 +26,12 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("shipid")]
-        public int? shipid { get; private set; }
+        public int? shipid => Ship.LocalId;
 
         [JsonProperty("ship")]
-        public string ship { get; private set; }
+        public string ship => Ship.model;
+
+        public string phoneticname => Ship.phoneticname;
 
         public string station { get; private set; }
 
@@ -47,11 +50,11 @@ namespace EddiShipMonitor
         // Admin
         public long fromMarketId { get; private set; }
         public long toMarketId { get; private set; }
+        public Ship Ship { get; private set; }
 
-        public ShipArrivedEvent(DateTime timestamp, string ship, int? shipid, string system, decimal distance, long? price, long? time, string station, long fromMarketId, long toMarketId) : base(timestamp, NAME)
+        public ShipArrivedEvent(DateTime timestamp, Ship Ship, string system, decimal distance, long? price, long? time, string station, long fromMarketId, long toMarketId) : base(timestamp, NAME)
         {
-            this.ship = ShipDefinitions.FromEDModel(ship).model;
-            this.shipid = shipid;
+            this.Ship = Ship;
             this.station = station;
             this.system = system;
             this.distance = distance;

--- a/ShipMonitor/ShipTransferInitiatedEvent.cs
+++ b/ShipMonitor/ShipTransferInitiatedEvent.cs
@@ -16,7 +16,8 @@ namespace EddiShipMonitor
         static ShipTransferInitiatedEvent()
         {
             VARIABLES.Add("shipid", "The ID of the ship that is being transferred");
-            VARIABLES.Add("ship", "The ship that is being transferred");
+            VARIABLES.Add("ship", "The ship model that is being transferred");
+            VARIABLES.Add("phoneticname", "The phonetic name of the ship that is being transferred");
             VARIABLES.Add("system", "The system from which the ship is being transferred");
             VARIABLES.Add("distance", "The distance that the transferred ship needs to travel, in light years");
             VARIABLES.Add("price", "The price of transferring the ship");
@@ -24,10 +25,12 @@ namespace EddiShipMonitor
         }
 
         [JsonProperty("shipid")]
-        public int? shipid { get; private set; }
+        public int? shipid => Ship.LocalId;
 
         [JsonProperty("ship")]
-        public string ship => shipDefinition.model;
+        public string ship => Ship.model;
+
+        public string phoneticname => Ship.phoneticname;
 
         [JsonProperty("system")]
         public string system { get; private set; }
@@ -44,13 +47,11 @@ namespace EddiShipMonitor
         // Admin
         public long fromMarketId { get; private set; }
         public long toMarketId { get; private set; }
-        public Ship shipDefinition => ShipDefinitions.FromEDModel(edModel);
-        public string edModel { get; private set; }
+        public Ship Ship { get; private set; }
 
-        public ShipTransferInitiatedEvent(DateTime timestamp, string ship, int? shipid, string system, decimal distance, long? price, long? time, long fromMarketId, long toMarketId) : base(timestamp, NAME)
+        public ShipTransferInitiatedEvent(DateTime timestamp, Ship Ship, string system, decimal distance, long? price, long? time, long fromMarketId, long toMarketId) : base(timestamp, NAME)
         {
-            this.edModel = ship;
-            this.shipid = shipid;
+            this.Ship = Ship;
             this.system = system;
             this.distance = distance;
             this.price = price;

--- a/SpeechResponder/Properties/CustomFunctions.Untranslated.Designer.cs
+++ b/SpeechResponder/Properties/CustomFunctions.Untranslated.Designer.cs
@@ -715,7 +715,7 @@ namespace EddiSpeechResponder.Properties {
         ///
         ///ShipName() takes an optional ship ID for which to provide the name. If no argument is supplied then it provides the name for your current ship.
         ///
-        ///If you have not set up a name for your ship it will just return &quot;your ship&quot;..
+        ///ShipName() also takes an optional ship model. If the optional ship ID is not found then this provides a ship name based on the ship mo [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ShipName {
             get {

--- a/SpeechResponder/Properties/CustomFunctions.Untranslated.resx
+++ b/SpeechResponder/Properties/CustomFunctions.Untranslated.resx
@@ -574,6 +574,8 @@ If you have set up a phonetic name for your ship it will return that, otherwise 
 
 ShipName() takes an optional ship ID for which to provide the name. If no argument is supplied then it provides the name for your current ship.
 
+ShipName() also takes an optional ship model. If the optional ship ID is not found then this provides a ship name based on the ship model.
+
 If you have not set up a name for your ship it will just return "your ship".</value>
   </data>
   <data name="Spacialise" xml:space="preserve">

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1822,7 +1822,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": "{Occasionally(2, '{F(\\'Honorific\\')}, ')}\r\nYour {P(event.ship, \"shipmodel\")} has \r\n\r\n{OneOf('arrived {if station.name != event.station && event.station: at}', \r\n       'completed its transfer {if station.name != event.station && event.station: to}')}\r\n\r\n{if station.name != event.station && event.station:\r\n   {P(event.station, \"station\")}\r\n   {if system.name != event.system && event.system:\r\n      in the {P(event.system, \"starsystem\")} system\r\n   }\r\n}.",
+      "script": "{Occasionally(2, '{F(\\'Honorific\\')}, ')}\r\n{ShipName(event.shipid, event.ship)} has \r\n\r\n{OneOf('arrived {if station.name != event.station && event.station: at}', \r\n       'completed its transfer {if station.name != event.station && event.station: to}')}\r\n\r\n{if station.name != event.station && event.station:\r\n   {P(event.station, \"station\")}\r\n   {if system.name != event.system && event.system:\r\n      in the {P(event.system, \"starsystem\")} system\r\n   }\r\n}.",
       "default": true,
       "name": "Ship arrived",
       "description": "Triggered when you complete a ship transfer"


### PR DESCRIPTION
- Use ship name or invariant model name on ship transfers rather than ship edmodel name.
- Update the `Ship arrived` event to use the `ShipName()` function.
- Update the `ShipName()` function to document its second argument.
- Resolves #2008.