### PR TITLE
Microsoft.TestPlatform Dlls do not ship

### DIFF
--- a/BuildInstaller/BuildInstaller.csproj
+++ b/BuildInstaller/BuildInstaller.csproj
@@ -40,7 +40,7 @@
     <PostBuildEvent>cd "$(SolutionDir)"
 if exist $(SolutionDir)postBuildTests.bat (
   @echo Post-build script exists at: $(SolutionDir)postBuild.bat - executing...
-  call $(SolutionDir)postBuildTests.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir)$(OutDir)"
+  call $(SolutionDir)postBuildTests.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir)" "$(OutDir)"
 )
 
 if "$(ConfigurationName)" == "Release" (

--- a/Tests/GeneratorTests.cs
+++ b/Tests/GeneratorTests.cs
@@ -13,6 +13,22 @@ namespace GeneratorTests
     [TestClass]
     public class GeneratorTests
     {
+        private string initialCurrentDirectory;
+
+        [TestInitialize]
+        public void SetOutputDirectory()
+        {
+            initialCurrentDirectory = Directory.GetCurrentDirectory();
+            string newCurrentDirectory = initialCurrentDirectory.Replace(@"Tests\", "");
+            Directory.SetCurrentDirectory(newCurrentDirectory);
+        }
+
+        [TestCleanup]
+        public void RestoreOutuptDirectory()
+        {
+            Directory.SetCurrentDirectory(initialCurrentDirectory);
+        }
+
         [TestMethod, TestCategory("DocGen")]
         public void TestGenerateWikiEvents()
         {
@@ -153,9 +169,6 @@ namespace GeneratorTests
                 .OrderBy(f => f.name)
                 .ToList();
 
-            // Make sure that a Wiki directory exists
-            Directory.CreateDirectory(@"Wiki\");
-
             // Prepare Help.md
             List<string> help = new List<string>();
             help.Add("");
@@ -181,6 +194,9 @@ namespace GeneratorTests
             {
                 functions.Add($"* {function.name}()");
             }
+
+            // Make sure that a Wiki directory exists
+            Directory.CreateDirectory(@"Wiki\");
 
             // Write our results
             File.WriteAllLines(@"Help.md", help);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -25,7 +25,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -33,7 +33,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ test_script:
       $openCoverArgs = '-mergebyhash -skipautoprops -excludebyattribute:*.ExcludeFromCodeCoverage*,*.GeneratedCodeAttribute* -excludebyfile:*\*.Designer.cs,*.xaml -filter:"+[Eddi*]* +[Utilities*]* +[Tests*]UnitTests*"'
       
       $target = '-target:"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
-      $targetArgs = '-targetargs:"bin\Release\Tests.dll' + $(If ($APPVEYOR) {' /logger:Appveyor'}) + ' /tests:UnitTests /Parallel /InIsolation /Blame"'
+      $targetArgs = '-targetargs:"Tests\bin\Release\Tests.dll' + $(If ($APPVEYOR) {' /logger:Appveyor'}) + ' /tests:UnitTests /Parallel /InIsolation /Blame"'
  
       New-Item -ItemType directory -Path '.\TestResults' -Force
       $output = '-output:".\TestResults\coverage.xml"'

--- a/postBuildTests.bat
+++ b/postBuildTests.bat
@@ -1,4 +1,4 @@
-:: Batch file assumes parameters: postBuild.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir)$(OutDir)"
+:: Batch file assumes parameters: postBuild.bat "$(ConfigurationName)" "$(DevEnvDir)" "$(SolutionDir) $(OutDir)"
 
 ECHO ****************************
 SET this=Post-build script
@@ -6,7 +6,8 @@ SET this=Post-build script
 :: Rename the passed parameters for clarity
 SET "buildConfiguration=%1"
 SET "devEnvDir=%~2"
-SET "buildDir=%~3"
+SET "solutionDir=%~3"
+SET "outDir=%~4"
 
 ECHO %this%: Build configuration is %buildConfiguration%
 
@@ -20,7 +21,7 @@ IF %buildConfiguration%=="Release" (
   SET "testCaseFilter=^/TestCaseFilter:""TestCategory=Credentials""^|""TestCategory=DocGen"""
 )
 
-SET "command="%devEnvDir%CommonExtensions\Microsoft\TestWindow\vstest.console.exe" "%buildDir%Tests.dll" %testCaseFilter%"
+SET "command="%devEnvDir%CommonExtensions\Microsoft\TestWindow\vstest.console.exe" "%solutionDir%Tests\%outDir%Tests.dll" %testCaseFilter%"
 
 ECHO %this%: Invoking... %command%
 %command%


### PR DESCRIPTION
We do not want `Microsoft.TestPlatform.AdapterUtilities.resources.dll` sprayed everywhere. In particular this causes localisation subdirs to be created for currently unsupported languages such as Polish and Korean.

Thus, redirect the output of `Tests.csproj` back to its own subdir and adjust the generator tests to compensate. 