### PR TITLE
exception handling for GetSystemExtras

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "workbench.colorTheme": "Solarized Dark"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.colorTheme": "Solarized Dark"
+}

--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -21,20 +21,20 @@ namespace EddiDataProviderService
         }
 
         // Uses the EDSM data service and legacy EDDP data
-        public StarSystem GetSystemData(string system, bool showCoordinates = true, bool showSystemInformation = true, bool showBodies = true, bool showStations = true, bool showFactions = true)
+        public StarSystem GetSystemData(string system, bool showCoordinates = true, bool showBodies = true, bool showStations = true, bool showFactions = true)
         {
             if (system == null || string.IsNullOrEmpty(system)) { return null; }
 
-            StarSystem starSystem = edsmService.GetStarMapSystem(system, showCoordinates, showSystemInformation);
-            starSystem = GetSystemExtras(starSystem, showSystemInformation, showBodies, showStations, showFactions);
+            StarSystem starSystem = edsmService.GetStarMapSystem(system, showCoordinates);
+            starSystem = GetSystemExtras(starSystem, showBodies, showStations, showFactions);
             return starSystem ?? new StarSystem() { systemname = system };
         }
 
-        public List<StarSystem> GetSystemsData(string[] systemNames, bool showCoordinates = true, bool showSystemInformation = true, bool showBodies = true, bool showStations = true, bool showFactions = true)
+        public List<StarSystem> GetSystemsData(string[] systemNames, bool showCoordinates = true, bool showBodies = true, bool showStations = true, bool showFactions = true)
         {
             if (systemNames == null || systemNames.Length == 0) { return new List<StarSystem>(); }
 
-            List<StarSystem> starSystems = edsmService.GetStarMapSystems(systemNames, showCoordinates, showSystemInformation);
+            List<StarSystem> starSystems = edsmService.GetStarMapSystems(systemNames, showCoordinates);
             if (starSystems == null) { return new List<StarSystem>(); }
 
             List<StarSystem> fullStarSystems = new List<StarSystem>();
@@ -42,22 +42,14 @@ namespace EddiDataProviderService
             {
                 if (!string.IsNullOrEmpty(systemName))
                 {
-                    fullStarSystems.Add(GetSystemExtras(starSystems.Find(s => s?.systemname == systemName), showSystemInformation, showBodies, showStations, showFactions) ?? new StarSystem() { systemname = systemName });
+                    fullStarSystems.Add(GetSystemExtras(starSystems.Find(s => s?.systemname == systemName), showBodies, showStations, showFactions) ?? new StarSystem() { systemname = systemName });
                 }
             }
             return fullStarSystems;
         }
 
