### PR TITLE
Enable parallel test runs

### DIFF
--- a/Tests/TestBase.cs
+++ b/Tests/TestBase.cs
@@ -3,6 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System.IO;
 
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.ClassLevel)]
+
 namespace UnitTests
 {
     public class TestBase


### PR DESCRIPTION
I tried ExecutionScope.MethodLevel but a couple of tests didn't like it.