### PR TITLE
Speech responder UI improvements

### DIFF
--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -90,9 +90,20 @@
             </Grid>
         </DockPanel>
         <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding ScriptsView}">
+            <DataGrid.Resources>
+                <ContextMenu x:Key="HeaderEnableAllContextMenu" DisplayMemberPath="Header">
+                    <MenuItem Header="{x:Static resx:SpeechResponder.context_menu_enable_all}" Click="EnableAll_Clicked"/>
+                    <MenuItem Header="{x:Static resx:SpeechResponder.context_menu_disable_all}" Click="DisableAll_Clicked"/>
+                </ContextMenu>
+            </DataGrid.Resources>
             <DataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending" />
                 <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_enabled}" CanUserSort="True" SortMemberPath="Value.Enabled">
+                    <DataGridTemplateColumn.HeaderStyle>
+                        <Style TargetType="DataGridColumnHeader">
+                            <Setter Property="ContextMenu" Value="{DynamicResource HeaderEnableAllContextMenu}"/>
+                        </Style>
+                    </DataGridTemplateColumn.HeaderStyle>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Border IsEnabled="{Binding Path=Value.Responder}">

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -101,7 +101,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}" CanUserSort="True" SortMemberPath="Value.Priority">
+                <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_priority}" CanUserSort="True" SortMemberPath="Value.Priority">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <ComboBox SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Priorities, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" SelectionChanged="eddiScriptsPriorityUpdated">

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -38,7 +38,12 @@
         </Grid>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5, 0">
             <TextBlock VerticalAlignment="Center" Text="{x:Static resx:SpeechResponder.active_personality}" />
-            <ComboBox Margin="5,0" ItemsSource="{Binding Personalities}" SelectedValue="{Binding Personality, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" SelectionChanged="personalityChanged" />
+            <ComboBox 
+                Margin="5,0" 
+                ItemsSource="{Binding Personalities, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" 
+                SelectedValue="{Binding Personality, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                DisplayMemberPath="Name" 
+                SelectionChanged="personalityChanged" />
             <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding Personality.Description}"/>
         </StackPanel>
         <DockPanel HorizontalAlignment="Stretch" DockPanel.Dock="Bottom" Margin="0, 0, 5, 0">
@@ -89,7 +94,7 @@
                 </TextBlock>
             </Grid>
         </DockPanel>
-        <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding ScriptsView}">
+        <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding ScriptsView, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">
             <DataGrid.Resources>
                 <ContextMenu x:Key="HeaderEnableAllContextMenu" DisplayMemberPath="Header">
                     <MenuItem Header="{x:Static resx:SpeechResponder.context_menu_enable_all}" Click="EnableAll_Clicked"/>

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -88,7 +88,7 @@
         <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding Personality.Scripts}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending" />
-                <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_enabled}">
+                <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_enabled}" CanUserSort="True" SortMemberPath="Value.Enabled">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Border IsEnabled="{Binding Path=Value.Responder}">
@@ -97,7 +97,7 @@
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}">
+                <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}" CanUserSort="True" SortMemberPath="Value.Priority">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <ComboBox SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Path=Value.Priorities}" SelectionChanged="eddiScriptsPriorityUpdated">

--- a/SpeechResponder/ConfigurationWindow.xaml
+++ b/SpeechResponder/ConfigurationWindow.xaml
@@ -41,66 +41,70 @@
             <ComboBox Margin="5,0" ItemsSource="{Binding Personalities}" SelectedValue="{Binding Personality, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" SelectionChanged="personalityChanged" />
             <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding Personality.Description}"/>
         </StackPanel>