-        private StarSystem GetSystemExtras(StarSystem starSystem, bool showInformation, bool showBodies, bool showStations, bool showFactions)
+        private StarSystem GetSystemExtras(StarSystem starSystem, bool showBodies, bool showStations, bool showFactions)
         {
-            if (!showInformation & showStations)
-            {
-                throw new Exception("System Station details cannot be retrieved while showInformation is false");
-            }
-            if (!showInformation & showFactions)
-            {
-                throw new Exception("System Faction details cannot be retrieved while showInformation is false");
-            }
 
             if (starSystem != null)
             {

--- a/DataProviderService/DataProviderService.cs
+++ b/DataProviderService/DataProviderService.cs
@@ -50,6 +50,15 @@ namespace EddiDataProviderService
 
         private StarSystem GetSystemExtras(StarSystem starSystem, bool showInformation, bool showBodies, bool showStations, bool showFactions)
         {
+            if (!showInformation & showStations)
+            {
+                throw new Exception("System Station details cannot be retrieved while showInformation is false");
+            }
+            if (!showInformation & showFactions)
+            {
+                throw new Exception("System Faction details cannot be retrieved while showInformation is false");
+            }
+
             if (starSystem != null)
             {
                 if (showBodies)

--- a/NavigationService/NavigationService.cs
+++ b/NavigationService/NavigationService.cs
@@ -527,7 +527,7 @@ namespace EddiNavigationService
             var systems = new List<string>();      // List of eligible mission destination systems
             var missionids = new List<long>();       // List of mission IDs for the next system
 
-            var homeStarSystem = dataProviderService.GetSystemData(homeSystem, true, false, false, false, false);
+            var homeStarSystem = dataProviderService.GetSystemData(homeSystem, showCoordinates: false, showBodies: false, showStations: false, showFactions: false);
             NavWaypoint homeSystemWaypoint = null;
             if (homeStarSystem != null)
             {
@@ -575,7 +575,7 @@ namespace EddiNavigationService
                 }
 
                 // Calculate the missions route using the 'Repetitive Nearest Neighbor' Algorithm (RNNA)
-                var navWaypoints = dataProviderService.GetSystemsData(systems.ToArray(), true, false, false, false, false).Select(s => new NavWaypoint(s)).ToList();
+                var navWaypoints = dataProviderService.GetSystemsData(systems.ToArray(), false, false, false, false).Select(s => new NavWaypoint(s)).ToList();
                 if (CalculateRNNA(navWaypoints, missions, out sortedRoute, homeSystemWaypoint))
                 {
                     // Prepend our current system to the route if it is not already present

--- a/StarMapService/EdsmSystemData.cs
+++ b/StarMapService/EdsmSystemData.cs
@@ -11,14 +11,14 @@ namespace EddiStarMapService
     public partial class StarMapService
     {
         /// <summary> Exactly one system name is required. </summary>
-        public StarSystem GetStarMapSystem(string system, bool showCoordinates = true, bool showSystemInformation = true)
+        public StarSystem GetStarMapSystem(string system, bool showCoordinates = true)
         {
             if (system == null) { return null; }
-            return GetStarMapSystems(new[] { system }, showCoordinates, showSystemInformation)?.FirstOrDefault();
+            return GetStarMapSystems(new[] { system }, showCoordinates)?.FirstOrDefault();
         }
 
         /// <summary> At least one system name is required. </summary>
-        public List<StarSystem> GetStarMapSystems(string[] systems, bool showCoordinates = true, bool showSystemInformation = true)
+        public List<StarSystem> GetStarMapSystems(string[] systems, bool showCoordinates = true)
         {
             if (systems == null) { return new List<StarSystem>(); }
 
@@ -29,8 +29,8 @@ namespace EddiStarMapService
             }
             request.AddParameter("showId", 1);
             request.AddParameter("showCoordinates", showCoordinates ? 1 : 0);
-            request.AddParameter("showInformation", showSystemInformation ? 1 : 0);
-            request.AddParameter("showPermit", showSystemInformation ? 1 : 0);
+            request.AddParameter("showInformation", 1); 
+            request.AddParameter("showPermit", 1);
             var clientResponse = restClient.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
             {
@@ -53,7 +53,7 @@ namespace EddiStarMapService
         }
 
         /// <summary> Get star systems around a specified system in a sphere or shell, with a maximum radius of 100 light years. </summary>
-        public List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true)
+        public List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showPermit = true)
         {
             if (starSystem == null) { return new List<Dictionary<string, object>>(); }
             if (maxRadiusLy > 100)
@@ -69,7 +69,7 @@ namespace EddiStarMapService
             request.AddParameter("showId", showEdsmId ? 1 : 0);
             request.AddParameter("showCoordinates", showCoordinates ? 1 : 0);
             request.AddParameter("showPrimaryStar", showPrimaryStar ? 1 : 0);
-            request.AddParameter("showInformation", showInformation ? 1 : 0);
+            request.AddParameter("showInformation", 1);
             request.AddParameter("showPermit", showPermit ? 1 : 0);
             var clientResponse = restClient.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)
@@ -97,7 +97,7 @@ namespace EddiStarMapService
         }
 
         /// <summary> Get star systems around a specified system in a cube, with a maximum cube size of 200 light years. </summary>
-        public List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true)
+        public List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showPermit = true)
         {
             if (starSystem == null) { return new List<StarSystem>(); }
             if (cubeLy > 200)
@@ -112,7 +112,7 @@ namespace EddiStarMapService
             request.AddParameter("showId", showEdsmId ? 1 : 0);
             request.AddParameter("showCoordinates", showCoordinates ? 1 : 0);
             request.AddParameter("showPrimaryStar", showPrimaryStar ? 1 : 0);
-            request.AddParameter("showInformation", showInformation ? 1 : 0);
+            request.AddParameter("showInformation", 1);
             request.AddParameter("showPermit", showPermit ? 1 : 0);
             var clientResponse = restClient.Execute<List<JObject>>(request);
             if (clientResponse.IsSuccessful)

--- a/StarMapService/IEdsmService.cs
+++ b/StarMapService/IEdsmService.cs
@@ -16,11 +16,11 @@ namespace EddiStarMapService
         List<string> getIgnoredEvents();
         List<Faction> GetStarMapFactions(string systemName, long? edsmId = null);
         List<Station> GetStarMapStations(string system, long? edsmId = null);
-        StarSystem GetStarMapSystem(string system, bool showCoordinates = true, bool showSystemInformation = true);
-        List<StarSystem> GetStarMapSystems(string[] systems, bool showCoordinates = true, bool showSystemInformation = true);
+        StarSystem GetStarMapSystem(string system, bool showCoordinates = true);
+        List<StarSystem> GetStarMapSystems(string[] systems, bool showCoordinates = true);
         List<string> GetTypeAheadStarSystems(string partialSystemName);
-        List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true);
-        List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showInformation = true, bool showPermit = true);
+        List<Dictionary<string, object>> GetStarMapSystemsSphere(string starSystem, int minRadiusLy = 0, int maxRadiusLy = 100, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showPermit = true);
+        List<StarSystem> GetStarMapSystemsCube(string starSystem, int cubeLy = 200, bool showEdsmId = true, bool showCoordinates = true, bool showPrimaryStar = true, bool showPermit = true);
         Traffic GetStarMapHostility(string systemName, long? edsmId = null);
         Traffic GetStarMapTraffic(string systemName, long? edsmId = null);
         Traffic GetStarMapDeaths(string systemName, long? edsmId = null);

