### PR TITLE
Refactor Humanize

### DIFF
--- a/SpeechService/Humanize.cs
+++ b/SpeechService/Humanize.cs
@@ -6,23 +6,14 @@ namespace EddiSpeechService
     {
         public static string Humanize(decimal? rawValue)
         {
-            if (rawValue == null)
-            {
-                return null;
-            }
+            if (rawValue == null) {return null;}
+            decimal value = (decimal) rawValue;
+            if (value == 0) {return Properties.Phrases.zero;}
 
-            var value = (decimal) rawValue;
-
-            bool isNegative = false;
-            if (value < 0)
+            bool isNegative = value < 0;
+            if (isNegative)
             {
-                isNegative = true;
                 value = -value;
-            }
-
-            if (value == 0)
-            {
-                return Properties.Phrases.zero;
             }
 
             if (value < 10)
@@ -40,16 +31,8 @@ namespace EddiSpeechService
                        (Math.Round(value * 10) / (decimal) Math.Pow(10, numzeros + 2));
             }
 
-            (int number, int nextDigit) Normalize(decimal inputValue, decimal orderMultiplierVal)
-            {
-                return (
-                    number: (int) (inputValue / orderMultiplierVal),
-                    nextDigit: (int) ((inputValue % orderMultiplierVal) / (orderMultiplierVal / 10))
-                );
-            }
-
-            var magnitude = Math.Log10((double) value);
-            var orderMultiplier = (long) Math.Pow(10, Math.Floor(magnitude / 3) * 3);
+            double magnitude = Math.Log10((double) value);
+            long orderMultiplier = (long) Math.Pow(10, Math.Floor(magnitude / 3) * 3);
             var (number, nextDigit) = Normalize(value, orderMultiplier);
 
             // See if we have a whole number that is fully described within the largest order
@@ -57,455 +40,422 @@ namespace EddiSpeechService
             {
                 // Some languages render these differently than others. "1000" in English is "one thousand" but in Italian is simply "mille".
                 // Consequently, we leave the interpretation to the culture-specific voice.
-                return (isNegative ? Properties.Phrases.minus + " " : "") + (number * orderMultiplier);
+                return FormatVerbatim(number, isNegative, orderMultiplier);
             }
 
             if (number < 100)
             {
-                // See if we have a number whose value can be expressed with a short decimal (i.e 1.3 million)
-                if (number + ((decimal) nextDigit / 10) == Math.Round(value / orderMultiplier, 2))
-                {
-                    if (nextDigit == 0)
-                    {
-                        return (isNegative ? Properties.Phrases.minus + " " : "") + number * orderMultiplier;
-                    }
-                    else
-                    {
-                        var shortDecimal = (number + ((decimal) nextDigit / 10));
-                        switch ((decimal) orderMultiplier)
-                        {
-                        case 1:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") + shortDecimal;
-                        case 1E3M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalThousand, shortDecimal);
-                        case 1E6M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalMillion, shortDecimal);
-                        case 1E9M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalBillion, shortDecimal);
-                        case 1E12M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalTrillion, shortDecimal);
-                        case 1E15M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalQuadrillion, shortDecimal);
-                        case 1E18M:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   string.Format(Properties.Phrases.shortDecimalQuintillion, shortDecimal);
-                        default:
-                            return (isNegative ? Properties.Phrases.minus + " " : "") +
-                                   (shortDecimal * orderMultiplier);
-                        }
-                    }
-                }
-
-                // Describe values for complex numbers where the largest order number does not exceed one hundred
-                switch (nextDigit)
-                {
-                case 1:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinus, number)
-                            : string.Format(Properties.Phrases.justOver, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusThousand, number)
-                            : string.Format(Properties.Phrases.justOverThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusMillion, number)
-                            : string.Format(Properties.Phrases.justOverMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusBillion, number)
-                            : string.Format(Properties.Phrases.justOverBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusTrillion, number)
-                            : string.Format(Properties.Phrases.justOverTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.justOverQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.justOverQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 2:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinus, number)
-                            : string.Format(Properties.Phrases.over, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusThousand, number)
-                            : string.Format(Properties.Phrases.overThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusMillion, number)
-                            : string.Format(Properties.Phrases.overMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusBillion, number)
-                            : string.Format(Properties.Phrases.overBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusTrillion, number)
-                            : string.Format(Properties.Phrases.overTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.overQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.overQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 3:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinus, number)
-                            : string.Format(Properties.Phrases.wellOver, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusThousand, number)
-                            : string.Format(Properties.Phrases.wellOverThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusMillion, number)
-                            : string.Format(Properties.Phrases.wellOverMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusBillion, number)
-                            : string.Format(Properties.Phrases.wellOverBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusTrillion, number)
-                            : string.Format(Properties.Phrases.wellOverTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.wellOverQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.wellOverQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 4:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyAndAHalf, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusThousandAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyThousandAndAHalf, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusMillionAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyMillionAndAHalf, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusBillionAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyBillionAndAHalf, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusTrillionAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyTrillionAndAHalf, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuadrillionAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyQuadrillionAndAHalf, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuintillionAndAHalf, number)
-                            : string.Format(Properties.Phrases.nearlyQuintillionAndAHalf, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 5:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalf, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalf, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfThousand, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfMillion, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfBillion, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfTrillion, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfQuadrillion, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.aroundMinusAndAHalfQuintillion, number)
-                            : string.Format(Properties.Phrases.aroundAndAHalfQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 6:
-                case 7:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalf, number)
-                            : string.Format(Properties.Phrases.overAndAHalf, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfThousand, number)
-                            : string.Format(Properties.Phrases.overAndAHalfThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfMillion, number)
-                            : string.Format(Properties.Phrases.overAndAHalfMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfBillion, number)
-                            : string.Format(Properties.Phrases.overAndAHalfBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfTrillion, number)
-                            : string.Format(Properties.Phrases.overAndAHalfTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfQuadrillion, number)
-                            : string.Format(Properties.Phrases.overAndAHalfQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusAndAHalfQuintillion, number)
-                            : string.Format(Properties.Phrases.overAndAHalfQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 8:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalf, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalf, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfThousand, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfMillion, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfBillion, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfTrillion, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfQuadrillion, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.wellOverMinusAndAHalfQuintillion, number)
-                            : string.Format(Properties.Phrases.wellOverAndAHalfQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 9:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinus, number)
-                            : string.Format(Properties.Phrases.nearly, number + 1);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusThousand, number)
-                            : string.Format(Properties.Phrases.nearlyThousand, number + 1);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusMillion, number)
-                            : string.Format(Properties.Phrases.nearlyMillion, number + 1);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusBillion, number)
-                            : string.Format(Properties.Phrases.nearlyBillion, number + 1);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusTrillion, number)
-                            : string.Format(Properties.Phrases.nearlyTrillion, number + 1);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.nearlyQuadrillion, number + 1);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.nearlyQuintillion, number + 1);
-                    default:
-                        return $"{rawValue}";
-                    }
-                default:
-                    // `nextDigit` is zero. the figure we are saying is round enough already
-                    return (isNegative ? Properties.Phrases.minus + " " : "") + (number * orderMultiplier);
-                }
+                return FormatWith2SignificantDigits(number, isNegative, orderMultiplier, nextDigit, value);
             }
