### PR TITLE
Add Pocket TTS engine integration via HTTP server

### DIFF
--- a/ConfigService/Configurations/SpeechServiceConfiguration.cs
+++ b/ConfigService/Configurations/SpeechServiceConfiguration.cs
@@ -28,7 +28,13 @@ namespace EddiConfigService.Configurations
 
         [JsonProperty("enableicao")]
         public bool EnableIcao { get; set; }
-        
+
+        [JsonProperty("pocketTtsEnabled")]
+        public bool PocketTtsEnabled { get; set; }
+
+        [JsonProperty("pocketTtsServerUrl")]
+        public string PocketTtsServerUrl { get; set; } = "http://localhost:8000";
+
         /// <summary>
         /// Clear the information held by speech
         /// </summary>
@@ -40,6 +46,8 @@ namespace EddiConfigService.Configurations
             DistortOnDamage = true;
             DisableIpa = false;
             EnableIcao = false;
+            PocketTtsEnabled = false;
+            PocketTtsServerUrl = "http://localhost:8000";
         }
     }
 }

--- a/EddiUI/Properties/Resources.Designer.cs
+++ b/EddiUI/Properties/Resources.Designer.cs
@@ -691,7 +691,34 @@ namespace EddiUI.Properties {
                 return ResourceManager.GetString("tab_tts_volume_label", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pocket TTS is a lightweight text-to-speech engine by Kyutai that runs on CPU....
+        /// </summary>
+        public static string tab_tts_pocket_tts_desc {
+            get {
+                return ResourceManager.GetString("tab_tts_pocket_tts_desc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enable Pocket TTS:.
+        /// </summary>
+        public static string tab_tts_pocket_tts_enabled_label {
+            get {
+                return ResourceManager.GetString("tab_tts_pocket_tts_enabled_label", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pocket TTS server URL:.
+        /// </summary>
+        public static string tab_tts_pocket_tts_url_label {
+            get {
+                return ResourceManager.GetString("tab_tts_pocket_tts_url_label", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Troubleshoot common issues.
         /// </summary>

--- a/EddiUI/Properties/Resources.resx
+++ b/EddiUI/Properties/Resources.resx
@@ -339,6 +339,15 @@ Please close the other instance and try again.</value>
   <data name="tab_tts_volume_label" xml:space="preserve">
     <value>Volume of speech:</value>
   </data>
+  <data name="tab_tts_pocket_tts_desc" xml:space="preserve">
+    <value>Pocket TTS is a lightweight text-to-speech engine by Kyutai that runs on CPU. To use it, install pocket-tts (pip install pocket-tts) and start the server with 'pocket-tts serve'. Enable the option below and set the server URL. EDDI must be restarted after changing these settings for the Pocket TTS voice to appear.</value>
+  </data>
+  <data name="tab_tts_pocket_tts_enabled_label" xml:space="preserve">
+    <value>Enable Pocket TTS:</value>
+  </data>
+  <data name="tab_tts_pocket_tts_url_label" xml:space="preserve">
+    <value>Pocket TTS server URL:</value>
+  </data>
   <data name="troubleshoot_common_issues" xml:space="preserve">
     <value>Troubleshoot common issues</value>
     <comment>A hyperlink to the troubleshooting URL (in english)</comment>

--- a/EddiUI/TextToSpeechTab.xaml
+++ b/EddiUI/TextToSpeechTab.xaml
@@ -29,6 +29,10 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="auto" />
             </Grid.RowDefinitions>
             <Label x:Name="ttsVoiceLabel" Grid.Column="0" Grid.Row="0" Margin="0, 5" VerticalContentAlignment="Center" Content="{x:Static resx:Resources.tab_tts_voice_label}" />
             <ComboBox x:Name="ttsVoiceDropDown" Grid.Column="1" Grid.Row="0" Margin="5" VerticalContentAlignment="Center" SelectionChanged="ttsVoiceDropDownUpdated"/>
@@ -64,6 +68,12 @@
             <TextBlock Grid.Column="0" Grid.Row="10" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:Resources.tab_tts_icao_desc}" />
             <Label x:Name="enableIcaoLabel" Grid.Column="0" Grid.Row="11" Margin="0, 5" Content="{x:Static resx:Resources.tab_tts_icao_label}" />
             <CheckBox x:Name="enableIcaoCheckbox" Grid.Column="1" Grid.Row="11" Margin="5" VerticalAlignment="Center" Checked="enableICAOUpdated" Unchecked="enableICAOUpdated"/>
+            <Separator Grid.Column="0" Grid.Row="12" Grid.ColumnSpan="2" Margin="5,10,5,5" />
+            <TextBlock Grid.Column="0" Grid.Row="13" Grid.ColumnSpan="2" Margin="5" TextWrapping="Wrap" Text="{x:Static resx:Resources.tab_tts_pocket_tts_desc}" />
+            <Label x:Name="pocketTtsEnabledLabel" Grid.Column="0" Grid.Row="14" Margin="0, 5" Content="{x:Static resx:Resources.tab_tts_pocket_tts_enabled_label}" />
+            <CheckBox x:Name="pocketTtsEnabledCheckbox" Grid.Column="1" Grid.Row="14" Margin="5" VerticalAlignment="Center" Checked="pocketTtsEnabledUpdated" Unchecked="pocketTtsEnabledUpdated"/>
+            <Label x:Name="pocketTtsServerUrlLabel" Grid.Column="0" Grid.Row="15" Margin="0, 5" VerticalContentAlignment="Center" Content="{x:Static resx:Resources.tab_tts_pocket_tts_url_label}" />
+            <TextBox x:Name="pocketTtsServerUrlText" Grid.Column="1" Grid.Row="15" Margin="5" VerticalContentAlignment="Center" LostFocus="pocketTtsServerUrlUpdated"/>
         </Grid>
     </DockPanel>
 </UserControl>

--- a/EddiUI/TextToSpeechTab.xaml.cs
+++ b/EddiUI/TextToSpeechTab.xaml.cs
@@ -57,6 +57,9 @@ namespace EddiUI
 
             ttsTestShipDropDown.ItemsSource = ShipDefinitions.ShipModels; // already sorted
             ttsTestShipDropDown.Text = "Adder";
+
+            pocketTtsEnabledCheckbox.IsChecked = speechServiceConfiguration.PocketTtsEnabled;
+            pocketTtsServerUrlText.Text = speechServiceConfiguration.PocketTtsServerUrl ?? "http://localhost:8000";
         }
 
         private void ttsVoiceDropDownUpdated(object sender, SelectionChangedEventArgs e)
@@ -154,6 +157,16 @@ namespace EddiUI
             ttsUpdated();
         }
 
+        private void pocketTtsEnabledUpdated(object sender, RoutedEventArgs e)
+        {
+            ttsUpdated();
+        }
+
+        private void pocketTtsServerUrlUpdated(object sender, RoutedEventArgs e)
+        {
+            ttsUpdated();
+        }
+
         /// <summary>
         /// fetch the Text-to-Speech Configuration and write it to File
         /// </summary>
@@ -161,16 +174,18 @@ namespace EddiUI
         {
             var speechConfiguration = new SpeechServiceConfiguration
             {
-                StandardVoice = ttsVoiceDropDown.SelectedItem == null || 
-                                ttsVoiceDropDown.SelectedItem.ToString() == "Windows TTS default" 
-                    ? null 
+                StandardVoice = ttsVoiceDropDown.SelectedItem == null ||
+                                ttsVoiceDropDown.SelectedItem.ToString() == "Windows TTS default"
+                    ? null
                     : ttsVoiceDropDown.SelectedItem.ToString(),
                 Volume = (int)ttsVolumeSlider.Value,
                 Rate = (int)ttsRateSlider.Value,
                 EffectsLevel = (int)ttsEffectsLevelSlider.Value,
                 DistortOnDamage = ttsDistortCheckbox.IsChecked ?? false,
                 DisableIpa = DisableIpaCheckbox.IsChecked ?? false,
-                EnableIcao = enableIcaoCheckbox.IsChecked ?? false
+                EnableIcao = enableIcaoCheckbox.IsChecked ?? false,
+                PocketTtsEnabled = pocketTtsEnabledCheckbox.IsChecked ?? false,
+                PocketTtsServerUrl = pocketTtsServerUrlText.Text
             };
             ConfigService.Instance.speechServiceConfiguration = speechConfiguration;
         }

--- a/SpeechService/EddiSpeechService.csproj
+++ b/SpeechService/EddiSpeechService.csproj
@@ -14,6 +14,7 @@
     <EmbeddedResource Include="Properties\pls.xsd" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Speech" />
   </ItemGroup>
   <ItemGroup>

--- a/SpeechService/SpeechManager.cs
+++ b/SpeechService/SpeechManager.cs
@@ -37,6 +37,7 @@ namespace EddiSpeechService
 
         private readonly SystemSpeechSynthesizer systemSpeechSynth;
         private readonly WindowsMediaSynthesizer windowsMediaSynth;
+        private readonly PocketTTSSynthesizer pocketTtsSynth;
 
         internal int activeSpeechPriority;
 
@@ -92,6 +93,16 @@ namespace EddiSpeechService
                     e );
             }
 
+            // Prep the Pocket TTS synthesizer (requires an external pocket-tts server)
+            try
+            {
+                pocketTtsSynth = new PocketTTSSynthesizer( ref voiceStore );
+            }
+            catch ( Exception e )
+            {
+                Logging.Error( "Unable to initialize Pocket TTS synthesizer.", e );
+            }
+
             // Sort results alphabetically by voice name
             allVoices = voiceStore.OrderBy( v => v.name ).ToList();
         }
@@ -111,6 +122,7 @@ namespace EddiSpeechService
                 {
                     windowsMediaSynth?.Dispose();
                 }
+                pocketTtsSynth?.Dispose();
             }
         }
 
@@ -513,6 +525,10 @@ namespace EddiSpeechService
         private Stream speak ( [NotNull] VoiceDetails voiceDetails, string speech )
         {
             var Configuration = ConfigService.Instance.speechServiceConfiguration;
+            if ( voiceDetails.synthType is PocketTTSSynthesizer.SynthTypeName )
+            {
+                return pocketTtsSynth?.Speak( voiceDetails, speech, Configuration );
+            }
             if ( voiceDetails.synthType is nameof( System ) )
             {
                 return systemSpeechSynth?.Speak( voiceDetails, speech, Configuration );

--- a/SpeechService/SpeechSynthesizers/PocketTTSSynthesizer.cs
+++ b/SpeechService/SpeechSynthesizers/PocketTTSSynthesizer.cs
@@ -1,0 +1,143 @@
+using EddiConfigService;
+using EddiConfigService.Configurations;
+using EddiSpeechService.SpeechPreparation;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Utilities;
+
+namespace EddiSpeechService.SpeechSynthesizers
+{
+    /// <summary>
+    /// Synthesizer that communicates with a locally running Pocket TTS server (https://github.com/kyutai-labs/pocket-tts).
+    /// The server must be started externally with `pocket-tts serve` before EDDI is launched.
+    /// Audio is returned as 24kHz mono 16-bit PCM WAV.
+    /// </summary>
+    public sealed class PocketTTSSynthesizer : IDisposable
+    {
+        private readonly HttpClient httpClient;
+        private bool serverAvailable;
+
+        /// <summary>The synthType identifier used for routing in SpeechManager.</summary>
+        internal const string SynthTypeName = "PocketTTS";
+
+        public PocketTTSSynthesizer ( ref HashSet<VoiceDetails> voiceStore )
+        {
+            httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds( 120 )
+            };
+
+            var config = ConfigService.Instance.speechServiceConfiguration;
+            if ( !config.PocketTtsEnabled )
+            {
+                Logging.Info( "Pocket TTS is disabled in configuration." );
+                return;
+            }
+
+            var serverUrl = GetServerUrl( config );
+            try
+            {
+                var response = httpClient.GetAsync( $"{serverUrl}/health" ).GetAwaiter().GetResult();
+                if ( response.IsSuccessStatusCode )
+                {
+                    serverAvailable = true;
+
+                    var voiceDetails = new VoiceDetails(
+                        "Pocket TTS",
+                        "NotSet",
+                        CultureInfo.GetCultureInfo( "en" ),
+                        SynthTypeName
+                    );
+                    voiceStore.Add( voiceDetails );
+                    Logging.Info( $"Pocket TTS server is available at {serverUrl}. Voice registered." );
+                }
+                else
+                {
+                    Logging.Warn( $"Pocket TTS server at {serverUrl} returned status {response.StatusCode}." );
+                }
+            }
+            catch ( Exception e )
+            {
+                Logging.Warn( "Pocket TTS server is not reachable. Pocket TTS voices will not be available.", e );
+            }
+        }
+
+        internal Stream Speak ( VoiceDetails voiceDetails, string speech, SpeechServiceConfiguration configuration )
+        {
+            Logging.Debug( $"Selecting {SynthTypeName} synthesizer" );
+
+            if ( !serverAvailable )
+            {
+                Logging.Warn( "Pocket TTS server is not available." );
+                return null;
+            }
+
+            return PocketTtsSynthesis( speech, configuration );
+        }
+
+        private MemoryStream PocketTtsSynthesis ( string speech, SpeechServiceConfiguration configuration )
+        {
+            if ( string.IsNullOrEmpty( speech ) )
+            {
+                return null;
+            }
+
+            // Strip SSML tags since Pocket TTS does not support SSML
+            speech = SpeechFormatter.StripSSML( speech );
+            if ( string.IsNullOrWhiteSpace( speech ) )
+            {
+                return null;
+            }
+
+            var serverUrl = GetServerUrl( configuration );
+            var stream = new MemoryStream();
+            var synthTask = Task.Run( async () =>
+            {
+                using ( var formContent = new MultipartFormDataContent() )
+                {
+                    formContent.Add( new StringContent( speech ), "text" );
+
+                    Logging.Debug( $"Sending speech to Pocket TTS server: \"{speech}\"" );
+                    var response = await httpClient
+                        .PostAsync( $"{serverUrl}/tts", formContent )
+                        .ConfigureAwait( false );
+                    response.EnsureSuccessStatusCode();
+
+                    await response.Content.CopyToAsync( stream ).ConfigureAwait( false );
+                    stream.Position = 0;
+                }
+            } );
+
+            try
+            {
+                Task.WaitAll( synthTask );
+            }
+            catch ( AggregateException ae )
+            {
+                foreach ( var ex in ae.InnerExceptions )
+                {
+                    throw ex;
+                }
+            }
+
+            return stream;
+        }
+
+        private static string GetServerUrl ( SpeechServiceConfiguration config )
+        {
+            var url = string.IsNullOrWhiteSpace( config.PocketTtsServerUrl )
+                ? "http://localhost:8000"
+                : config.PocketTtsServerUrl;
+            return url.TrimEnd( '/' );
+        }
+
+        public void Dispose ()
+        {
+            httpClient?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Integrate Kyutai's Pocket TTS as a new text-to-speech engine option. Pocket TTS is a lightweight 100M-parameter model that runs efficiently on CPU, communicating via a local HTTP server (pocket-tts serve).

New files:
- PocketTTSSynthesizer.cs: HTTP client that sends text to the pocket-tts /tts endpoint and receives 24kHz WAV audio

Modified files:
- SpeechServiceConfiguration: Added PocketTtsEnabled and PocketTtsServerUrl settings (persisted to speech.json)
- SpeechManager: Registers PocketTTSSynthesizer alongside existing engines, routes speech based on synthType, disposes properly
- EddiSpeechService.csproj: Added System.Net.Http reference
- TextToSpeechTab.xaml/.cs: Added UI controls for enabling Pocket TTS and configuring the server URL
- Resources.resx/.Designer.cs: Added localization strings for new UI

https://claude.ai/code/session_01WbRN2wpyPuHrpK8oyEZyjU