--- a/Tests/EdsmDataTests.cs
+++ b/Tests/EdsmDataTests.cs
@@ -451,7 +451,7 @@ namespace UnitTests
 
             // Act
             string[] systemNames = new string[] { "Sol", "Achenar", "Alioth" };
-            List<StarSystem> starSystems = fakeEdsmService.GetStarMapSystems(systemNames, true, false);
+            List<StarSystem> starSystems = fakeEdsmService.GetStarMapSystems(systemNames, showCoordinates: true);
 
             // Assert
             Assert.AreEqual(3, starSystems?.Count);
@@ -511,7 +511,7 @@ namespace UnitTests
             fakeEdsmRestClient.Expect(resource, json, data);
 
             // Act
-            StarSystem system = fakeEdsmService.GetStarMapSystem("No such system", false, false);
+            StarSystem system = fakeEdsmService.GetStarMapSystem("No such system", showCoordinates: false);
 
             // Assert
             // Unknown systems shall return null from here. We create a synthetic system in DataProviderService.cs if this returns null;


### PR DESCRIPTION
For the GetSystemData or GetSystemsData functions, if you choose showInformation = false, EDSM will not return a population value for that system. Therefore, when these functions make their calls to the GetSystemExtras, the _**if**_ statement below will always evaluate false and will not pull Station or Faction data. As it stands, the code just returns your StarSystems without the requested Stations and Factions, even though it is possible to pull Station and Faction data without pulling System Information. 

This modification adds Exceptions for this situation. I couldn't find anywhere where these parameters would be set by an end-user, so an Exception seemed the most appropriate. 

**I wasn't sure this was the best way to handle this potential problem. I thought of a couple of other versions:**

1) It appears this IF statement is just there to avoid the extra API calls for empty systems, so technically we could just add to the if statement and allow it to proceed
`if (starSystem.population > 0 || !showInformation)`

2) We could also automatically change the value of showInformation in each of the GetSystemData and GetSystemsData functions. By default, these parameters are all set to true, so if someone intentionally turned off the showInformation setting, I would want them to get a more prominent warning.
```
if ((showFactions || showStations) & !showSystemInformation)
{
    Logging.Warn("systemInformation must be true if showFactions or showStations is true");
    showSystemInformation = true;
    Logging.Warn($"systemInformation has been automatically changed to {showSystemInformation}");
}
```