-            // Describe (less precisely) values for complex numbers where the largest order number exceeds one hundred
-            else
+            else // Describe (less precisely) values for numbers where the largest order number exceeds one hundred
             {
-                // Round largest order numbers in the hundreds to the nearest 10, except where the number after the hundreds place is 20 or less
-                if (number - (int) ((decimal) number / 100) * 100 >= 20)
+                return FormatWith3SignificantDigits(number, isNegative, orderMultiplier, nextDigit, value);
+            }
+        }
+
+        private static (int number, int nextDigit) Normalize(decimal inputValue, decimal orderMultiplierVal)
+        {
+            return (number: (int) (inputValue / orderMultiplierVal), nextDigit: (int) ((inputValue % orderMultiplierVal) / (orderMultiplierVal / 10)));
+        }
+
+        private static string FormatWith2SignificantDigits(int number, bool isNegative, long orderMultiplier, int nextDigit, decimal value)
+        {
+            // See if we have a number whose value can be expressed with a short decimal (i.e 1.3 million)
+            var shortDecimal = (number + ((decimal) nextDigit / 10));
+            if (shortDecimal == Math.Round(value / orderMultiplier, 2))
+            {
+                if (nextDigit == 0)
                 {
-                    (number, nextDigit) = Normalize(number, 10);
-                    number *= 10;
+                    return FormatVerbatim(number, isNegative, orderMultiplier);
                 }
 
-                switch (nextDigit)
-                {
+                return FormatAsShortDecimal(shortDecimal, isNegative, orderMultiplier);
+            }
+
+            // Describe values for numbers where the largest order number does not exceed one hundred
+            switch (nextDigit)
+            {
+            case 1:
+                return FormatAsJustOver(number, isNegative, orderMultiplier, value);
+            case 2:
+                return FormatAsOver(number, isNegative, orderMultiplier, value);
+            case 3:
+                return FormatAsWellOver(number, isNegative, orderMultiplier, value);
+            case 4:
+                return FormatAsNearlyOneAndAHalf(number, isNegative, orderMultiplier, value);
+            case 5:
+                return FormatAsAroundOneAndAHalf(number, isNegative, orderMultiplier, value);
+            case 6:
+            case 7:
+                return FormatAsOverOneAndAHalf(number, isNegative, orderMultiplier, value);
+            case 8:
+                return FormatAsWellOverOneAndAHalf(number, isNegative, orderMultiplier, value);
+            case 9:
+                return FormatAsNearly(number + 1, isNegative, orderMultiplier, value);
+            default:
+                // `nextDigit` is zero. the figure we are saying is round enough already
+                return FormatVerbatim(number, isNegative, orderMultiplier);
+            }
+        }
+
+        private static string FormatWith3SignificantDigits(int number, bool isNegative, long orderMultiplier, int nextDigit,
+            decimal value)
+        {
+            // Round largest order numbers in the hundreds to the nearest 10, except where the number after the hundreds place is 20 or less
+            if (number - (int)((decimal)number / 100) * 100 >= 20)
+            {
+                (number, nextDigit) = Normalize(number, 10);
+                number *= 10;
+            }
+
+            switch (nextDigit)
+            {
+            case 1:
+                return FormatAsJustOver(number, isNegative, orderMultiplier, value);
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+                return FormatAsOver(number, isNegative, orderMultiplier, value);
+            case 7:
+            case 8:
+            case 9:
+                return FormatAsNearly(number + 1, isNegative, orderMultiplier, value);
+            default:
+                // `nextDigit` is zero. the figure we are saying is round enough already
+                return FormatVerbatim(number, isNegative, orderMultiplier);
+            }
+        }
+
+        private static string FormatVerbatim(int number, bool isNegative, long orderMultiplier)
+        {
+            return (isNegative ? Properties.Phrases.minus + " " : "") + (number * orderMultiplier);
+        }
+
+        private static string FormatAsShortDecimal(decimal shortDecimal, bool isNegative, long orderMultiplier)
+        {
+            switch ((decimal) orderMultiplier)
+            {
+            case 1:
+                return (isNegative ? Properties.Phrases.minus + " " : "") + shortDecimal;
+            case 1E3M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalThousand, shortDecimal);
+            case 1E6M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalMillion, shortDecimal);
+            case 1E9M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalBillion, shortDecimal);
+            case 1E12M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalTrillion, shortDecimal);
+            case 1E15M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalQuadrillion, shortDecimal);
+            case 1E18M:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       string.Format(Properties.Phrases.shortDecimalQuintillion, shortDecimal);
+            default:
+                return (isNegative ? Properties.Phrases.minus + " " : "") +
+                       (shortDecimal * orderMultiplier);
+            }
+        }
+
+        private static string FormatAsJustOver(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal) orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinus, number)
+                    : string.Format(Properties.Phrases.justOver, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusThousand, number)
+                    : string.Format(Properties.Phrases.justOverThousand, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusMillion, number)
+                    : string.Format(Properties.Phrases.justOverMillion, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusBillion, number)
+                    : string.Format(Properties.Phrases.justOverBillion, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusTrillion, number)
+                    : string.Format(Properties.Phrases.justOverTrillion, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusQuadrillion, number)
+                    : string.Format(Properties.Phrases.justOverQuadrillion, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.justOverMinusQuintillion, number)
+                    : string.Format(Properties.Phrases.justOverQuintillion, number);
+            default:
+                return $"{value}";
+            }
+        }
+
+        private static string FormatAsOver(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal) orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinus, number)
+                    : string.Format(Properties.Phrases.over, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusThousand, number)
+                    : string.Format(Properties.Phrases.overThousand, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusMillion, number)
+                    : string.Format(Properties.Phrases.overMillion, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusBillion, number)
+                    : string.Format(Properties.Phrases.overBillion, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusTrillion, number)
+                    : string.Format(Properties.Phrases.overTrillion, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusQuadrillion, number)
+                    : string.Format(Properties.Phrases.overQuadrillion, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.overMinusQuintillion, number)
+                    : string.Format(Properties.Phrases.overQuintillion, number);
+            default:
+                return $"{value}";
+            }
+        }
+
+        private static string FormatAsWellOver(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal)orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinus, number)
+                    : string.Format(Properties.Phrases.wellOver, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusThousand, number)
+                    : string.Format(Properties.Phrases.wellOverThousand, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusMillion, number)
+                    : string.Format(Properties.Phrases.wellOverMillion, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusBillion, number)
+                    : string.Format(Properties.Phrases.wellOverBillion, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusTrillion, number)
+                    : string.Format(Properties.Phrases.wellOverTrillion, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusQuadrillion, number)
+                    : string.Format(Properties.Phrases.wellOverQuadrillion, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusQuintillion, number)
+                    : string.Format(Properties.Phrases.wellOverQuintillion, number);
+            default:
+                return $"{value}";
+            }
+        }
+
+        private static string FormatAsNearlyOneAndAHalf(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal)orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyAndAHalf, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusThousandAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyThousandAndAHalf, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusMillionAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyMillionAndAHalf, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusBillionAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyBillionAndAHalf, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusTrillionAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyTrillionAndAHalf, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusQuadrillionAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyQuadrillionAndAHalf, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusQuintillionAndAHalf, number)
+                    : string.Format(Properties.Phrases.nearlyQuintillionAndAHalf, number);
+            default:
+                return $"{value}";
+            }
+        }
+
+        private static string FormatAsAroundOneAndAHalf(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal)orderMultiplier)
+            {
                 case 1:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinus, number)