-        <Grid DockPanel.Dock="Bottom" Margin="0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="0" Click="copyPersonalityClicked" Content="{x:Static resx:SpeechResponder.button_copy}"></Button>
-            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="1" Click="newScriptClicked" Content="{x:Static resx:SpeechResponder.button_new}">
-                <Button.Style>
-                    <Style TargetType="{x:Type Button}">
-                        <Setter Property="Visibility"  Value="Visible" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="False">
-                                <Setter Property="Visibility"  Value="Hidden" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
-            <Button Margin="10" HorizontalAlignment="Center" Grid.Column="2" Click="deletePersonalityClicked" IsEnabled="{Binding Path=Personality.IsEditable}" Content="{x:Static resx:SpeechResponder.button_delete}">
-                <Button.Style>
-                    <Style TargetType="{x:Type Button}">
-                        <Setter Property="Visibility"  Value="Visible" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="False">
-                                <Setter Property="Visibility"  Value="Hidden" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
-            <TextBlock x:Name="defaultText" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.Column="1" Grid.ColumnSpan="2" TextWrapping="Wrap" Width="Auto" Margin="10, 0" Text="{x:Static resx:SpeechResponder.default_is_read_only}" FontWeight="Bold" FontStyle="Italic" FontSize="13">
-                <TextBlock.Style>
-                    <Style TargetType="{x:Type TextBlock}">
-                        <Setter Property="Visibility"  Value="Visible" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=Personality.IsEditable}" Value="True">
-                                <Setter Property="Visibility"  Value="Hidden" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBlock.Style>
-            </TextBlock>
-        </Grid>
-        <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding Personality.Scripts}">
+        <DockPanel HorizontalAlignment="Stretch" DockPanel.Dock="Bottom" Margin="0, 0, 5, 0">
+            <Label x:Name ="searchLabel" VerticalContentAlignment="Center" Content="{x:Static resx:SpeechResponder.search_filter}" />
+            <TextBox x:Name ="searchFilterText" VerticalAlignment="Center" VerticalContentAlignment="Center" Height="25" Width="Auto" MinWidth="100" TextChanged="SearchFilterText_OnTextChanged"/>
+            <Grid Margin="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button Margin="10" HorizontalAlignment="Center" Grid.Column="0" Click="copyPersonalityClicked" Content="{x:Static resx:SpeechResponder.button_copy}"></Button>
+                <Button Margin="10" HorizontalAlignment="Center" Grid.Column="1" Click="newScriptClicked" Content="{x:Static resx:SpeechResponder.button_new}">
+                    <Button.Style>
+                        <Style TargetType="{x:Type Button}">
+                            <Setter Property="Visibility"  Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=Personality.IsCustom}" Value="False">
+                                    <Setter Property="Visibility"  Value="Hidden" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                <Button Margin="10" HorizontalAlignment="Center" Grid.Column="2" Click="deletePersonalityClicked" IsEnabled="{Binding Path=Personality.IsCustom}" Content="{x:Static resx:SpeechResponder.button_delete}">
+                    <Button.Style>
+                        <Style TargetType="{x:Type Button}">
+                            <Setter Property="Visibility"  Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=Personality.IsCustom}" Value="False">
+                                    <Setter Property="Visibility"  Value="Hidden" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                <TextBlock x:Name="defaultText" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.Column="1" Grid.ColumnSpan="2" TextWrapping="Wrap" Width="Auto" Margin="10, 0" Text="{x:Static resx:SpeechResponder.default_is_read_only}" FontWeight="Bold" FontStyle="Italic" FontSize="13">
+                    <TextBlock.Style>
+                        <Style TargetType="{x:Type TextBlock}">
+                            <Setter Property="Visibility"  Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=Personality.IsCustom}" Value="True">
+                                    <Setter Property="Visibility"  Value="Hidden" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </DockPanel>
+        <DataGrid Margin="0,5" IsReadOnly="True" AutoGenerateColumns="False" x:Name="scriptsData" CanUserAddRows="false" ItemsSource="{Binding ScriptsView}">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending" />
+                <DataGridTextColumn Header="{x:Static resx:SpeechResponder.header_name}" Binding="{Binding Path=Value.Name}" SortDirection="Ascending"/>
                 <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_enabled}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Border IsEnabled="{Binding Path=Value.Responder}">
-                                <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding Path=Value.Enabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsEditable}" Checked="eddiScriptsEnabledUpdated" Unchecked="eddiScriptsEnabledUpdated" />
+                                <CheckBox HorizontalAlignment="Center" VerticalAlignment="Center" IsChecked="{Binding Path=Value.Enabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsCustom}" Checked="eddiScriptsEnabledUpdated" Unchecked="eddiScriptsEnabledUpdated" />
                             </Border>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
-                <DataGridTemplateColumn x:Name="Priorities" Header="{x:Static resx:SpeechResponder.header_priority}">
+                <DataGridTemplateColumn Header="{x:Static resx:SpeechResponder.header_priority}">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <ComboBox SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Path=Value.Priorities}" SelectionChanged="eddiScriptsPriorityUpdated">
+                            <ComboBox SelectedValue="{Binding Path=Value.Priority, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" ItemsSource="{Binding Priorities, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" SelectionChanged="eddiScriptsPriorityUpdated">
                                 <ComboBox.Style>
                                     <Style TargetType="{x:Type ComboBox}">
                                         <Setter Property="Opacity"  Value="1" />
@@ -109,7 +113,7 @@
                                             <DataTrigger Binding="{Binding Path=Value.Responder}" Value="False">
                                                 <Setter Property="Opacity"  Value="0" />
                                             </DataTrigger>
-                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsEditable}" Value="False">
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsCustom}" Value="False">
                                                 <Setter Property="IsEnabled"  Value="False" />
                                             </DataTrigger>
                                         </Style.Triggers>
