### PR TITLE
Adjust maximum system search radius 

### DIFF
--- a/StarMapService/EdsmSystemData.cs
+++ b/StarMapService/EdsmSystemData.cs
@@ -52,10 +52,15 @@ namespace EddiStarMapService
             return new List<StarSystem>();
         }
 
-        /// <summary> Get star systems around a specified system in a sphere or shell, with a maximum radius of 200 light years. </summary>
-        public List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true)
+        /// <summary> Get star systems around a specified system in a sphere or shell, with a maximum radius of 100 light years. </summary>
+        public List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true)
         {
             if (starSystem == null) { return new List<Dictionary<string, object>>(); }
+            if (maxRadiusLy > 100)
+            {
+                maxRadiusLy = 100;
+                Logging.Warn("The maximum allowable sphere radius is 100 LY. Results are automatically truncated.");
+            }
 
             var request = new RestRequest("api-v1/sphere-systems", Method.POST);
             request.AddParameter("systemName", starSystem);
@@ -95,7 +100,13 @@ namespace EddiStarMapService
         public List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true)
         {
             if (starSystem == null) { return new List<StarSystem>(); }
-
+            if (cubeLy > 200)
+            {
+                cubeLy = 200;
+                Logging.Warn("The maximum allowable cube size is 100 LY. Results are automatically truncated.");
+            }
+            
+            
             var request = new RestRequest("api-v1/cube-systems", Method.POST);
             request.AddParameter("systemName", starSystem);
             request.AddParameter("size", cubeLy);

--- a/StarMapService/IEdsmService.cs
+++ b/StarMapService/IEdsmService.cs
@@ -19,7 +19,7 @@ namespace EddiStarMapService
         StarSystem GetStarMapSystem(string system, bool showCoordinates = true, bool showSystemInformation = true);
         List<StarSystem> GetStarMapSystems(string[] systems, bool showCoordinates = true, bool showSystemInformation = true);
         List<string> GetTypeAheadStarSystems(string partialSystemName);
-        List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true);
+        List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true);
         List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true);
         Traffic GetStarMapHostility(string systemName, long? edsmId = null);
         Traffic GetStarMapTraffic(string systemName, long? edsmId = null);


### PR DESCRIPTION
For the sphere-systems endpoint, EDSM won't accept a max radius higher than 100LY.  It doesn't return an exception, it just returns an empty result.

Examples:
- https://www.edsm.net/api-v1/sphere-systems/?systemName=Sol&minRadius=0&radius=100' => returns 8254 systems
- https://www.edsm.net/api-v1/sphere-systems/?systemName=Sol&minRadius=50&radius=150' => returns an empty dict {}

The cube-systems endpoint works differently. It has a maximum size of 200LY, doesn't include a minRadius factor, and still returns a result if you request more than the maximum. However, the results for any request over 200LY will simply be truncated to the 200LY size.

For example, the following two queries return identical results. 
- https://www.edsm.net/api-v1/cube-systems/?systemName=Sol&size=200
- https://www.edsm.net/api-v1/cube-systems/?systemName=Sol&size=300


I changed the defaults and added checks to consistently handle calls to these functions and return the (truncated) result. I also checked other references and tests and none of them explicitly call either of these functions with maxRadius or cubeRadius values over 200. 