-                            : string.Format(Properties.Phrases.justOver, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusThousand, number)
-                            : string.Format(Properties.Phrases.justOverThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusMillion, number)
-                            : string.Format(Properties.Phrases.justOverMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusBillion, number)
-                            : string.Format(Properties.Phrases.justOverBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusTrillion, number)
-                            : string.Format(Properties.Phrases.justOverTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.justOverQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.justOverMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.justOverQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 2:
-                case 3:
-                case 4:
-                case 5:
-                case 6:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinus, number)
-                            : string.Format(Properties.Phrases.over, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusThousand, number)
-                            : string.Format(Properties.Phrases.overThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusMillion, number)
-                            : string.Format(Properties.Phrases.overMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusBillion, number)
-                            : string.Format(Properties.Phrases.overBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusTrillion, number)
-                            : string.Format(Properties.Phrases.overTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.overQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.overMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.overQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
-                case 7:
-                case 8:
-                case 9:
-                    switch ((decimal) orderMultiplier)
-                    {
-                    case 1:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinus, number)
-                            : string.Format(Properties.Phrases.nearly, number);
-                    case 1E3M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusThousand, number)
-                            : string.Format(Properties.Phrases.nearlyThousand, number);
-                    case 1E6M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusMillion, number)
-                            : string.Format(Properties.Phrases.nearlyMillion, number);
-                    case 1E9M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusBillion, number)
-                            : string.Format(Properties.Phrases.nearlyBillion, number);
-                    case 1E12M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusTrillion, number)
-                            : string.Format(Properties.Phrases.nearlyTrillion, number);
-                    case 1E15M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuadrillion, number)
-                            : string.Format(Properties.Phrases.nearlyQuadrillion, number);
-                    case 1E18M:
-                        return isNegative
-                            ? string.Format(Properties.Phrases.nearlyMinusQuintillion, number)
-                            : string.Format(Properties.Phrases.nearlyQuintillion, number);
-                    default:
-                        return $"{rawValue}";
-                    }
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalf, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalf, number);
+                case 1E3M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfThousand, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfThousand, number);
+                case 1E6M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfMillion, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfMillion, number);
+                case 1E9M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfBillion, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfBillion, number);
+                case 1E12M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfTrillion, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfTrillion, number);
+                case 1E15M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfQuadrillion, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfQuadrillion, number);
+                case 1E18M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.aroundMinusAndAHalfQuintillion, number)
+                        : string.Format(Properties.Phrases.aroundAndAHalfQuintillion, number);
                 default:
-                    // `nextDigit` is zero. the figure we are saying is round enough already
-                    return (isNegative ? Properties.Phrases.minus + " " : "") + (number * orderMultiplier);
-                }
+                    return $"{value}";
+            }
+        }
+
+        private static string FormatAsOverOneAndAHalf(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal)orderMultiplier)
+            {
+                case 1:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalf, number)
+                        : string.Format(Properties.Phrases.overAndAHalf, number);
+                case 1E3M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfThousand, number)
+                        : string.Format(Properties.Phrases.overAndAHalfThousand, number);
+                case 1E6M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfMillion, number)
+                        : string.Format(Properties.Phrases.overAndAHalfMillion, number);
+                case 1E9M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfBillion, number)
+                        : string.Format(Properties.Phrases.overAndAHalfBillion, number);
+                case 1E12M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfTrillion, number)
+                        : string.Format(Properties.Phrases.overAndAHalfTrillion, number);
+                case 1E15M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfQuadrillion, number)
+                        : string.Format(Properties.Phrases.overAndAHalfQuadrillion, number);
+                case 1E18M:
+                    return isNegative
+                        ? string.Format(Properties.Phrases.overMinusAndAHalfQuintillion, number)
+                        : string.Format(Properties.Phrases.overAndAHalfQuintillion, number);
+                default:
+                    return $"{value}";
+            }
+        }
+
+        private static string FormatAsWellOverOneAndAHalf(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal)orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalf, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalf, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfThousand, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfThousand, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfMillion, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfMillion, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfBillion, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfBillion, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfTrillion, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfTrillion, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfQuadrillion, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfQuadrillion, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.wellOverMinusAndAHalfQuintillion, number)
+                    : string.Format(Properties.Phrases.wellOverAndAHalfQuintillion, number);
+            default:
+                return $"{value}";
+            }
+        }
+
+        private static string FormatAsNearly(int number, bool isNegative, long orderMultiplier, decimal value)
+        {
+            switch ((decimal) orderMultiplier)
+            {
+            case 1:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinus, number)
+                    : string.Format(Properties.Phrases.nearly, number);
+            case 1E3M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusThousand, number)
+                    : string.Format(Properties.Phrases.nearlyThousand, number);
+            case 1E6M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusMillion, number)
+                    : string.Format(Properties.Phrases.nearlyMillion, number);
+            case 1E9M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusBillion, number)
+                    : string.Format(Properties.Phrases.nearlyBillion, number);
+            case 1E12M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusTrillion, number)
+                    : string.Format(Properties.Phrases.nearlyTrillion, number);
+            case 1E15M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusQuadrillion, number)
+                    : string.Format(Properties.Phrases.nearlyQuadrillion, number);
+            case 1E18M:
+                return isNegative
+                    ? string.Format(Properties.Phrases.nearlyMinusQuintillion, number)
+                    : string.Format(Properties.Phrases.nearlyQuintillion, number);
+            default:
+                return $"{value}";
             }
         }
     }