@@ -137,7 +141,7 @@
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button IsEnabled="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsEditable}" Click="editScript" Content="{x:Static resx:SpeechResponder.edit_script}" />
+                            <Button IsEnabled="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=Personality.IsCustom}" Click="editScript" Content="{x:Static resx:SpeechResponder.edit_script}" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Threading;
+using Utilities;
 
 namespace EddiSpeechResponder
 {
@@ -329,10 +330,14 @@ namespace EddiSpeechResponder
             {
                 case MessageBoxResult.Yes:
                     // Remove the personality from the list and the local filesystem
-                    Personality oldPersonality = Personality;
-                    Personalities.Remove(oldPersonality);
-                    Personality = Personalities[0];
-                    oldPersonality.RemoveFile();
+                    LockManager.GetLock("DeletePersonality", () => 
+                    {
+                        Personality oldPersonality = Personality;
+                        Personality = null; // Forces bindings to update
+                        Personalities.Remove(oldPersonality);
+                        oldPersonality.RemoveFile();
+                        Personality = Personalities[0];
+                    });
                     break;
             }
             EDDI.Instance.SpeechResponderModalWait = false;

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -34,10 +34,10 @@ namespace EddiSpeechResponder
 
         public Personality Personality
         {
-            get => personality ?? Personalities.FirstOrDefault(p => p.Name == configuration.Personality) ?? defaultPersonality;
+            get => personality ?? Personalities.FirstOrDefault(p => p.Name == configuration.Personality) ?? Personalities[0];
             set
             {
-                personality = value;
+                personality = value ?? personalities[0] ?? defaultPersonality;
                 InitializeView(personality.Scripts);
                 OnPropertyChanged();
             }
@@ -120,6 +120,7 @@ namespace EddiSpeechResponder
         {
             return Personality
                 ?? Personalities.SingleOrDefault(p => p.Name == configuration.Personality)
+                ?? personalities[0]
                 ?? defaultPersonality;
         }
 
@@ -309,7 +310,9 @@ namespace EddiSpeechResponder
             {
                 string PersonalityName = window.PersonalityName?.Trim();
                 string PersonalityDescription = window.PersonalityDescription?.Trim();
+                bool disableScripts = window.PersonalityDisableScripts;
                 Personality newPersonality = Personality.Copy(PersonalityName, PersonalityDescription);
+                if (disableScripts) { EnableOrDisableAll(newPersonality, false); }
                 Personalities.Add(newPersonality);
                 Personality = newPersonality;
             }
@@ -427,18 +430,18 @@ namespace EddiSpeechResponder
 
         private void EnableAll_Clicked(object sender, RoutedEventArgs e) 
         {
-            EnableOrDisableAll(true);
+            EnableOrDisableAll(Personality, true);
         }
 
         private void DisableAll_Clicked(object sender, RoutedEventArgs e)
         {
-            EnableOrDisableAll(false);
+            EnableOrDisableAll(Personality, false);
         }
 
-        private void EnableOrDisableAll(bool desiredState)
+        private void EnableOrDisableAll(Personality targetPersonality, bool desiredState)
         {
             EDDI.Instance.SpeechResponderModalWait = true;
-            foreach (var kvScript in Personality.Scripts)
+            foreach (var kvScript in targetPersonality.Scripts)
             {
                 var script = kvScript.Value;
                 if (script.Responder)

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -95,7 +95,7 @@ namespace EddiSpeechResponder
         {
             ScriptsView = CollectionViewSource.GetDefaultView(source);
             ScriptsView.SortDescriptions.Add(new SortDescription("Value.Name", ListSortDirection.Ascending));
-            searchFilterText.Text = null; // Clear any active filters
+            searchFilterText.Text = string.Empty; // Clear any active filters
         }
 
         private ObservableCollection<Personality> GetPersonalities()

--- a/SpeechResponder/ConfigurationWindow.xaml.cs
+++ b/SpeechResponder/ConfigurationWindow.xaml.cs
@@ -425,6 +425,32 @@ namespace EddiSpeechResponder
             }
         }
 
+        private void EnableAll_Clicked(object sender, RoutedEventArgs e) 
+        {
+            EnableOrDisableAll(true);
+        }
+
+        private void DisableAll_Clicked(object sender, RoutedEventArgs e)
+        {
+            EnableOrDisableAll(false);
+        }
+
+        private void EnableOrDisableAll(bool desiredState)
+        {
+            EDDI.Instance.SpeechResponderModalWait = true;
+            foreach (var kvScript in Personality.Scripts)
+            {
+                var script = kvScript.Value;
+                if (script.Responder)
+                {
+                    script.Enabled = desiredState;
+                }
+            }
+            Personality.ToFile();
+            EDDI.Instance.Reload("Speech responder");
+            EDDI.Instance.SpeechResponderModalWait = false;
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
         public void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {

--- a/SpeechResponder/CopyPersonalityWindow.xaml
+++ b/SpeechResponder/CopyPersonalityWindow.xaml
@@ -32,6 +32,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -53,7 +54,11 @@
                     <Binding Path="PersonalityDescription" Mode="TwoWay" />
                 </TextBox.Text>
             </TextBox>
-            <UniformGrid Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="20" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">
+            <StackPanel Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Center" Orientation="Horizontal" Margin="10">
+                <CheckBox Name="DisableScripts" VerticalAlignment="Center" HorizontalAlignment="Stretch" Width="Auto" Margin="5, 0" IsChecked="{Binding PersonalityDisableScripts}" />
+                <TextBlock Text="{x:Static resx:SpeechResponder.context_menu_disable_all}"/>
+            </StackPanel>
+            <UniformGrid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Margin="20, 0" Rows="1" Columns="2" Width="260" HorizontalAlignment="Center">
                 <Button x:Name="acceptButton" IsDefault="True" FontSize="18" 
                         Content="{x:Static resx:SpeechResponder.button_ok}" 
                         VerticalAlignment="Top" 

--- a/SpeechResponder/CopyPersonalityWindow.xaml.cs
+++ b/SpeechResponder/CopyPersonalityWindow.xaml.cs
@@ -36,6 +36,17 @@ namespace EddiSpeechResponder
             }
         }
 
+        private bool personalityDisableScripts;
+        public bool PersonalityDisableScripts
+        {
+            get => personalityDisableScripts;
+            set
+            {
+                personalityDisableScripts = value;
+                OnPropertyChanged(nameof(PersonalityDisableScripts));
+            }
+        }
+
         bool CanAccept()
         {
             return string.IsNullOrWhiteSpace(Error);

--- a/SpeechResponder/EditScriptWindow.xaml
+++ b/SpeechResponder/EditScriptWindow.xaml
@@ -100,9 +100,22 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock Margin="10, 5, 10, 0" Grid.Row="0" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_name}"/>
-            <TextBox Margin="10, 5, 10, 0" Grid.Row="0" Grid.Column="1" Text="{Binding Path=ScriptName, Mode=TwoWay}" IsReadOnly="{Binding Path=Responder}"/>
-            <TextBlock Margin="10, 5, 10, 0" Grid.Row="1" Grid.Column="0" Text="{x:Static resx:SpeechResponder.header_description}"/>
-            <TextBox Margin="10, 5, 10, 0" Grid.Row="1" Grid.Column="1" Text="{Binding Path=ScriptDescription, Mode=TwoWay}" IsReadOnly="{Binding Path=Responder}"/>
+            <TextBox Margin="10, 5, 10, 0" 
+                     Grid.Row="0" 
+                     Grid.Column="1" 
+                     Text="{Binding Path=editorScript.Name, Mode=TwoWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window }}" 
+                     IsReadOnly="{Binding Path=editorScript.Responder, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window }}"
+                     />
+            <TextBlock Margin="10, 5, 10, 0" 
+                       Grid.Row="1" 
+                       Grid.Column="0" 
+                       Text="{x:Static resx:SpeechResponder.header_description}"
+                       />
+            <TextBox Margin="10, 5, 10, 0" 
+                     Grid.Row="1" 
+                     Grid.Column="1" 
+                     Text="{Binding Path=editorScript.Description, Mode=TwoWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window }}" 
+                     IsReadOnly="{Binding Path=editorScript.Responder, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window }}"/>
             <avalonEdit:TextEditor Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="10" 
                                    Name="scriptView"
                                    Foreground="DarkSlateGray"

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -47,9 +47,9 @@ namespace EddiSpeechResponder
             set { responder = value; OnPropertyChanged("Responder"); }
         }
 
-        private int _priority;
+        private int? _priority;
 
-        public int Priority
+        public int? Priority
         {
             get { return _priority; }
             set

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
+using Utilities;
 
 namespace EddiSpeechResponder
 {

--- a/SpeechResponder/EditScriptWindow.xaml.cs
+++ b/SpeechResponder/EditScriptWindow.xaml.cs
@@ -3,112 +3,51 @@ using EddiSpeechService;
 using ICSharpCode.AvalonEdit.Search;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Windows;
-using Utilities;
 
 namespace EddiSpeechResponder
 {
     /// <summary>
     /// Interaction logic for EditScriptWindow.xaml
     /// </summary>
-    public partial class EditScriptWindow : Window, INotifyPropertyChanged
+    public partial class EditScriptWindow : Window
     {
+        public Script script { get; private set; }
+        public Script editorScript { get; private set; }
+
         private readonly Dictionary<string, Script> _scripts;
-        private Script _script;
-        private readonly string originalName;
-
-        private string scriptName;
-        public string ScriptName
-        {
-            get { return scriptName; }
-            set { scriptName = value; OnPropertyChanged("ScriptName"); }
-        }
-        private string scriptDescription;
-        public string ScriptDescription
-        {
-            get { return scriptDescription; }
-            set { scriptDescription = value; OnPropertyChanged("ScriptDescription"); }
-        }
-        private string scriptValue;
-        public string ScriptValue
-        {
-            get { return scriptValue; }
-            set
-            {
-                scriptValue = string.IsNullOrWhiteSpace(value) ? null : value;
-                OnPropertyChanged("ScriptValue");
-            }
-        }
-
-        private bool responder;
-        public bool Responder
-        {
-            get { return responder; }
-            set { responder = value; OnPropertyChanged("Responder"); }
-        }
-
-        private int? _priority;
-
-        public int? Priority
-        {
-            get { return _priority; }
-            set
-            {
-                _priority = value;
-                OnPropertyChanged(nameof(Priority));
-            }
-        }
-
-        public string ScriptDefaultValue;
-
-        public event PropertyChangedEventHandler PropertyChanged;
-        protected void OnPropertyChanged(string name)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
 
         public ScriptRecoveryService ScriptRecoveryService { get; set; }
 
-        public EditScriptWindow(Dictionary<string, Script> scripts, string name)
+        public EditScriptWindow(Script script, Dictionary<string, Script> scripts)
         {
             InitializeComponent();
             DataContext = this;
             SearchPanel.Install(scriptView);
 
             this._scripts = scripts;
-            this.originalName = name;
+            this.script = script;
 
-            scripts.TryGetValue(name, out _script);
-            if (_script == null)
+            if (script == null)
             {
                 // This is a new script
-                ScriptName = "New script";
-                ScriptDescription = null;
-                ScriptValue = null;
-                Responder = false;
-                Priority = 3;
+                editorScript = new Script("New script", null, false, null);
             }
             else
             {
                 // This is an existing script
-                ScriptName = _script.Name;
-                ScriptDescription = _script.Description;
-                ScriptValue = _script.Value;
-                ScriptDefaultValue = _script.defaultValue;
-                Responder = _script.Responder;
-                Priority = _script.Priority;
+                editorScript = script.Copy();
             }
 
             // See if there is the default value for this script is empty
-            if (string.IsNullOrWhiteSpace(ScriptDefaultValue))
+            if (string.IsNullOrWhiteSpace(editorScript.defaultValue))
             {
                 // No default; disable reset and show
                 showDiffButton.IsEnabled = false;
                 resetToDefaultButton.IsEnabled = false;
             }
 
-            scriptView.Text = scriptValue;
+            scriptView.Text = editorScript.Value;
             ScriptRecoveryService = new ScriptRecoveryService(this);
             ScriptRecoveryService.BeginScriptRecovery();
             scriptView.TextChanged += ScriptView_TextChanged;
@@ -116,7 +55,7 @@ namespace EddiSpeechResponder
 
         private void ScriptView_TextChanged(object sender, System.EventArgs e)
         {
-            ScriptValue = scriptView.Text;
+            editorScript.Value = scriptView.Text;
         }
 
         protected override void OnClosed(EventArgs e)
@@ -127,29 +66,15 @@ namespace EddiSpeechResponder
 
         private void acceptButtonClick(object sender, RoutedEventArgs e)
         {
-            // Update the script
-            string newScriptText = string.IsNullOrWhiteSpace(scriptView.Text) ? null : scriptView.Text;
-            if (_script != null)
-            {
-                Script newScript = new Script(scriptName,
-                    scriptDescription,
-                    _script?.Responder ?? false,
-                    newScriptText,
-                    Priority,
-                    _script.defaultValue);
-                _script = newScript;
-            }
+            // Update the output script
+            script = editorScript;
 
+            // Make sure default values are set as required
             Script defaultScript = null;
-            if (Personality.Default().Scripts?.TryGetValue(_script.Name, out defaultScript) ?? false)
+            if (Personality.Default().Scripts?.TryGetValue(script.Name, out defaultScript) ?? false)
             {
-                _script = Personality.UpgradeScript(_script, defaultScript);
+                script = Personality.UpgradeScript(script, defaultScript);
             }
-
-            // Might be updating an existing script so remove it from the list before adding
-            _scripts.Remove(originalName);
-
-            _scripts.Add(_script.Name, _script);
 
             DialogResult = true;
             this.Close();
@@ -169,38 +94,33 @@ namespace EddiSpeechResponder
 
         private void variablesButtonClick(object sender, RoutedEventArgs e)
         {
-            VariablesWindow variablesWindow = new VariablesWindow(ScriptName);
+            VariablesWindow variablesWindow = new VariablesWindow(editorScript.Name);
             variablesWindow.Show();
         }
 
         private void resetButtonClick(object sender, RoutedEventArgs e)
         {
             // Resetting the script resets it to its value in the default personality
-            ScriptValue = ScriptDefaultValue;
-            scriptView.Text = ScriptValue;
+            editorScript.Value = editorScript.defaultValue;
+            scriptView.Text = editorScript.Value;
         }
 
         private void testButtonClick(object sender, RoutedEventArgs e)
         {
             if (!SpeechService.Instance.eddiSpeaking)
             {
-                ScriptRecoveryService.SaveRecoveryScript(ScriptValue,
-                    ScriptName,
-                    ScriptDescription,
-                    Responder,
-                    Priority,
-                    _script.defaultValue);
+                ScriptRecoveryService.SaveRecoveryScript(editorScript);
 
                 // Splice the new script in to the existing scripts
-                ScriptValue = scriptView.Text;
+                editorScript.Value = scriptView.Text;
                 Dictionary<string, Script> newScripts = new Dictionary<string, Script>(_scripts);
-                Script testScript = new Script(ScriptName, ScriptDescription, false, ScriptValue);
-                newScripts.Remove(ScriptName);
-                newScripts.Add(ScriptName, testScript);
+                Script testScript = new Script(editorScript.Name, editorScript.Description, false, editorScript.Value);
+                newScripts.Remove(editorScript.Name);
+                newScripts.Add(editorScript.Name, testScript);
 
                 SpeechResponder speechResponder = new SpeechResponder();
                 speechResponder.Start();
-                speechResponder.TestScript(ScriptName, newScripts);
+                speechResponder.TestScript(editorScript.Name, newScripts);
             }
             else
             {
@@ -210,10 +130,10 @@ namespace EddiSpeechResponder
 
         private void showDiffButtonClick(object sender, RoutedEventArgs e)
         {
-            ScriptValue = scriptView.Text;
-            if (!string.IsNullOrWhiteSpace(ScriptDefaultValue))
+            editorScript.Value = scriptView.Text;
+            if (!string.IsNullOrWhiteSpace(editorScript.defaultValue))
             {
-                new ShowDiffWindow(ScriptDefaultValue, ScriptValue).Show();
+                new ShowDiffWindow(editorScript.defaultValue, editorScript.Value).Show();
             }
         }
     }

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -237,7 +237,7 @@ namespace EddiSpeechResponder
             // Default personality for reference scripts
             var defaultPersonality = !personality.IsCustom ? null : Default();
 
-            var fixedScripts = new ObservableConcurrentDictionary<string, Script>();
+            var fixedScripts = new Dictionary<string, Script>();
             // Ensure that every required event is present
             List<string> missingScripts = new List<string>();
             foreach (KeyValuePair<string, string> defaultEvent in Events.DESCRIPTIONS)

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -145,16 +145,23 @@ namespace EddiSpeechResponder
                 }
                 catch (Exception e)
                 {
-                    // malformed JSON for some reason: rename so that the user can examine and fix it.
-                    string newFileName = filename + ".malformed";
-                    if (File.Exists(newFileName))
+                    if (!isDefault)
                     {
-                        // no point keeping a history: only the latest is likely to be useful. Pro users will be using version control anyway.
-                        File.Delete(newFileName);
-                    }
-                    File.Move(filename, newFileName);
+                        // malformed JSON for some reason: rename so that the user can examine and fix it.
+                        string newFileName = filename + ".malformed";
+                        if (File.Exists(newFileName))
+                        {
+                            // no point keeping a history: only the latest is likely to be useful. Pro users will be using version control anyway.
+                            File.Delete(newFileName);
+                        }
+                        File.Move(filename, newFileName);
 
-                    Logging.Error($"Could not parse \"{filename}\": moved to \"{newFileName}\". Error was \"{e.Message}\"");
+                        Logging.Error($"Could not parse \"{filename}\": moved to \"{newFileName}\". Error was \"{e.Message}\"");
+                    }
+                    else
+                    {
+                        throw new FormatException("Could not parse default personality (eddi.json)");
+                    }
                 }
             }
 

--- a/SpeechResponder/Personality.cs
+++ b/SpeechResponder/Personality.cs
@@ -2,9 +2,11 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Utilities;
 
@@ -13,23 +15,53 @@ namespace EddiSpeechResponder
     /// <summary>
     /// A personality is a combination of scripts used to respond to specific events
     /// </summary>
-    public class Personality
+    public class Personality : INotifyPropertyChanged
     {
         [JsonProperty("name")]
-        public string Name { get; private set; }
+        public string Name
+        {
+            get => _name;
+            private set
+            {
+                _name = value;
+                OnPropertyChanged();
+            }
+        }
 
         [JsonProperty("description")]
-        public string Description { get; private set; }
-
-        [JsonIgnore]
-        public bool IsDefault { get; set; } = false;
-
-        [JsonIgnore]
-        public bool IsCustom => !IsDefault;
+        public string Description
+        {
+            get => _description;
+            private set
+            {
+                _description = value;
+                OnPropertyChanged();
+            }
+        }
 
         [JsonProperty("scripts")]
-        public Dictionary<string, Script> Scripts { get; private set; }
+        public Dictionary<string, Script> Scripts
+        {
+            get => _scripts;
+            private set
+            {
+                _scripts = value;
+                OnPropertyChanged();
+            }
+        }
 
+        [JsonIgnore]
+        private string _name;
+
+        [JsonIgnore]
+        private string _description;
+
+        [JsonIgnore]
+        public bool IsCustom { get; set; }
+
+        [JsonIgnore]
+        private Dictionary<string, Script> _scripts;
+        
         [JsonIgnore]
         private string dataPath;
 
@@ -47,14 +79,7 @@ namespace EddiSpeechResponder
             Description = description;
             Scripts = scripts;
         }
-
-        [JsonIgnore]
-        public bool IsEditable
-        {
-            get { return (Name != "EDDI"); }
-            set { }
-        }
-
+        
         /// <summary>
         /// Obtain all personalities from a directory.  If the directory name is not supplied the
         /// default of Constants.Data_DIR\personalities is used
@@ -136,7 +161,7 @@ namespace EddiSpeechResponder
             if (personality != null)
             {
                 personality.dataPath = filename;
-                personality.IsDefault = isDefault;
+                personality.IsCustom = !isDefault;
                 fixPersonalityInfo(personality);
             }
 
@@ -203,9 +228,9 @@ namespace EddiSpeechResponder
         private static void fixPersonalityInfo(Personality personality)
         {
             // Default personality for reference scripts
-            Personality defaultPersonality = personality.IsDefault ? null : Default();
+            var defaultPersonality = !personality.IsCustom ? null : Default();
 
-            Dictionary<string, Script> fixedScripts = new Dictionary<string, Script>();
+            var fixedScripts = new ObservableConcurrentDictionary<string, Script>();
             // Ensure that every required event is present
             List<string> missingScripts = new List<string>();
             foreach (KeyValuePair<string, string> defaultEvent in Events.DESCRIPTIONS)
@@ -233,7 +258,7 @@ namespace EddiSpeechResponder
                     fixedScripts.Add(kv.Key, script);
                 }
             }
-            if (!personality.IsDefault)
+            if (personality.IsCustom)
             {
                 // Remove deprecated scripts from the list
                 List<string> scriptHolder = new List<string>();
@@ -306,10 +331,8 @@ namespace EddiSpeechResponder
                 Logging.Info("Failed to find scripts" + string.Join(";", missingScripts));
             }
 
-            // Re-order the scripts by name
-            fixedScripts = fixedScripts.OrderBy(s => s.Key).ToDictionary(s => s.Key, s => s.Value);
-
-            personality.Scripts = fixedScripts;
+            // Re-order the scripts by name and save to file
+            personality.Scripts = fixedScripts.OrderBy(s => s.Key).ToDictionary(s => s.Key, s => s.Value);
             personality.ToFile();
         }
 
@@ -340,5 +363,20 @@ namespace EddiSpeechResponder
 
             return script;
         }
+
+        #region INotifyPropertyChanged
+        /// <summary>
+        /// Raised when a property on this object has a new value.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Raises this object's PropertyChanged event.
+        /// </summary>
+        public void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
     }
 }

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -340,6 +340,15 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filter:.
+        /// </summary>
+        public static string search_filter {
+            get {
+                return ResourceManager.GetString("search_filter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read about the speech responder&apos;s functions.
         /// </summary>
         public static string speechResponderHelp {

--- a/SpeechResponder/Properties/SpeechResponder.Designer.cs
+++ b/SpeechResponder/Properties/SpeechResponder.Designer.cs
@@ -133,6 +133,24 @@ namespace EddiSpeechResponder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disable all event-based scripts.
+        /// </summary>
+        public static string context_menu_disable_all {
+            get {
+                return ResourceManager.GetString("context_menu_disable_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable all event-based scripts.
+        /// </summary>
+        public static string context_menu_enable_all {
+            get {
+                return ResourceManager.GetString("context_menu_enable_all", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The default personality cannot be modified. If you wish to make changes, create a copy..
         /// </summary>
         public static string default_is_read_only {

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -242,4 +242,7 @@
   <data name="validation_tooltip_name_taken" xml:space="preserve">
     <value>That name is taken; please supply another</value>
   </data>
+  <data name="search_filter" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
 </root>

--- a/SpeechResponder/Properties/SpeechResponder.resx
+++ b/SpeechResponder/Properties/SpeechResponder.resx
@@ -245,4 +245,10 @@
   <data name="search_filter" xml:space="preserve">
     <value>Filter:</value>
   </data>
+  <data name="context_menu_enable_all" xml:space="preserve">
+    <value>Enable all event-based scripts</value>
+  </data>
+  <data name="context_menu_disable_all" xml:space="preserve">
+    <value>Disable all event-based scripts</value>
+  </data>
 </root>

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -1,8 +1,8 @@
-﻿using EddiSpeechService;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace EddiSpeechResponder
@@ -11,39 +11,48 @@ namespace EddiSpeechResponder
     {
         [JsonProperty("name")]
         public string Name { get; private set; }
+
         [JsonProperty("description")]
-        public string Description { get; set; }
+        public string Description
+        {
+            get => description;
+            set
+            {
+                description = value; OnPropertyChanged();
+            }
+        }
+
         [JsonProperty("enabled")]
-        private bool enabled;
-        [JsonProperty("priority")]
-        private int priority = 3;
-        [JsonProperty("responder")]
-        private bool responder;
-        [JsonProperty("script")]
-        private string script;
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        [JsonIgnore]
         public bool Enabled
         {
-            get { return enabled; }
-            set { enabled = value; OnPropertyChanged("Enabled"); }
+            get => enabled;
+            set { enabled = value; OnPropertyChanged(); }
         }
 
-        [JsonIgnore]
+        [JsonProperty("priority")]
         public int Priority
         {
-            get { return priority; }
-            set { priority = value; OnPropertyChanged("Priority"); }
+            get => priority;
+            set { priority = value; OnPropertyChanged(); }
         }
 
-        [JsonIgnore]
+        [JsonProperty("responder")]
         public bool Responder
         {
-            get { return responder; }
-            set { responder = value; OnPropertyChanged("Responder"); }
+            get => responder;
+            set { responder = value; OnPropertyChanged(); }
         }
+
+        [JsonProperty("script")]
+        public string Value
+        {
+            get => script;
+            set { script = value; OnPropertyChanged(); }
+        }
+
+        [JsonProperty("defaultValue")]
+
+        public string defaultValue { get; set; }
 
         [JsonProperty("default")]
         // Determine whether the script matches the default, treating empty strings and null values as equal
@@ -55,40 +64,25 @@ namespace EddiSpeechResponder
         public bool IsResettableOrDeletable
         {
             get { resettableOrDeletable = !Default || (!Responder && string.IsNullOrWhiteSpace(defaultValue)); return resettableOrDeletable; }
-            set { resettableOrDeletable = value; OnPropertyChanged("IsResettableOrDeletable"); }
+            set { resettableOrDeletable = value; OnPropertyChanged(); }
         }
-        [JsonIgnore]
-        private bool resettableOrDeletable;
-
         [JsonIgnore]
         public bool IsResettable => Responder || (!Responder && !string.IsNullOrWhiteSpace(defaultValue));
-
         [JsonIgnore]
-        public string Value
-        {
-            get { return script; }
-            set { script = value; OnPropertyChanged("Value"); }
-        }
-
-        [JsonProperty("defaultValue")]
-        public string defaultValue { get; set; }
-
+        public bool HasValue => script != null;
         [JsonIgnore]
-        public bool HasValue
-        {
-            get { return script != null; }
-        }
-
+        private string description;
         [JsonIgnore]
-        public IList<int> Priorities
-        {
-            get { return priorities; }
-            set { if (priorities != value) { priorities = value; OnPropertyChanged("Priorities"); }; }
-        }
-
+        private bool enabled;
         [JsonIgnore]
-        private IList<int> priorities;
-
+        private int priority = 3;
+        [JsonIgnore]
+        private bool responder;
+        [JsonIgnore]
+        private string script;
+        [JsonIgnore]
+        private bool resettableOrDeletable;
+        
         public Script(string name, string description, bool responder, string script, int priority = 3, string defaultScript = null)
         {
             Name = name;
@@ -98,17 +92,6 @@ namespace EddiSpeechResponder
             Priority = priority;
             Enabled = true;
             defaultValue = defaultScript;
-
-            Priorities = new List<int>();
-            for (int i = 1; i <= SpeechService.Instance.speechQueue.priorityQueues.Count - 1; i++)
-            {
-                if (i > 0) { Priorities.Add(i); }
-            }
-        }
-
-        protected void OnPropertyChanged(string name)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }
 
         [JsonExtensionData]
@@ -132,5 +115,20 @@ namespace EddiSpeechResponder
                 }
             }
         }
+
+        #region INotifyPropertyChanged
+        /// <summary>
+        /// Raised when a property on this object has a new value.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Raises this object's PropertyChanged event.
+        /// </summary>
+        public void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
     }
 }

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -10,7 +10,14 @@ namespace EddiSpeechResponder
     public class Script : INotifyPropertyChanged
     {
         [JsonProperty("name")]
-        public string Name { get; private set; }
+        public string Name
+        {
+            get => name;
+            set
+            {
+                name = value; OnPropertyChanged();
+            }
+        }
 
         [JsonProperty("description")]
         public string Description
@@ -70,6 +77,8 @@ namespace EddiSpeechResponder
         public bool IsResettable => Responder || (!Responder && !string.IsNullOrWhiteSpace(defaultValue));
         [JsonIgnore]
         public bool HasValue => script != null;
+        [JsonIgnore]
+        private string name;
         [JsonIgnore]
         private string description;
         [JsonIgnore]

--- a/SpeechResponder/Script.cs
+++ b/SpeechResponder/Script.cs
@@ -16,7 +16,7 @@ namespace EddiSpeechResponder
         [JsonProperty("enabled")]
         private bool enabled;
         [JsonProperty("priority")]
-        private int priority = 3;
+        private int? priority = 3;
         [JsonProperty("responder")]
         private bool responder;
         [JsonProperty("script")]
@@ -32,9 +32,9 @@ namespace EddiSpeechResponder
         }
 
         [JsonIgnore]
-        public int Priority
+        public int? Priority
         {
-            get { return priority; }
+            get { return responder ? priority : null; }
             set { priority = value; OnPropertyChanged("Priority"); }
         }
 
@@ -80,16 +80,16 @@ namespace EddiSpeechResponder
         }
 
         [JsonIgnore]
-        public IList<int> Priorities
+        public IList<int?> Priorities
         {
             get { return priorities; }
             set { if (priorities != value) { priorities = value; OnPropertyChanged("Priorities"); }; }
         }
 
         [JsonIgnore]
-        private IList<int> priorities;
+        private IList<int?> priorities;
 
-        public Script(string name, string description, bool responder, string script, int priority = 3, string defaultScript = null)
+        public Script(string name, string description, bool responder, string script, int? priority = 3, string defaultScript = null)
         {
             Name = name;
             Description = description;
@@ -99,7 +99,7 @@ namespace EddiSpeechResponder
             Enabled = true;
             defaultValue = defaultScript;
 
-            Priorities = new List<int>();
+            Priorities = new List<int?>();
             for (int i = 1; i <= SpeechService.Instance.speechQueue.priorityQueues.Count - 1; i++)
             {
                 if (i > 0) { Priorities.Add(i); }

--- a/SpeechResponder/ScriptRecoveryService/ScriptRecoveryService.cs
+++ b/SpeechResponder/ScriptRecoveryService/ScriptRecoveryService.cs
@@ -20,7 +20,7 @@ namespace EddiSpeechResponder.Service
 
         private static readonly string WorkingDirectory;
         private string _tempFileName;
-        private EditScriptWindow _scriptWindow;
+        private readonly EditScriptWindow _scriptWindow;
         private bool _scriptSaveCallGuard;
         private readonly object _lockRoot;
 
@@ -54,12 +54,12 @@ namespace EddiSpeechResponder.Service
                 File.Delete(_tempFileName);
             }
 
-            _scriptWindow.PropertyChanged += _scriptWindow_PropertyChanged;
+            _scriptWindow.editorScript.PropertyChanged += _scriptWindow_PropertyChanged;
         }
 
         private void _scriptWindow_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(EditScriptWindow.ScriptValue))
+            if (e.PropertyName == nameof(EditScriptWindow.editorScript.Value))
             {
                 //the script value has changed. Begin the callguard and save the script value
                 BeginScriptSave(_scriptWindow);
@@ -81,12 +81,7 @@ namespace EddiSpeechResponder.Service
                 try
                 {
                     await Task.Delay(TimeSpan.FromSeconds(3));
-                    SaveRecoveryScript(window.ScriptValue,
-                        window.ScriptName,
-                        window.ScriptDescription,
-                        window.Responder,
-                        window.Priority,
-                        window.ScriptDefaultValue);
+                    SaveRecoveryScript(window.editorScript);
                 }
                 finally
                 {
@@ -98,16 +93,10 @@ namespace EddiSpeechResponder.Service
         /// <summary>
         ///        Should be called periodically and saves the script into the temp file
         /// </summary>
-        public void SaveRecoveryScript(string scriptValue,
-            string scriptName,
-            string scriptDescription,
-            bool isResponder,
-            int? priority,
-            string defaultScript)
+        public void SaveRecoveryScript(Script script)
         {
             lock (_lockRoot)
             {
-                var script = new Script(scriptName, scriptDescription, isResponder, scriptValue, priority, defaultScript);
                 var serializeObject = JsonConvert.SerializeObject(script);
                 File.WriteAllText(_tempFileName, serializeObject);
             }
@@ -122,7 +111,7 @@ namespace EddiSpeechResponder.Service
             {
                 File.Delete(_tempFileName);
             }
-            _scriptWindow.PropertyChanged -= _scriptWindow_PropertyChanged;
+            _scriptWindow.editorScript.PropertyChanged -= _scriptWindow_PropertyChanged;
         }
     }
 }

--- a/SpeechResponder/ScriptRecoveryService/ScriptRecoveryService.cs
+++ b/SpeechResponder/ScriptRecoveryService/ScriptRecoveryService.cs
@@ -102,7 +102,7 @@ namespace EddiSpeechResponder.Service
             string scriptName,
             string scriptDescription,
             bool isResponder,
-            int priority,
+            int? priority,
             string defaultScript)
         {
             lock (_lockRoot)

--- a/SpeechService/SpeechQueue.cs
+++ b/SpeechService/SpeechQueue.cs
@@ -36,6 +36,21 @@ namespace EddiSpeechService
             }
         }
 
+        public List<int?> priorities => PreparePrioritiesList();
+
+        private List<int?> PreparePrioritiesList()
+        {
+            List<int?> result = new List<int?>();
+            for (int i = 1; i <= priorityQueues.Count - 1; i++)
+            {
+                if (i > 0)
+                {
+                    result.Add(i);
+                }
+            }
+            return result;
+        }
+
         private void PrepareSpeechQueues()
         {
             priorityQueues = new List<ConcurrentQueue<EddiSpeech>>();


### PR DESCRIPTION
- Enables sorting by `Priority` and `Enabled` (Resolves #1236)
- Adds a filter field to enable filtering scripts by name, description, and contents (Resolves #1576)
- Allows users to disable all scripts at once (either when copying a personality or by accessing a context menu on the `Enabled` header) (Resolves #2097)
- Fixes the selected personality combo box losing track of the current selected item when a personality is deleted.
- Refactors and simplifies the script editor code-behind