### PR TITLE
Localize module names for the `Ship rebooted` event

### DIFF
--- a/JournalMonitor/JournalMonitor.cs
+++ b/JournalMonitor/JournalMonitor.cs
@@ -3184,14 +3184,55 @@ namespace EddiJournalMonitor
                                 break;
                             case "RebootRepair":
                                 {
+                                    // This event returns a list of slots rather than actual module ednames.
                                     data.TryGetValue("Modules", out object val);
-                                    List<object> modulesJson = (List<object>)val;
+                                    List<object> slotsJson = (List<object>)val;
 
-                                    List<string> modules = new List<string>();
-                                    foreach (string module in modulesJson)
+                                    var ship = ((ShipMonitor)EDDI.Instance.ObtainMonitor("Ship monitor"))?.GetCurrentShip();
+                                    List<Module> modules = new List<Module>();
+                                    foreach (string slot in slotsJson)
                                     {
-                                        modules.Add(module);
+                                        Module module = null;
+                                        if (slot.Contains("CargoHatch"))
+                                        {
+                                            module = ship.cargohatch;
+                                        }
+                                        else if (slot.Contains("FrameShiftDrive"))
+                                        {
+                                            module = ship.frameshiftdrive;
+                                        }
+                                        else if (slot.Contains("LifeSupport"))
+                                        {
+                                            module = ship.lifesupport;
+                                        }
+                                        else if (slot.Contains("MainEngines"))
+                                        {
+                                            module = ship.thrusters;
+                                        }
+                                        else if (slot.Contains("PowerDistributor"))
+                                        {
+                                            module = ship.powerdistributor;
+                                        }
+                                        else if (slot.Contains("PowerPlant"))
+                                        {
+                                            module = ship.powerplant;
+                                        }
+                                        else if (slot.Contains("Radar"))
+                                        {
+                                            module = ship.sensors;
+                                        }
+                                        else if (slot.Contains("Hardpoint"))
+                                        {
+                                            module = ship.hardpoints.SingleOrDefault(h => h.name == slot)?.module;
+                                        }
+                                        else if (slot.Contains("Slot") || slot.Contains("Military"))
+                                        {
+                                            module = ship.compartments.SingleOrDefault(c => c.name == slot)?.module;
+                                        }
+
+                                        if (module != null) { modules.Add(module); }
                                     }
+
                                     events.Add(new ShipRebootedEvent(timestamp, modules) { raw = line, fromLoad = fromLogLoad });
                                 }
                                 handled = true;

--- a/ShipMonitor/ShipRebootedEvent.cs
+++ b/ShipMonitor/ShipRebootedEvent.cs
@@ -1,7 +1,8 @@
-﻿using EddiEvents;
-using Newtonsoft.Json;
+﻿using EddiDataDefinitions;
+using EddiEvents;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace EddiShipMonitor
 {
@@ -9,20 +10,25 @@ namespace EddiShipMonitor
     {
         public const string NAME = "Ship rebooted";
         public const string DESCRIPTION = "Triggered when you run reboot/repair on your ship";
-        public static string SAMPLE = "{\"timestamp\":\"2016-06-10T14:32:03Z\",\"event\":\"RebootRepair\",\"Modules\":[\"MainEngines\",\"TinyHardpoint1\"]}";
+        public static ShipRebootedEvent SAMPLE = new ShipRebootedEvent(DateTime.UtcNow, new List<Module>() { Module.FromEDName("modularcargobaydoor"), Module.FromEDName("int_powerplant_size2_class5"), Module.FromEDName("int_engine_size7_class2"), Module.FromEDName("hpt_plasmapointdefence_turret_tiny") });
         public static Dictionary<string, string> VARIABLES = new Dictionary<string, string>();
 
         static ShipRebootedEvent()
         {
-            VARIABLES.Add("modules", "The modules that have been repaired");
+            VARIABLES.Add("modules", "The localized module names that have been repaired");
+            VARIABLES.Add("modules_invariant", "The invariant module names that have been repaired");
         }
 
-        [JsonProperty("modules")]
-        public List<string> modules { get; private set; }
+        public List<string> modules => Modules?.Select(m => m.localizedName).ToList();
 
-        public ShipRebootedEvent(DateTime timestamp, List<string> modules) : base(timestamp, NAME)
+        public List<string> modules_invariant => Modules?.Select(m => m.invariantName).ToList();
+        
+        // Not intended to be user facing
+        public List<Module> Modules { get; private set; }
+
+        public ShipRebootedEvent(DateTime timestamp, List<Module> Modules) : base(timestamp, NAME)
         {
-            this.modules = modules;
+            this.Modules = Modules;
         }
     }
 }

--- a/SpeechResponder/eddi.json
+++ b/SpeechResponder/eddi.json
@@ -1894,7 +1894,7 @@
       "enabled": true,
       "priority": 3,
       "responder": true,
-      "script": null,
+      "script": "{if len(event.modules) > 0:\r\n    Emergency repairs have been\r\n    {OneOf(\"made\", \"applied\")}\r\n    to the {List(event.modules)}.\r\n}",
       "default": true,
       "name": "Ship rebooted",
       "description": "Triggered when you run reboot/repair on your ship"


### PR DESCRIPTION
- Resolves #2079
- Adds an option for invariant names in addition to localized names
- Adds a new script for the `Ship rebooted` event