--- a/Tests/HumanizeTests.cs
+++ b/Tests/HumanizeTests.cs
@@ -6,8 +6,22 @@ namespace UnitTests
     [TestClass]
     public class HumanizeTests
     {
+        [TestMethod]
+        public void TestNullInput()
+        {
+            Assert.IsNull(Translations.Humanize(null));
+        }
+
         [DataTestMethod]
+        [DataRow(0, "zero")]
+        [DataRow(456, "456")]
+        [DataRow(-1000, "minus 1000")]
+        [DataRow(100000, "100000")]
+        [DataRow(51000001, "51000000")]
+        [DataRow(-51000000, "minus 51000000")]
         [DataRow(-12345, "well over minus 12 thousand")]
+        [DataRow(1800001, "1.8 million")]
+        [DataRow(-1999001, "nearly minus 2 million")]
         public void TestIntToFloatingMantissa(int number, string expected)
         {
             Assert.AreEqual(expected, Translations.Humanize(number));
@@ -15,147 +29,62 @@ namespace UnitTests
 
         [DataTestMethod]
         [DataRow(-12345.0, "well over minus 12 thousand")]
+        [DataRow(0.15555555, "0.16")]
+        [DataRow(0.015555555, "0.016")]
+        [DataRow(0.0015555555, "0.0016")]
+        [DataRow(-0.15555555, "minus 0.16")]
+        [DataRow(-0.015555555, "minus 0.016")]
+        [DataRow(-0.0015555555, "minus 0.0016")]
+        [DataRow(-12.1, "minus 12.1")]
+        [DataRow(-12.01, "minus 12")]
+        [DataRow(6.459E5, "over 640 thousand")]
+        [DataRow(1.8E6, "1.8 million")]
+        [DataRow(9.4571E11, "over 940 billion")]
+        [DataRow(4.36156E14, "over 430 trillion")]
+        [DataRow(9.1235E17, "over 912 quadrillion")]
         public void TestDoubleToFloatingMantissa(double number, string expected)
         {
             Assert.AreEqual(expected, Translations.Humanize((decimal)number));
         }
 
-        [TestMethod]
-        public void TestSpeechHumanize1()
+        [DataTestMethod]
+        [DataRow(1100001, "1.1 million")]
+        [DataRow(1110001, "just over 1 million")]
+        [DataRow(1210001, "over 1 million")]
+        [DataRow(1310001, "well over 1 million")]
+        [DataRow(1410001, "nearly 1 million and a half")]
+        [DataRow(1510001, "around 1 and a half million")]
+        [DataRow(1610001, "over 1 and a half million")]
+        [DataRow(1810001, "well over 1 and a half million")]
+        [DataRow(1999001, "nearly 2 million")]
+        public void Test2ndDigitRangePositive(int number, string expected)
         {
-            Assert.AreEqual("well over minus 12 thousand", Translations.Humanize(-12345));
+            Assert.AreEqual(expected, Translations.Humanize(number));
         }
 
-        [TestMethod]
-        public void TestSpeechHumanize2()
+        [DataTestMethod]
+        [DataRow(-1100001, "minus 1.1 million")]
+        [DataRow(-1110001, "just over minus 1 million")]
+        [DataRow(-1210001, "over minus 1 million")]
+        [DataRow(-1310001, "well over minus 1 million")]
+        [DataRow(-1410001, "nearly minus 1 and a half million")]
+        [DataRow(-1510001, "around minus 1 and a half million")]
+        [DataRow(-1610001, "over minus 1 and a half million")]
+        [DataRow(-1810001, "well over minus 1 and a half million")]
+        [DataRow(-1999001, "nearly minus 2 million")]
+        public void Test2ndDigitRangeNegative(int number, string expected)
         {
-            Assert.AreEqual(null, Translations.Humanize(null));
+            Assert.AreEqual(expected, Translations.Humanize(number));
         }
 
-        [TestMethod]
-        public void TestSpeechHumanize3()
+        [DataTestMethod]
+        [DataRow(111000, "111000")]
+        [DataRow(111100, "just over 111 thousand")]
+        [DataRow(111200, "over 111 thousand")]
+        [DataRow(111700, "nearly 112 thousand")]
+        public void TestNumbersWith3DigitMantissa(int number, string expected)
         {
-            Assert.AreEqual("zero", Translations.Humanize(0));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize4()
-        {
-            Assert.AreEqual("0.16", Translations.Humanize(0.15555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize5()
-        {
-            Assert.AreEqual("0.016", Translations.Humanize(0.015555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize6()
-        {
-            Assert.AreEqual("0.0016", Translations.Humanize(0.0015555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize7()
-        {
-            Assert.AreEqual("minus 51000000", Translations.Humanize(-51000000));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize8()
-        {
-            Assert.AreEqual("51000000", Translations.Humanize(51000001));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize9()
-        {
-            Assert.AreEqual("10000", Translations.Humanize(10000));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize10()
-        {
-            Assert.AreEqual("100000", Translations.Humanize(100000));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize11()
-        {
-            Assert.AreEqual("minus 0.16", Translations.Humanize(-0.15555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize12()
-        {
-            Assert.AreEqual("minus 0.016", Translations.Humanize(-0.015555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize13()
-        {
-            Assert.AreEqual("minus 0.0016", Translations.Humanize(-0.0015555555M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize14()
-        {
-            Assert.AreEqual("minus 12.1", Translations.Humanize(-12.1M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize15()
-        {
-            Assert.AreEqual("minus 12", Translations.Humanize(-12.01M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize16()
-        {
-            Assert.AreEqual("over 430 trillion", Translations.Humanize(4.36156E14M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize17()
-        {
-            Assert.AreEqual("over 940 billion", Translations.Humanize(9.4571E11M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize18()
-        {
-            Assert.AreEqual("over 912 quadrillion", Translations.Humanize(9.1235E17M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize19()
-        {
-            Assert.AreEqual("over 640 thousand", Translations.Humanize(6.459E5M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize20()
-        {
-            Assert.AreEqual("456", Translations.Humanize(456));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize21()
-        {
-            Assert.AreEqual("1.8 million", Translations.Humanize(1.8E6M));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize22()
-        {
-            Assert.AreEqual("1.8 million", Translations.Humanize(1800001));
-        }
-
-        [TestMethod]
-        public void TestSpeechHumanize23()
-        {
-            Assert.AreEqual("minus 1000", Translations.Humanize(-1000));
+            Assert.AreEqual(expected, Translations.Humanize(number));
         }
     }
 }


### PR DESCRIPTION
Refactor `Humanise()` and greatly increase test coverage.

Extract the methods for each formatting style, to make the shape of the calling function clearer.

This is a precursor to enabling an option to force integer mantissas, to aid in correct TTS in Slavic languages such as Russian.