### PR TITLE
Add xml.xsd to lexicon schema set

### DIFF
--- a/SpeechService/EddiSpeechService.csproj
+++ b/SpeechService/EddiSpeechService.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="Properties\pls.xsd" />
+        <EmbeddedResource Include="Properties\xml.xsd" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="Properties\FormatOverrides.Designer.cs">

--- a/SpeechService/Properties/xml.xsd
+++ b/SpeechService/Properties/xml.xsd
@@ -1,0 +1,286 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>

--- a/SpeechService/SpeechManager.cs
+++ b/SpeechService/SpeechManager.cs
@@ -146,6 +146,7 @@ namespace EddiSpeechService
                 }
 
                 FetchSchemasFromResource( "EddiSpeechService.Properties.pls.xsd" );
+                FetchSchemasFromResource( "EddiSpeechService.Properties.xml.xsd" );
             }
             catch ( ArgumentException ae )
             {


### PR DESCRIPTION
.NET 5.0 and above disable remote XML schema downloads by default, resulting in lexicon schema validation failing due to the XML namespace schema (http://www.w3.org/XML/1998/namespace) not being present in the available schemas.

Add a cached copy of https://www.w3.org/2009/01/xml.xsd (the current immutable version of the schema at http://www.w3.org/2001/xml.xsd) to the lexicon schema set.

Reported as #2814 

Error reported in EDCD#eddi Discord:

> Hi, my lexicon file, which used to work, is now getting renamed to malformed.
> I get the following error in the log file:
> ```
> 2026-05-15T10:07:46.2462358Z [16] [Warning] SpeechFormatter:IsValidXML Could not load lexicon file '%APPDATA%\EDDI\lexicons\en.pls', please review.: {"ClassName":"System.Xml.Schema.XmlSchemaValidationException","Message":"The 'http://www.w3.org/XML/1998/namespace:base' attribute is not declared.","Data":null,"InnerException":null,"HelpURL":null,"StackTraceString":"   at System.Xml.Schema.XmlSchemaValidator.SendValidationEvent(XmlSchemaValidationException e, XmlSeverityType severity)\r\n   at System.Xml.Schema.XmlSchemaValidator.RecompileSchemaSet()\r\n   at System.Xml.Schema.XmlSchemaValidator.Init()\r\n   at System.Xml.Schema.XNodeValidator.Validate(XObject source, XmlSchemaObject partialValidationType, Boolean addSchemaInfo)\r\n   at EddiSpeechService.SpeechPreparation.SpeechFormatter.IsValidXML(String filename) in EddiSpeechService\SpeechPreparation\SpeechFormatter.cs:line 277","RemoteStackTraceString":null,"RemoteStackIndex":0,"ExceptionMethod":null,"HResult":-2146231999,"Source":"System.Private.Xml","WatsonBuckets":null,"res":"The '{0}' attribute is not declared.","args":["http://www.w3.org/XML/1998/namespace:base"],"sourceUri":"","lineNumber":69,"linePosition":14,"version":"2.0"}
> ```
> I get what looks like the same error if I use the example apple to orange lexicon from here https://github.com/EDCD/EDDI/wiki/Lexicons
> I think this is probably easy to fix by editing my lexicon file, but I don't understand the problem well enough to fix it. I thought I'd metion here as it feels like the example file will need the same fix.
> I thiiink this started happening when I updated EDDI to 5.0, but I'm not certain.

Example program showing underlying issue:
```cs
using System.Diagnostics;
using System.Security.Cryptography;
using System.Xml.Linq;
using System.Xml.Schema;

var pls = """
<?xml version="1.0" encoding="UTF-8"?>
<lexicon version="1.0" 
      xmlns="http://www.w3.org/2005/01/pronunciation-lexicon"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
      xsi:schemaLocation="http://www.w3.org/2005/01/pronunciation-lexicon 
        http://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd"
      alphabet="ipa" xml:lang="en-gb">
  <lexeme>
    <grapheme>apple</grapheme>
    <phoneme>ˈɔɹɪnd͡ʒ</phoneme>
  </lexeme>
</lexicon>
""";

static async Task AddRemoteSchema(HttpClient client, XmlSchemaSet xmlschemas, string url, string targetns, string sha256sum)
{
    if (!xmlschemas.Contains(targetns))
    {
        var schemaData = await client.GetByteArrayAsync(url);
        Debug.Assert(Convert.ToHexStringLower(SHA256.HashData(schemaData)) == sha256sum);
        using var memstream = new MemoryStream(schemaData);
        var schema = XmlSchema.Read(memstream, null);
        Debug.Assert(schema != null);
        Debug.Assert(schema.TargetNamespace == targetns);
        xmlschemas.Add(schema);
    }
}

var xmlschemas = new XmlSchemaSet();

using var client = new HttpClient();

await AddRemoteSchema(
    client,
    xmlschemas,
    "https://www.w3.org/TR/2007/CR-pronunciation-lexicon-20071212/pls.xsd",
    "http://www.w3.org/2005/01/pronunciation-lexicon",
    "5c15b4a8862e5232512bc26ca6359f0c679f0059515dc66af8ae8be125a74061"
);

if (args.Contains("--import-xml-schema"))
{
    await AddRemoteSchema(
        client,
        xmlschemas,
        "https://www.w3.org/2009/01/xml.xsd",
        "http://www.w3.org/XML/1998/namespace",
        "cc701736c42cc64126fad063bb95f94484b5de3b5f808a86ea098b0957aff829"
    );
}

var xml = XDocument.Parse(pls);

xml.Validate(xmlschemas, (o, e) =>
{
    if (e.Severity is XmlSeverityType.Error or XmlSeverityType.Warning)
    {
        throw new XmlSchemaValidationException(e.Message, e.Exception);
    }
});

Console.WriteLine("OK");
```

```
klightspeed@Capella MINGW64 ~/source/repos/ConsoleApp1/app
$ dotnet run Program.cs
Unhandled exception. System.Xml.Schema.XmlSchemaValidationException: The 'http://www.w3.org/XML/1998/namespace:base' attribute is not declared.
   at System.Xml.Schema.XmlSchemaValidator.SendValidationEvent(XmlSchemaValidationException e, XmlSeverityType severity)
   at System.Xml.Schema.XmlSchemaValidator.RecompileSchemaSet()
   at System.Xml.Schema.XmlSchemaValidator.Init()
   at System.Xml.Schema.XNodeValidator.Validate(XObject source, XmlSchemaObject partialValidationType, Boolean addSchemaInfo)
   at Program.<Main>$(String[] args)
   at Program.<Main>(String[] args)

klightspeed@Capella MINGW64 ~/source/repos/ConsoleApp1/app
$ dotnet run Program.cs --import-xml-schema
OK

```

xml.xsd should have blob hash `bd291f3d4be818edcb1498697ffd03f0226a9cf8`:
```
$ IFS='' read -r -d '' xml_xsd < <(curl -s https://www.w3.org/2009/01/xml.xsd); printf "%s" "$xml_xsd" | sha256sum; printf "blob %d\0%s" "$(printf "%s" "$xml_xsd" | wc -c)" "$xml_xsd" | sha1sum
cc701736c42cc64126fad063bb95f94484b5de3b5f808a86ea098b0957aff829  -
bd291f3d4be818edcb1498697ffd03f0226a9cf8  -
$ curl -s -L -H "Accept: application/vnd.github.object" -H "X-GitHub-Api-Version: 2026-03-10" https://api.github.com/repos/klightspeed/EDDI/contents/SpeechService/Properties/xml.xsd?ref=add-xml-xsd | jq '.sha'
"bd291f3d4be818edcb1498697ffd03f0226a9cf8"
```