### PR TITLE
Create a Github Action to cancel prior instances of a given given workflow

### DIFF
--- a/.github/workflows/CancelDuplicateWorkflows.yml
+++ b/.github/workflows/CancelDuplicateWorkflows.yml
@@ -1,0 +1,19 @@
+# Ref. https://github.com/potiuk/cancel-workflow-runs
+
+name: Cancel Duplicate Runs
+on:
+  workflow_run:
+    workflows: ['Continuous Integration']
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@v4_8
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Normally, submitted a PR would trigger a check against the commit and then a second check against the pull request (we're familiar with this for AppVeyor). Github Actions allows us to easily halt and remove unnecessary checks from the UI, but this will allow it to be done automatically instead.